### PR TITLE
Add diffing feature to app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5286,6 +5286,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dingbat-to-unicode": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
@@ -9969,6 +9978,7 @@
         "@codemirror/lang-javascript": "^6.2.2",
         "clsx": "^2.1.1",
         "codemirror": "^6.0.1",
+        "diff": "^8.0.2",
         "driver.js": "^1.3.6",
         "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.11",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -656,6 +656,56 @@ app.post('/api/projects/:id/file', validateBody(saveFileSchema), async (req, res
 });
 
 /**
+ * POST /api/projects/:id/revert
+ * Revert a file to its previous state
+ */
+app.post('/api/projects/:id/revert', async (req, res, next) => {
+  try {
+    const authReq = req as unknown as AuthenticatedRequest;
+    const userId = authReq.user.id;
+    const { id } = req.params;
+    let { file_path, content } = req.body;
+
+    // Validate inputs
+    if (!file_path) {
+      res.status(400).json({ error: 'file_path is required' });
+      return;
+    }
+
+    // Strip leading slashes
+    file_path = file_path.replace(/^\/+/, '');
+
+    // Security: basic path validation (prevent directory traversal)
+    if (file_path.includes('..')) {
+      res.status(403).json({ error: 'Invalid file path' });
+      return;
+    }
+
+    // If content is null, delete the file (reverting a create)
+    if (content === null) {
+      await storage.deleteFile(userId, id, file_path);
+      res.json({
+        success: true,
+        path: file_path,
+        message: 'File deleted (reverted creation)',
+      });
+      return;
+    }
+
+    // Otherwise, restore the file content
+    await storage.writeFile(userId, id, file_path, content);
+
+    res.json({
+      success: true,
+      path: file_path,
+      message: 'File reverted successfully',
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
  * POST /api/projects/:id/upload
  * Upload file(s) to a user's project
  */

--- a/packages/backend/src/tools/file-tools.ts
+++ b/packages/backend/src/tools/file-tools.ts
@@ -207,6 +207,23 @@ or updates it if it does. Parent directories are created automatically.`,
     }).shape,
     async (params) => {
       try {
+        // Capture before state for diffing
+        let beforeContent: string | null = null;
+        let isNewFile = false;
+
+        try {
+          if (useStorage && userId && projectId) {
+            beforeContent = await storage.readFile(userId, projectId, params.file_path);
+          } else {
+            const fullPath = path.join(projectPath, params.file_path);
+            beforeContent = await fs.readFile(fullPath, 'utf-8');
+          }
+        } catch {
+          // File doesn't exist - this is a new file
+          isNewFile = true;
+        }
+
+        // Write the file
         if (useStorage && userId && projectId) {
           // Use storage abstraction
           await storage.writeFile(userId, projectId, params.file_path, params.content);
@@ -218,13 +235,25 @@ or updates it if it does. Parent directories are created automatically.`,
           await fs.writeFile(fullPath, params.content, 'utf-8');
         }
 
-        // Return user-friendly message
+        // Return user-friendly message with diff data
         const fileName = params.file_path.split('/').pop() || params.file_path;
         const size = Buffer.byteLength(params.content, 'utf-8');
+
+        // Include diff metadata in the response
+        const diffData = JSON.stringify({
+          type: 'file_write',
+          file_path: params.file_path,
+          before: beforeContent,
+          after: params.content,
+          isNewFile,
+        });
+
         return {
           content: [{
             type: 'text' as const,
-            text: `✓ Created ${fileName} (${size} bytes)`,
+            text: isNewFile
+              ? `✓ Created ${fileName} (${size} bytes)\n<!-- diff:${diffData} -->`
+              : `✓ Updated ${fileName} (${size} bytes)\n<!-- diff:${diffData} -->`,
           }],
         };
       } catch (error: any) {
@@ -251,6 +280,21 @@ or updates it if it does. Parent directories are created automatically.`,
     }).shape,
     async (params) => {
       try {
+        // Capture content before deletion for potential revert
+        let beforeContent: string | null = null;
+
+        try {
+          if (useStorage && userId && projectId) {
+            beforeContent = await storage.readFile(userId, projectId, params.file_path);
+          } else {
+            const fullPath = path.join(projectPath, params.file_path);
+            beforeContent = await fs.readFile(fullPath, 'utf-8');
+          }
+        } catch {
+          // File doesn't exist or is binary - skip capture
+        }
+
+        // Delete the file
         if (useStorage && userId && projectId) {
           // Use storage abstraction
           await storage.deleteFile(userId, projectId, params.file_path);
@@ -267,11 +311,20 @@ or updates it if it does. Parent directories are created automatically.`,
           await fs.unlink(fullPath);
         }
 
+        // Include diff metadata
+        const diffData = JSON.stringify({
+          type: 'file_delete',
+          file_path: params.file_path,
+          before: beforeContent,
+          after: null,
+          isNewFile: false,
+        });
+
         const fileName = params.file_path.split('/').pop() || params.file_path;
         return {
           content: [{
             type: 'text' as const,
-            text: `✓ Deleted ${fileName}`,
+            text: `✓ Deleted ${fileName}\n<!-- diff:${diffData} -->`,
           }],
         };
       } catch (error: any) {
@@ -449,10 +502,19 @@ or updates it if it does. Parent directories are created automatically.`,
           await fs.writeFile(fullPath, updated, 'utf-8');
         }
 
+        // Include diff metadata
+        const diffData = JSON.stringify({
+          type: 'file_edit',
+          file_path: params.file_path,
+          before: content,
+          after: updated,
+          isNewFile: false,
+        });
+
         return {
           content: [{
             type: 'text' as const,
-            text: `✓ Edited ${params.file_path.split('/').pop() || params.file_path}`,
+            text: `✓ Edited ${params.file_path.split('/').pop() || params.file_path}\n<!-- diff:${diffData} -->`,
           }],
         };
       } catch (error: any) {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -32,6 +32,7 @@
     "@codemirror/lang-javascript": "^6.2.2",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.1",
+    "diff": "^8.0.2",
     "driver.js": "^1.3.6",
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.11",

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -578,7 +578,7 @@
 							{:else if block.type === 'tools' && block.tools}
 								<div class="tools-section">
 									{#each block.tools as tool, i}
-										<ToolExecutionCard {tool} index={i} />
+										<ToolExecutionCard {tool} index={i} {projectId} onRevert={onUpdate} />
 									{/each}
 								</div>
 							{/if}

--- a/packages/frontend/src/lib/components/DiffDisplay.svelte
+++ b/packages/frontend/src/lib/components/DiffDisplay.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+	import { diffLines, type Change } from 'diff';
+	import { Button } from './ui/button';
+	import { Undo2 } from 'lucide-svelte';
+	import { resolvePath } from '$lib/utils/paths';
+
+	interface DiffData {
+		type: 'file_write' | 'file_edit' | 'file_delete';
+		file_path: string;
+		before: string | null;
+		after: string | null;
+		isNewFile: boolean;
+	}
+
+	let {
+		diffData,
+		projectId,
+		onRevert
+	}: {
+		diffData: DiffData;
+		projectId: string;
+		onRevert?: () => void;
+	} = $props();
+
+	let isReverting = $state(false);
+	let reverted = $state(false);
+
+	// Compute the diff
+	let changes = $derived.by(() => {
+		if (diffData.type === 'file_delete') {
+			// For deletions, show all lines as removed
+			return diffData.before
+				? diffLines('', diffData.before).map((change) => ({ ...change, removed: true, added: false }))
+				: [];
+		} else if (diffData.isNewFile) {
+			// For new files, show all lines as added
+			return diffData.after
+				? diffLines('', diffData.after).map((change) => ({ ...change, added: true, removed: false }))
+				: [];
+		} else {
+			// For edits, show the actual diff
+			return diffLines(diffData.before || '', diffData.after || '');
+		}
+	});
+
+	// Count additions and deletions
+	let stats = $derived.by(() => {
+		let additions = 0;
+		let deletions = 0;
+		for (const change of changes) {
+			const lineCount = change.value.split('\n').filter((l) => l).length;
+			if (change.added) additions += lineCount;
+			if (change.removed) deletions += lineCount;
+		}
+		return { additions, deletions };
+	});
+
+	async function handleRevert() {
+		if (reverted) return; // Already reverted
+
+		isReverting = true;
+		try {
+			const response = await fetch(resolvePath(`/api/projects/${projectId}/revert`), {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					file_path: diffData.file_path,
+					content: diffData.before, // Restore to before state
+				}),
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to revert file');
+			}
+
+			reverted = true;
+
+			// Notify parent component if callback provided
+			if (onRevert) {
+				onRevert();
+			}
+		} catch (error) {
+			console.error('Error reverting file:', error);
+			alert('Failed to revert file. Please try again.');
+		} finally {
+			isReverting = false;
+		}
+	}
+</script>
+
+<div class="diff-display">
+	<div class="diff-header">
+		<div class="diff-file-info">
+			<span class="diff-file-path">{diffData.file_path}</span>
+			{#if diffData.type === 'file_delete'}
+				<span class="diff-badge deleted">Deleted</span>
+			{:else if diffData.isNewFile}
+				<span class="diff-badge created">Created</span>
+			{:else}
+				<span class="diff-badge modified">Modified</span>
+			{/if}
+		</div>
+		<div class="diff-stats">
+			{#if stats.additions > 0}
+				<span class="stat additions">+{stats.additions}</span>
+			{/if}
+			{#if stats.deletions > 0}
+				<span class="stat deletions">-{stats.deletions}</span>
+			{/if}
+			<Button
+				variant={reverted ? "default" : "outline"}
+				size="sm"
+				onclick={handleRevert}
+				disabled={isReverting || reverted}
+			>
+				<Undo2 size={14} />
+				{reverted ? 'Reverted' : isReverting ? 'Reverting...' : 'Revert'}
+			</Button>
+		</div>
+	</div>
+
+	<div class="diff-content">
+		{#each changes as change}
+			{#if change.added}
+				<div class="diff-line added">
+					<span class="line-marker">+</span>
+					<pre>{change.value.trimEnd()}</pre>
+				</div>
+			{:else if change.removed}
+				<div class="diff-line removed">
+					<span class="line-marker">-</span>
+					<pre>{change.value.trimEnd()}</pre>
+				</div>
+			{:else}
+				<div class="diff-line unchanged">
+					<span class="line-marker"> </span>
+					<pre>{change.value.trimEnd()}</pre>
+				</div>
+			{/if}
+		{/each}
+	</div>
+</div>
+
+<style>
+	.diff-display {
+		border: 1px solid var(--color-border);
+		border-radius: 8px;
+		overflow: hidden;
+		background: var(--color-bg-secondary);
+		margin: 0.5rem 0;
+	}
+
+	.diff-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.75rem;
+		background: var(--color-bg-tertiary);
+		border-bottom: 1px solid var(--color-border);
+		gap: 0.75rem;
+	}
+
+	.diff-file-info {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.diff-file-path {
+		font-family: 'Courier New', monospace;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.diff-badge {
+		padding: 0.125rem 0.5rem;
+		border-radius: 4px;
+		font-size: 0.75rem;
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	.diff-badge.created {
+		background: rgba(34, 197, 94, 0.15);
+		color: rgb(34, 197, 94);
+	}
+
+	.diff-badge.modified {
+		background: rgba(59, 130, 246, 0.15);
+		color: rgb(59, 130, 246);
+	}
+
+	.diff-badge.deleted {
+		background: rgba(239, 68, 68, 0.15);
+		color: rgb(239, 68, 68);
+	}
+
+	.diff-stats {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.stat {
+		font-family: 'Courier New', monospace;
+		font-size: 0.75rem;
+		font-weight: 600;
+	}
+
+	.stat.additions {
+		color: rgb(34, 197, 94);
+	}
+
+	.stat.deletions {
+		color: rgb(239, 68, 68);
+	}
+
+	.diff-content {
+		max-height: 400px;
+		overflow-y: auto;
+		font-family: 'Courier New', monospace;
+		font-size: 0.75rem;
+		line-height: 1.5;
+	}
+
+	.diff-line {
+		display: flex;
+		align-items: flex-start;
+		min-height: 1.5rem;
+	}
+
+	.diff-line.added {
+		background: rgba(34, 197, 94, 0.1);
+	}
+
+	.diff-line.removed {
+		background: rgba(239, 68, 68, 0.1);
+	}
+
+	.diff-line.unchanged {
+		background: transparent;
+	}
+
+	.line-marker {
+		display: inline-block;
+		width: 2rem;
+		padding: 0 0.5rem;
+		text-align: center;
+		flex-shrink: 0;
+		user-select: none;
+		color: var(--color-text-secondary);
+	}
+
+	.diff-line.added .line-marker {
+		color: rgb(34, 197, 94);
+		font-weight: 600;
+	}
+
+	.diff-line.removed .line-marker {
+		color: rgb(239, 68, 68);
+		font-weight: 600;
+	}
+
+	.diff-line pre {
+		margin: 0;
+		padding: 0 0.5rem;
+		flex: 1;
+		white-space: pre-wrap;
+		word-break: break-all;
+		color: var(--color-text-primary);
+		background: transparent;
+	}
+</style>

--- a/packages/frontend/src/lib/components/ToolExecutionCard.svelte
+++ b/packages/frontend/src/lib/components/ToolExecutionCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ChevronDown, ChevronRight, FileEdit, FolderPlus, Trash2, FolderOpen, Play, CheckCircle2, AlertCircle } from 'lucide-svelte';
+	import DiffDisplay from './DiffDisplay.svelte';
 
 	interface ToolExecution {
 		name: string;
@@ -8,12 +9,24 @@
 		output?: string;
 	}
 
+	interface DiffData {
+		type: 'file_write' | 'file_edit' | 'file_delete';
+		file_path: string;
+		before: string | null;
+		after: string | null;
+		isNewFile: boolean;
+	}
+
 	let {
 		tool,
-		index = 0
+		index = 0,
+		projectId = '',
+		onRevert
 	}: {
 		tool: ToolExecution;
 		index?: number;
+		projectId?: string;
+		onRevert?: () => void;
 	} = $props();
 
 	let expanded = $state(false);
@@ -86,6 +99,27 @@
 		if (tool.status === 'error') return 'status-error';
 		return 'status-running';
 	}
+
+	// Extract diff data from output
+	function extractDiffData(output: string | undefined): { diffData: DiffData | null; cleanOutput: string } {
+		if (!output) return { diffData: null, cleanOutput: '' };
+
+		const diffMatch = output.match(/<!-- diff:(.*?) -->/s);
+		if (diffMatch) {
+			try {
+				const diffData = JSON.parse(diffMatch[1]) as DiffData;
+				const cleanOutput = output.replace(/<!-- diff:.*? -->/s, '').trim();
+				return { diffData, cleanOutput };
+			} catch (e) {
+				console.error('Failed to parse diff data:', e);
+			}
+		}
+
+		return { diffData: null, cleanOutput: output };
+	}
+
+	let parsedOutput = $derived(extractDiffData(tool.output));
+	let hasDiff = $derived(parsedOutput.diffData !== null);
 </script>
 
 <button class="tool-card {getStatusClass()}" onclick={() => {
@@ -109,9 +143,16 @@
 		</div>
 	</div>
 
-	{#if expanded && tool.output}
+	{#if expanded && (hasDiff || parsedOutput.cleanOutput)}
 		<div class="tool-output">
-			<pre><code>{tool.output}</code></pre>
+			{#if hasDiff && parsedOutput.diffData}
+				<DiffDisplay diffData={parsedOutput.diffData} {projectId} {onRevert} />
+			{/if}
+			{#if parsedOutput.cleanOutput}
+				<div class="output-message">
+					{parsedOutput.cleanOutput}
+				</div>
+			{/if}
 		</div>
 	{/if}
 </button>
@@ -279,5 +320,15 @@
 	.tool-output code {
 		font-family: 'Courier New', monospace;
 		color: var(--color-text-secondary);
+	}
+
+	.output-message {
+		margin-top: 0.5rem;
+		padding: 0.75rem;
+		background: var(--color-bg-secondary);
+		border-radius: 6px;
+		font-size: 0.875rem;
+		color: var(--color-text-primary);
+		line-height: 1.5;
 	}
 </style>


### PR DESCRIPTION
This commit implements a complete diffing and revert system for file operations in the agent chat interface, providing users with visual feedback on changes and the ability to undo unwanted modifications.

Backend changes:
- Enhanced file-tools.ts to capture before/after file content for write_file, edit_file, and delete_file operations
- Modified tool responses to include diff metadata in HTML comments
- Added POST /api/projects/:id/revert endpoint for reverting file changes
- Support for reverting creates (by deleting), edits (by restoring), and deletes (by restoring previous content)

Frontend changes:
- Added 'diff' library for computing line-by-line diffs
- Created DiffDisplay.svelte component with:
  - Color-coded line additions/deletions
  - File operation badges (Created/Modified/Deleted)
  - Addition/deletion statistics
  - Revert button with loading states
- Updated ToolExecutionCard.svelte to:
  - Parse diff metadata from tool output
  - Display DiffDisplay component when diff data is present
  - Pass revert callback to trigger file refresh
- Updated AgentChat.svelte to pass projectId and onRevert callback

User experience improvements:
- Users now see visual diffs for all file changes in chat
- Changes can be reverted with a single click
- Diff view shows exactly what changed with line-level precision
- Automatic file refresh after revert

Technical implementation:
- Uses HTML comments to embed diff data in tool responses
- Diff data includes: type, file_path, before, after, isNewFile
- Revert endpoint handles all three operation types correctly
- Proper error handling and loading states throughout