### PR TITLE
Consume the identity keyring: gateway calls use the verified gateway leg

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@cuny-ai-lab:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@cloudflare/ai-chat": "0.9.3",
         "@cloudflare/codemode": "0.4.3",
         "@cuny-ai-lab/cail-client": "^1.3.0",
-        "@cuny-ai-lab/cail-identity": "5.0.0",
+        "@cuny-ai-lab/cail-identity": "5.1.0",
         "@cuny-ai-lab/cail-log": "^0.4.0",
         "agents": "0.17.4",
         "ai": "6.0.225",
@@ -252,7 +252,7 @@
 
     "@cuny-ai-lab/cail-client": ["@cuny-ai-lab/cail-client@1.3.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-client/1.3.0/51b55d77eeff1d847009623ffe5af169d7bc488d", { "dependencies": { "@cuny-ai-lab/cail-log": "^0.4.0" } }, "sha512-UDXBOdgRaGcnqM8T9w8yi0vkc9JT/4MzvHMAVlROYgH2zf5QP5LKvciUj1enijNdQDPASngkE/iCU+cRT332KQ=="],
 
-    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.0.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.0.0/fa21ee9d0cd0527b23fdb6f98dfe7a6d47f20d09", { "dependencies": { "jose": "6.2.3" } }, "sha512-ox09gifiFHnB9WEu+WvcJKErid9PZOw+9wfkYp1dYOlzQzDe7RYxDJKqBHf7oX53VUvOzlkvDr55QOkKm3wYSA=="],
+    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.1.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.1.0/27675a38c797795d11c3e99b8f7d2e519731faf2", { "dependencies": { "jose": "6.2.3" } }, "sha512-L4XnjVlefEctstO7OKCPnQV0yv/WQyIuowx6aBe1Tq603iANuDCTp16n5llwmVEOC2tRh1CDnRQuD06kJZASFQ=="],
 
     "@cuny-ai-lab/cail-log": ["@cuny-ai-lab/cail-log@0.4.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-log/0.4.0/67018d294dc7048944cbfab0361e46e148adaab4", {}, "sha512-V2WswlIra6BedHaf1T14JoL3RkTYkikJIusio5em9/E3PGVOdCDTKwzlszKOQ9o6t0qDhn2xs/kpqNcQIsBO4Q=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install.scopes]
+"@cuny-ai-lab" = { url = "https://npm.pkg.github.com", token = "$NODE_AUTH_TOKEN" }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,7 @@
     "@cloudflare/ai-chat": "0.9.3",
     "@cloudflare/codemode": "0.4.3",
     "@cuny-ai-lab/cail-client": "^1.3.0",
-    "@cuny-ai-lab/cail-identity": "5.0.0",
+    "@cuny-ai-lab/cail-identity": "5.1.0",
     "@cuny-ai-lab/cail-log": "^0.4.0",
     "agents": "0.17.4",
     "ai": "6.0.225",

--- a/packages/app/src/lib/cail-identity.ts
+++ b/packages/app/src/lib/cail-identity.ts
@@ -18,6 +18,9 @@
  */
 
 import {
+  CAIL_GATEWAY_AUDIENCE,
+  readIdentityKeyring,
+  verifyKeyringGatewayJwt,
   type CailIdentity,
   type IdentityVerifierConfig,
   loadIdentityVerifierConfig,
@@ -55,20 +58,21 @@ const VERIFIER_CACHE_MAX = 2;
 const verifierCache = new Map<string, IdentityVerifierConfig>();
 
 async function loadVerifier(
-  env: IdentityVerificationEnv
+  env: IdentityVerificationEnv,
+  audience: string = CAIL_IDENTITY_AUDIENCE
 ): Promise<IdentityVerifierConfig | null> {
   const jwks = env.CAIL_IDENTITY_JWKS;
   const issuer = env.CAIL_IDENTITY_ISSUER;
   if (!jwks || typeof issuer !== "string" || issuer.length === 0 || issuer.trim() !== issuer) {
     return null;
   }
-  const key = `${issuer}\u0000${jwks}`;
+  const key = `${audience}\u0000${issuer}\u0000${jwks}`;
   const cached = verifierCache.get(key);
   if (cached) return cached;
   const loaded = await loadIdentityVerifierConfig({
     jwks,
     issuer,
-    expectedAudience: CAIL_IDENTITY_AUDIENCE,
+    expectedAudience: audience,
     supportedIssuers: [issuer],
   });
   if (!loaded.ok) return null;
@@ -146,4 +150,25 @@ export function cailAuthRequiredResponse(): Response {
       },
     }
   );
+}
+
+
+/**
+ * Resolve the keyring gateway leg (identity-keyring-v1) for a request whose
+ * app leg already verified: full verification against the cail:gateway
+ * audience plus subject agreement. Returns the token to forward, null when
+ * absent, or "invalid" (callers fail closed).
+ */
+export async function resolveKeyringGatewayJwt(
+  request: Request,
+  env: IdentityVerificationEnv,
+  verifiedSubject: string,
+): Promise<string | null | "invalid"> {
+  const keyring = readIdentityKeyring(request.headers);
+  if (keyring === null) return "invalid";
+  if (keyring.gatewayJwt === undefined) return null;
+  const loaded = await loadVerifier(env, CAIL_GATEWAY_AUDIENCE);
+  if (loaded === null) return "invalid";
+  const identity = await verifyKeyringGatewayJwt(keyring, loaded, verifiedSubject);
+  return identity === null ? "invalid" : keyring.gatewayJwt;
 }

--- a/packages/app/src/lib/session.ts
+++ b/packages/app/src/lib/session.ts
@@ -6,6 +6,7 @@ import { SESSION_COOKIE_NAME, SESSION_TTL_SECONDS } from "./constants";
 import {
   cailAuthRequiredResponse,
   cailIdentityRequired,
+  resolveKeyringGatewayJwt,
   resolveRequestIdentity,
   type CailIdentity,
 } from "./cail-identity";
@@ -25,6 +26,7 @@ type SessionVariables = {
    * Downstream handlers forward this exact token to the CAIL model proxy.
    */
   cailIdentityJwt?: string;
+  cailGatewayJwt?: string;
 };
 
 /** KV session key for a verified CAIL subject. */
@@ -418,6 +420,21 @@ export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Sessi
     const { identity, token } = identityResolution;
     c.set("cailIdentityJwt", token);
 
+    // Keyring gateway leg (identity-keyring-v1): verified against the
+    // gateway audience and bound to this request's subject before it may be
+    // forwarded. A present-but-invalid leg fails the request closed.
+    const gatewayLeg = await resolveKeyringGatewayJwt(
+      c.req.raw,
+      c.env,
+      identity.subject
+    );
+    if (gatewayLeg === "invalid") {
+      return cailAuthRequiredResponse();
+    }
+    if (gatewayLeg !== null) {
+      c.set("cailGatewayJwt", gatewayLeg);
+    }
+
     const subject = identity.subject;
 
     if (!importWindow) {
@@ -583,6 +600,11 @@ export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Sessi
 /** The verified CAIL identity JWT for this request, if any (already verified). */
 export function getCailIdentityJwt(c: { get: (key: "cailIdentityJwt") => string | undefined }): string | null {
   return c.get("cailIdentityJwt") ?? null;
+}
+
+/** The verified keyring gateway leg for this request, if delivered. */
+export function getCailGatewayJwt(c: { get: (key: "cailGatewayJwt") => string | undefined }): string | null {
+  return c.get("cailGatewayJwt") ?? null;
 }
 
 export function getUser(c: { get: (key: "user") => User }): User {

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -34,11 +34,11 @@ describe("observability source contract", () => {
 
   it("pins the reviewed identity and transport primitives in the app", () => {
     const source = readFileSync(new URL("../package.json", import.meta.url), "utf8");
-    // Exact pin, not a range: cail-identity 5.0.0 carries the v2 subject
+    // Exact pin, not a range: cail-identity 5.x carries the v2 subject
     // derivation, whose ownership subjects differ from every 4.x value. A
     // caret range here could silently move that contract.
     expect(source).toContain(
-      '"@cuny-ai-lab/cail-identity": "5.0.0"',
+      '"@cuny-ai-lab/cail-identity": "5.1.0"',
     );
     expect(source).toContain(
       '"@cuny-ai-lab/cail-client": "^1.3.0"',

--- a/packages/app/src/routes/agents.test.ts
+++ b/packages/app/src/routes/agents.test.ts
@@ -50,7 +50,7 @@ describe("agent route WebSocket gate (rule 4)", () => {
   let kv: ReturnType<typeof createMockKV>;
   let bucket: R2Bucket;
   let csrf: CsrfSession;
-  let app: Hono<{ Bindings: Env; Variables: { user: { id: string }; cailIdentityJwt?: string } }>;
+  let app: Hono<{ Bindings: Env; Variables: { user: { id: string }; cailGatewayJwt?: string } }>;
 
   const env = () =>
     ({
@@ -65,10 +65,10 @@ describe("agent route WebSocket gate (rule 4)", () => {
     bucket = createMockBucket();
     csrf = await mintCsrfSession(bucket, USER_ID);
     vi.mocked(getAgentByName).mockClear();
-    app = new Hono<{ Bindings: Env; Variables: { user: { id: string }; cailIdentityJwt?: string } }>();
+    app = new Hono<{ Bindings: Env; Variables: { user: { id: string }; cailGatewayJwt?: string } }>();
     app.use("*", async (c, next) => {
       c.set("user", { id: USER_ID });
-      c.set("cailIdentityJwt", "verified-token");
+      c.set("cailGatewayJwt", "verified-token");
       await next();
     });
     app.route("/", createAgentRouter());

--- a/packages/app/src/routes/agents.ts
+++ b/packages/app/src/routes/agents.ts
@@ -3,7 +3,7 @@ import { Hono, type Context } from "hono";
 import type { Env, SiteBuilderAgentProps } from "../types";
 import { CSRF_ERROR_BODY, getCsrfToken, verifyWsUpgrade } from "../lib/csrf";
 import { jsonError } from "../lib/http";
-import { getCailIdentityJwt, getUser } from "../lib/session";
+import { getCailGatewayJwt, getUser } from "../lib/session";
 import { sanitizeProjectId } from "../lib/path";
 import { R2ProjectStorage } from "../storage/r2";
 import { getCorrelation, type LoggingVariables } from "../lib/logging";
@@ -60,7 +60,7 @@ export function createAgentRouter() {
     const props: SiteBuilderAgentProps = {
       userId: user.id,
       projectId,
-      identityJwt: getCailIdentityJwt(c) ?? undefined
+      identityJwt: getCailGatewayJwt(c) ?? undefined
     };
 
     return getAgentByName(

--- a/packages/app/src/routes/quota.test.ts
+++ b/packages/app/src/routes/quota.test.ts
@@ -17,9 +17,9 @@ describe("quota route", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const app = new Hono<{ Bindings: Env; Variables: { cailIdentityJwt: string } }>();
+    const app = new Hono<{ Bindings: Env; Variables: { cailGatewayJwt: string } }>();
     app.use("*", async (c, next) => {
-      c.set("cailIdentityJwt", "verified-jwt");
+      c.set("cailGatewayJwt", "verified-jwt");
       await next();
     });
     app.route("/", createQuotaRouter());
@@ -40,9 +40,9 @@ describe("quota route", () => {
       throw new TypeError("private transport detail");
     }));
 
-    const app = new Hono<{ Bindings: Env; Variables: { cailIdentityJwt: string } }>();
+    const app = new Hono<{ Bindings: Env; Variables: { cailGatewayJwt: string } }>();
     app.use("*", async (c, next) => {
-      c.set("cailIdentityJwt", "verified-jwt");
+      c.set("cailGatewayJwt", "verified-jwt");
       await next();
     });
     app.route("/", createQuotaRouter());

--- a/packages/app/src/routes/quota.ts
+++ b/packages/app/src/routes/quota.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { createCailClient, CailError } from "@cuny-ai-lab/cail-client";
 import type { Env } from "../types";
-import { getCailIdentityJwt } from "../lib/session";
+import { getCailGatewayJwt } from "../lib/session";
 import { CAIL_APP_SLUG } from "../lib/model";
 import { jsonError } from "../lib/http";
 
@@ -10,7 +10,7 @@ export function createQuotaRouter() {
 
   app.get("/api/quota", async (c) => {
     c.header("Cache-Control", "private, no-store");
-    const jwt = getCailIdentityJwt(c);
+    const jwt = getCailGatewayJwt(c);
     if (!jwt) jsonError("authentication_required", 401);
     if (!c.env.CAIL_API_BASE) jsonError("CAIL_API_BASE is not configured", 503);
 


### PR DESCRIPTION
Pins cail-identity 5.1.0 and wires identity-keyring-v1: the session
middleware verifies an optional gateway-audience leg (subject-bound,
fail-closed on mismatch); quota and site-builder agent calls forward
only that leg, never the app-audience token. Replaces the tokenless
.npmrc (which shadowed all registry auth under bun) with bunfig scoped
registry + NODE_AUTH_TOKEN, matching CI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
