### PR TITLE
Point Site Studio at the canonical Model API

### DIFF
--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -38,6 +38,13 @@ describe("observability source contract", () => {
     expect(source).not.toContain("analytics_engine_datasets");
   });
 
+  it("pins the app to the canonical production CAIL Model API Worker", () => {
+    const source = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+    expect(source).toMatch(
+      /"CAIL_API_BASE"\s*:\s*"https:\/\/cail-model-api\.ailab-452\.workers\.dev"/,
+    );
+  });
+
   it.each([
     new URL("../package.json", import.meta.url),
     new URL("../../worker/package.json", import.meta.url),

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -57,11 +57,11 @@
     "APP_PUBLIC_DOMAIN": "https://tools.ailab.gc.cuny.edu",
     "PUBLISHED_BASE_URL": "https://tools.cuny.qzz.io",
     // ---- CAIL backbone (see cail-gateway docs/INTEGRATION.md) ----
-    // CAIL_API_BASE: the one public base URL of the CAIL model proxy (serves
+    // CAIL_API_BASE: the one public base URL of the CAIL Model API (serves
     // /v1/... model calls and /keys) in the institutional Cloudflare account.
     // Chat calls hit {CAIL_API_BASE}/v1/chat/completions; image
     // generation hits the native {CAIL_API_BASE}/v1/run.
-    "CAIL_API_BASE": "https://cail-model-proxy.ailab-452.workers.dev",
+    "CAIL_API_BASE": "https://cail-model-api.ailab-452.workers.dev",
     // CAIL_MODEL: Workers AI catalog id. CAIL policy (2026-07-04): Cloudflare
     // models only — any override must also be a `@cf/...` id. Default is the
     // agentic-coding flagship; `@cf/openai/gpt-oss-120b` is the cheaper fallback.


### PR DESCRIPTION
## What changed

- replaces the obsolete model-proxy hostname with the canonical production Model API origin
- pins that exact origin in the existing configuration contract test

## Why

Greenfield source should have one current Model API. The canonical Worker exposes the live, ready, catalog, and authenticated model contracts; the old Worker remains only as an external obsolete deployment.

## Validation

- canonical live, ready, and public catalog endpoints return 200; protected model routes return 401 without credentials and make no billable call
- app: 660 tests; publisher Worker: 90 tests; frontend: 172 tests
- root checks/builds and both Worker dry-runs pass
- independent Luna review: approved with no P0-P2 findings