### PR TITLE
Fix launch Site Studio recovery and copy

### DIFF
--- a/packages/app/src/lib/not-found-page.ts
+++ b/packages/app/src/lib/not-found-page.ts
@@ -2,10 +2,12 @@
  * Render the neutral fallback document used by preview and published-site
  * routes when a requested page is missing and the project has no `404.html`.
  */
-export function renderNotFoundPage(siteRootPath?: string): string {
+export function renderNotFoundPage(siteRootPath?: string, appRootPath?: string): string {
   const homeLink = siteRootPath
     ? `\n        <p class="actions"><a href="${escapeHtmlAttribute(siteRootPath)}">Go to site home</a></p>`
-    : "";
+    : appRootPath
+      ? `\n        <p class="actions"><a href="${escapeHtmlAttribute(appRootPath)}">Explore CUNY AI Lab tools</a></p>`
+      : "";
 
   return `<!doctype html>
 <html lang="en">

--- a/packages/app/src/lib/serving.test.ts
+++ b/packages/app/src/lib/serving.test.ts
@@ -76,17 +76,27 @@ describe("app serving security headers", () => {
 });
 
 describe("app not-found page", () => {
-  it("renders a home link only when a site root path is supplied", () => {
+  it("links to the site home when known and the Lab tools index otherwise", () => {
     const withLink = renderNotFoundPage("/u/example/blog/");
     expect(withLink).toContain('href="/u/example/blog/"');
     expect(withLink).toContain("Go to site home");
 
+    const fallbackLink = renderNotFoundPage(undefined, "https://tools.example.test/");
+    expect(fallbackLink).toContain('href="https://tools.example.test/"');
+    expect(fallbackLink).toContain("Explore CUNY AI Lab tools");
+
     const withoutLink = renderNotFoundPage();
-    expect(withoutLink).not.toContain("Go to site home");
+    expect(withoutLink).not.toContain("Explore CUNY AI Lab tools");
   });
 
   it("escapes the site root path into the href attribute", () => {
     const html = renderNotFoundPage('/u/example/"><script>/');
+    expect(html).not.toContain('"><script>');
+    expect(html).toContain("&quot;&gt;&lt;script&gt;");
+  });
+
+  it("escapes the Lab tools fallback into the href attribute", () => {
+    const html = renderNotFoundPage(undefined, 'https://tools.example.test/"><script>/');
     expect(html).not.toContain('"><script>');
     expect(html).toContain("&quot;&gt;&lt;script&gt;");
   });

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -83,7 +83,7 @@ async function collectPublishA11yFindings(
  */
 function publishedNotFound(c: AppContext, filePath: string, siteRootPath?: string): Response {
   if (looksLikePageNavigation(c.req.header("Accept"), filePath)) {
-    return c.html(renderNotFoundPage(siteRootPath), 404);
+    return c.html(renderNotFoundPage(siteRootPath, getAppPublicRoot(c)), 404);
   }
   return c.text("Not found", 404);
 }
@@ -128,6 +128,16 @@ function slugify(value: string): string {
 
 function normalizeBaseUrl(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function getAppPublicRoot(c: AppContext): string {
+  const requestOrigin = new URL(c.req.url).origin;
+  if (isLoopbackOrigin(requestOrigin)) {
+    return `${requestOrigin}/`;
+  }
+
+  const configuredOrigin = c.env.APP_PUBLIC_DOMAIN?.trim();
+  return `${normalizeBaseUrl(configuredOrigin || requestOrigin)}/`;
 }
 
 function getPublishedBaseUrl(c: AppContext): string {

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -276,6 +276,23 @@ describe("route regressions", () => {
     expect(body).toContain('href="/u/janedoe/pub/"');
   });
 
+  it("links an unknown public site to the canonical Lab tools index", async () => {
+    const env = createEnv(bucket);
+    env.APP_PUBLIC_DOMAIN = "https://cail-doorway.ailab-452.workers.dev";
+
+    const response = await app.request(
+      "https://site-studio-app.ailab-452.workers.dev/u/unknown/missing/",
+      { headers: { Accept: "text/html" } },
+      env
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.text();
+    expect(body).toContain("Explore CUNY AI Lab tools");
+    expect(body).toContain('href="https://cail-doorway.ailab-452.workers.dev/"');
+    expect(body).not.toContain("Go to site home");
+  });
+
   it("honors a project 404.html for missing published navigations", async () => {
     await storage.createProject(userId, "pub2", "Pub2");
     await storage.writeFile(userId, "pub2", "index.html", "<h1>Home</h1>");

--- a/packages/frontend/src/lib/components/NewProjectDialog.svelte
+++ b/packages/frontend/src/lib/components/NewProjectDialog.svelte
@@ -200,7 +200,7 @@
 		<Dialog.Header>
 			<Dialog.Title>Create New Project</Dialog.Title>
 			<Dialog.Description>
-				Choose a starting template. Customize the static website with the AI assistant. Prompts and attached files are sent to CAIL and saved with this project; AI use is subject to your CAIL usage limit.
+				Choose a starting template and customize the static website with the AI assistant. Site Studio saves prompts and attached files with your private project. Model-provider routes are configured not to retain prompts or outputs; that setting does not cover Site Studio storage. Publishing separately makes the site files public. AI use is subject to your CAIL usage limit.
 			</Dialog.Description>
 		</Dialog.Header>
 

--- a/packages/frontend/src/lib/components/NewProjectDialog.test.ts
+++ b/packages/frontend/src/lib/components/NewProjectDialog.test.ts
@@ -146,3 +146,19 @@ describe('NewProjectDialog project-name suggestion race', () => {
 		expect(input.value).toBe('alpha-5');
 	});
 });
+
+describe('NewProjectDialog data disclosure', () => {
+	beforeEach(() => {
+		mockFetchProjects.mockReset();
+		mockFetchTemplateCategories.mockReset();
+		mockFetchTemplateCategories.mockResolvedValue(categories);
+	});
+
+	it('distinguishes project storage, model-provider retention, and publishing', () => {
+		openDialog();
+
+		expect(screen.getByText(/Site Studio saves prompts and attached files with your private project/)).toBeInTheDocument();
+		expect(screen.getByText(/Model-provider routes are configured not to retain prompts or outputs/)).toBeInTheDocument();
+		expect(screen.getByText(/Publishing separately makes the site files public/)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## What changed

- Give visitors to an unknown public site one recovery action to the canonical CUNY AI Lab tools home.
- Preserve the existing known-site home action and plain asset 404 behavior.
- Explain private Site Studio project storage, model-provider non-retention configuration, and public publishing as separate boundaries.

## Why

Real local and live browser runs reproduced a styled unknown-site 404 with no link or button on desktop and mobile. The direct Worker and Doorway-mounted routes need the same canonical recovery destination.

## Validation

- bun run check: 694 app tests, 169 frontend tests, Svelte check, production build
- Wrangler production dry-run
- Real local Workerd and Playwright public 404 readback with no horizontal overflow
- Direct-origin and mounted-route behavior covered separately; known-site and asset 404 behavior retained
- Independent Luna review: no blockers
