### PR TITLE
Expose guarded Worker version metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,12 @@ respective accounting systems.
 `GET /api/health` and the publisher's `GET /healthz` return static
 `cail.health.v1` liveness markers with `Cache-Control: no-store`. They prove that
 the relevant Worker loaded and dispatched the request; they deliberately do not
-claim readiness for R2, KV, Durable Objects, or the model gateway.
+claim readiness for R2, KV, Durable Objects, or the model gateway. When the
+Cloudflare [version-metadata binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/)
+is available, each response exposes only a canonical Cloudflare version UUID
+and a lowercase 40-hex `version_tag`; local, older, or nonconforming metadata
+returns `null`. Deployment automation must still set and verify that tag from
+the intended Git SHA before treating it as source linkage.
 
 See [`docs/cail-log-alignment.md`](docs/cail-log-alignment.md) for the event map,
 denominator rules, operating defaults, and remaining external inputs.

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -327,7 +327,7 @@ describe("observability source contract", () => {
     });
   });
 
-  it("returns a stable, no-store app liveness response", async () => {
+  it("returns a stable, no-store app liveness response with null local metadata", async () => {
     const response = await createHealthRouter().request(
       "https://app.example/api/health",
       {},
@@ -346,6 +346,47 @@ describe("observability source contract", () => {
         name: "site-studio-app",
         version: "0.1.0",
       },
+      version_id: null,
+      version_tag: null,
+    });
+  });
+
+  it("returns exact canonical Cloudflare version metadata when present", async () => {
+    const response = await createHealthRouter().request(
+      "https://app.example/api/health",
+      {},
+      {
+        CAIL_LOG_ENV: "test",
+        CF_VERSION_METADATA: {
+          id: "095f00a7-23a7-43b7-a227-e4c97cab5f22",
+          tag: "0123456789abcdef0123456789abcdef01234567",
+          timestamp: "2026-08-07T12:00:00.000Z",
+        },
+      } as Env,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      version_id: "095f00a7-23a7-43b7-a227-e4c97cab5f22",
+      version_tag: "0123456789abcdef0123456789abcdef01234567",
+    });
+  });
+
+  it("nulls non-canonical version metadata", async () => {
+    const response = await createHealthRouter().request(
+      "https://app.example/api/health",
+      {},
+      {
+        CAIL_LOG_ENV: "test",
+        CF_VERSION_METADATA: {
+          id: "095F00A7-23A7-43B7-A227-E4C97CAB5F22",
+          tag: "release-2026-08-07",
+          timestamp: "2026-08-07T12:00:00.000Z",
+        },
+      } as Env,
+    );
+    expect(await response.json()).toMatchObject({
+      version_id: null,
+      version_tag: null,
     });
   });
 

--- a/packages/app/src/routes/health.ts
+++ b/packages/app/src/routes/health.ts
@@ -14,7 +14,7 @@ export function createHealthRouter() {
     if (!parseCailLogEnvironment(c.env.CAIL_LOG_ENV)) {
       return serviceUnavailableResponse();
     }
-    return healthResponse("app");
+    return healthResponse("app", c.env.CF_VERSION_METADATA);
   });
 
   return app;

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -7,6 +7,9 @@ import type {
 } from "@cuny-ai-lab/cail-log";
 
 export interface Env {
+  // Cloudflare Version Metadata binding. It is unavailable in local/test
+  // runtimes, so the health response treats it as optional.
+  CF_VERSION_METADATA?: WorkerVersionMetadata;
   // Source-ready fleet projection. The live Analytics Engine dataset/binding
   // is provisioned separately; without it Workers structured logs continue.
   CAIL_FLEET_EVENTS?: CailAnalyticsEngineDataset;

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -5,6 +5,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-03-25",
   "compatibility_flags": ["nodejs_compat"],
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
   "observability": {
     "enabled": true,
     "logs": {

--- a/packages/observability-core/src/contract.ts
+++ b/packages/observability-core/src/contract.ts
@@ -559,7 +559,38 @@ export function auditTelemetryLifecyclePairs(
   return issues;
 }
 
-export function healthResponse(service: SiteStudioService): Response {
+/**
+ * The Cloudflare version-metadata binding is absent in local development and
+ * older deployments. Keep its public health projection joinable and explicit:
+ * only a canonical Cloudflare version UUID and a lowercase full Git SHA tag
+ * are exposed; invalid or missing fields become null.
+ */
+export type HealthVersionMetadata = Readonly<{
+  id: string;
+  tag: string;
+  timestamp?: string;
+}>;
+
+const CLOUDFLARE_VERSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const GIT_SHA_VERSION_TAG_PATTERN = /^[0-9a-f]{40}$/;
+
+function cloudflareVersionId(value: unknown): string | null {
+  return typeof value === "string" && CLOUDFLARE_VERSION_ID_PATTERN.test(value)
+    ? value
+    : null;
+}
+
+function gitShaVersionTag(value: unknown): string | null {
+  return typeof value === "string" && GIT_SHA_VERSION_TAG_PATTERN.test(value)
+    ? value
+    : null;
+}
+
+export function healthResponse(
+  service: SiteStudioService,
+  versionMetadata?: HealthVersionMetadata | null,
+): Response {
   const definition = OBSERVABILITY_CONTRACT.services[service];
   return Response.json(
     {
@@ -572,6 +603,8 @@ export function healthResponse(service: SiteStudioService): Response {
         name: definition.name,
         version: definition.version,
       },
+      version_id: cloudflareVersionId(versionMetadata?.id),
+      version_tag: gitShaVersionTag(versionMetadata?.tag),
     },
     {
       status: 200,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -139,6 +139,9 @@ function errorTypeFrom(error: unknown): string {
 }
 
 export type Env = {
+  // Cloudflare Version Metadata binding. It is unavailable in local/test
+  // runtimes, so the health response treats it as optional.
+  CF_VERSION_METADATA?: WorkerVersionMetadata;
   PUBLIC_DOMAIN?: string;
   CAIL_FLEET_EVENTS?: CailAnalyticsEngineDataset;
   CAIL_LOG_ENV?: CailLogEnvironment;
@@ -517,7 +520,7 @@ async function handlePublishedRequest(
     url.pathname === OBSERVABILITY_CONTRACT.services.publisher.healthPath
     && (request.method === "GET" || request.method === "HEAD")
   ) {
-    const response = healthResponse("publisher");
+    const response = healthResponse("publisher", env.CF_VERSION_METADATA);
     return request.method === "HEAD"
       ? new Response(null, { status: response.status, headers: response.headers })
       : response;

--- a/packages/worker/src/observability-contract.test.ts
+++ b/packages/worker/src/observability-contract.test.ts
@@ -58,11 +58,45 @@ describe("publisher observability contract", () => {
         name: "site-studio-publisher",
         version: "0.1.0",
       },
+      version_id: null,
+      version_tag: null,
     });
     expect(bucket.get).not.toHaveBeenCalled();
     expect(points).toHaveLength(4);
     expect(points.every((point) => point.indexes[0] === "test:site-studio")).toBe(true);
     expect(JSON.stringify(points)).not.toContain("private=value");
+
+    const versioned = await worker.fetch(
+      new Request("https://publisher.example/healthz"),
+      {
+        ...env,
+        CF_VERSION_METADATA: {
+          id: "1a88955c-2fbd-4a72-9d9b-3ba1e59842f2",
+          tag: "fedcba9876543210fedcba9876543210fedcba98",
+          timestamp: "2026-08-07T12:00:00.000Z",
+        },
+      },
+    );
+    expect(await versioned.json()).toMatchObject({
+      version_id: "1a88955c-2fbd-4a72-9d9b-3ba1e59842f2",
+      version_tag: "fedcba9876543210fedcba9876543210fedcba98",
+    });
+
+    const invalid = await worker.fetch(
+      new Request("https://publisher.example/healthz"),
+      {
+        ...env,
+        CF_VERSION_METADATA: {
+          id: "1A88955C-2FBD-4A72-9D9B-3BA1E59842F2",
+          tag: "release-2026-08-07",
+          timestamp: "2026-08-07T12:00:00.000Z",
+        },
+      },
+    );
+    expect(await invalid.json()).toMatchObject({
+      version_id: null,
+      version_tag: null,
+    });
   });
 
   it("classifies health as a safe dashboard route", () => {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -5,6 +5,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-03-25",
   "compatibility_flags": ["nodejs_compat"],
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
   "observability": {
     "enabled": true,
     "logs": {


### PR DESCRIPTION
Adds the smallest source-to-serving join needed by the fleet observer.

- binds Cloudflare version metadata in both Workers
- exposes only canonical UUID version IDs
- exposes version tags only when they are lowercase full Git SHAs
- reports absent or noncanonical values as null
- preserves existing no-store liveness semantics

No deployment or routing change.

Checks: full repository check, production build, repository verification, focused app/publisher tests, and diff checks passed.