### PR TITLE
Serialize Site Studio chat admission

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -156,7 +156,17 @@ app.notFound(async (c) => {
     return c.env.ASSETS.fetch(assetRequest(c));
   }
 
-  return c.json({ error: "Not found" }, 404);
+  return c.json(
+    { error: "Not found" },
+    404,
+    {
+      "Cache-Control": "no-store",
+      "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+      "X-Frame-Options": "DENY"
+    }
+  );
 });
 
 export default app;

--- a/packages/app/src/lib/cail-identity.test.ts
+++ b/packages/app/src/lib/cail-identity.test.ts
@@ -311,6 +311,7 @@ describe("cailAuthRequiredResponse", () => {
   it("returns the CAIL authentication_required envelope", async () => {
     const response = cailAuthRequiredResponse();
     expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     await expect(response.json()).resolves.toMatchObject({
       error: "authentication_required",
       login_url: "/site-studio/",

--- a/packages/app/src/lib/cail-identity.ts
+++ b/packages/app/src/lib/cail-identity.ts
@@ -131,6 +131,7 @@ export function cailAuthRequiredResponse(): Response {
       headers: {
         "Content-Type": "application/json",
         "WWW-Authenticate": 'Bearer realm="CAIL"',
+        "Cache-Control": "no-store",
       },
     }
   );

--- a/packages/app/src/lib/serving-headers.ts
+++ b/packages/app/src/lib/serving-headers.ts
@@ -14,3 +14,15 @@ export function servedContentHeaders(): Record<string, string> {
     "Referrer-Policy": "no-referrer"
   };
 }
+
+/** Headers for the app-generated 404 document or plain-text missing asset. */
+export function servedNotFoundHeaders(cacheControl: string): Record<string, string> {
+  return {
+    "Cache-Control": cacheControl,
+    "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+    "Referrer-Policy": "no-referrer",
+    "Vary": "Accept",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY"
+  };
+}

--- a/packages/app/src/lib/serving.test.ts
+++ b/packages/app/src/lib/serving.test.ts
@@ -3,7 +3,7 @@ import {
   SERVED_CONTENT_TYPES,
   getServedContentType
 } from "./content-types";
-import { servedContentHeaders } from "./serving-headers";
+import { servedContentHeaders, servedNotFoundHeaders } from "./serving-headers";
 import { renderNotFoundPage } from "./not-found-page";
 import { looksLikePageNavigation } from "./page-navigation";
 
@@ -72,6 +72,15 @@ describe("app serving security headers", () => {
     expect(headers["Referrer-Policy"]).toBe("no-referrer");
     expect(headers).not.toHaveProperty("Content-Disposition");
     expect(headers["Content-Security-Policy"]).not.toContain("default-src");
+  });
+
+  it("keeps generated public 404s revalidated and non-embeddable", () => {
+    const headers = servedNotFoundHeaders("public, max-age=0, must-revalidate");
+    expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");
+    expect(headers["Content-Security-Policy"]).toContain("default-src 'none'");
+    expect(headers["Content-Security-Policy"]).not.toContain("sandbox");
+    expect(headers.Vary).toBe("Accept");
+    expect(headers["X-Frame-Options"]).toBe("DENY");
   });
 });
 

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -4,7 +4,7 @@ import { addCacheBusterToHtml, collectPreviewResourcePaths } from "../lib/path";
 import { getServedContentType } from "../lib/constants";
 import { binaryBody } from "../lib/http";
 import { renderNotFoundPage } from "../lib/not-found-page";
-import { servedContentHeaders } from "../lib/serving-headers";
+import { servedContentHeaders, servedNotFoundHeaders } from "../lib/serving-headers";
 import { looksLikePageNavigation } from "../lib/page-navigation";
 import { resolveExtensionlessFile } from "../lib/extensionless";
 import { isProtectedServedPath } from "../lib/protected-files";
@@ -19,10 +19,11 @@ type AppContext = Context<{
 }>;
 
 function previewNotFound(c: AppContext, filePath: string, siteRootPath?: string): Response {
+  const headers = servedNotFoundHeaders("no-store");
   if (looksLikePageNavigation(c.req.header("Accept"), filePath)) {
-    return c.html(renderNotFoundPage(siteRootPath), 404);
+    return c.html(renderNotFoundPage(siteRootPath), 404, headers);
   }
-  return c.text("Not found", 404);
+  return c.text("Not found", 404, headers);
 }
 
 export function createPreviewRouter() {

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -10,7 +10,7 @@ import {
 import { binaryBody, jsonError } from "../lib/http";
 import { getUserHandle, resolveHandleOwner } from "../lib/handles";
 import { renderNotFoundPage } from "../lib/not-found-page";
-import { servedContentHeaders } from "../lib/serving-headers";
+import { servedContentHeaders, servedNotFoundHeaders } from "../lib/serving-headers";
 import { looksLikePageNavigation } from "../lib/page-navigation";
 import { resolveExtensionlessFile } from "../lib/extensionless";
 import { isProtectedServedPath } from "../lib/protected-files";
@@ -82,10 +82,11 @@ async function collectPublishA11yFindings(
  * plain-text 404.
  */
 function publishedNotFound(c: AppContext, filePath: string, siteRootPath?: string): Response {
+  const headers = servedNotFoundHeaders("public, max-age=0, must-revalidate");
   if (looksLikePageNavigation(c.req.header("Accept"), filePath)) {
-    return c.html(renderNotFoundPage(siteRootPath, getAppPublicRoot(c)), 404);
+    return c.html(renderNotFoundPage(siteRootPath, getAppPublicRoot(c)), 404, headers);
   }
-  return c.text("Not found", 404);
+  return c.text("Not found", 404, headers);
 }
 
 /**

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -972,7 +972,7 @@ describe("served-bytes security headers (§3¾)", () => {
     expect(response.headers.get("Content-Security-Policy")).toBeNull();
   });
 
-  it("does NOT sandbox the styled fallback 404 (our own trusted markup)", async () => {
+  it("hardens the styled fallback 404 without sandboxing our own trusted markup", async () => {
     await storage.createProject(userId, "fb", "Fb");
     await storage.writeFile(userId, "fb", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "fb", { published: true, slug: "fb" });
@@ -984,7 +984,8 @@ describe("served-bytes security headers (§3¾)", () => {
     );
     expect(response.status).toBe(404);
     expect(await response.text()).toContain("Page not found");
-    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    expect(response.headers.get("Content-Security-Policy")).toContain("default-src 'none'");
+    expect(response.headers.get("Content-Security-Policy")).not.toContain("sandbox");
   });
 
   it("adds nosniff but does NOT sandbox the owner thumbnail PNG", async () => {

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -76,6 +76,8 @@
 	let historyLoadFailed = $state(false);
 	let input = $state('');
 	let isLoading = $state(false);
+	let isPreparingRequest = $state(false);
+	let requestPreparationSequence = 0;
 	let messagesContainer: HTMLDivElement;
 	let fileInput: HTMLInputElement;
 	let currentStatus = $state<string>('');
@@ -888,10 +890,11 @@
 		return ws;
 	}
 
-	async function sendChatRequest(messagesForRequest: UIChatMessage[]) {
-		const targetProjectId = projectId;
-		const targetEpoch = projectContextEpoch;
-
+	async function sendChatRequest(
+		messagesForRequest: UIChatMessage[],
+		targetProjectId: string,
+		targetEpoch: number
+	) {
 		const ws = await prepareSocketForModelTurn(targetProjectId, targetEpoch);
 		const requestId = generateId();
 		const startedAt = Date.now();
@@ -1131,6 +1134,8 @@
 
 		const targetProjectId = projectId;
 		projectContextEpoch += 1;
+		requestPreparationSequence += 1;
+		isPreparingRequest = false;
 		const targetEpoch = projectContextEpoch;
 		previousProjectId = targetProjectId;
 		input = '';
@@ -1161,6 +1166,8 @@
 		if (!currentRequestId) {
 			return;
 		}
+		requestPreparationSequence += 1;
+		isPreparingRequest = false;
 
 		// SS-9: remember the cancelled id so a late CF_AGENT_USE_CHAT_RESPONSE frame
 		// for it can't recreate activeStream and resume appending after the stop.
@@ -1178,11 +1185,11 @@
 		resetRequestState();
 	}
 
-	async function uploadFile(file: File): Promise<string> {
+	async function uploadFile(file: File, targetProjectId: string): Promise<string> {
 		const formData = new FormData();
 		formData.append('file', file);
 
-		const response = await csrfFetch(resolvePath(`/api/projects/${projectId}/upload`), {
+		const response = await csrfFetch(resolvePath(`/api/projects/${targetProjectId}/upload`), {
 			method: 'POST',
 			body: formData
 		});
@@ -1195,7 +1202,7 @@
 		return data.filename;
 	}
 
-	async function ensureReadyForRequest(): Promise<boolean> {
+	async function ensureReadyForRequest(preparation?: RequestPreparation): Promise<boolean> {
 		if (!onBeforeSend) {
 			return true;
 		}
@@ -1204,70 +1211,94 @@
 			return await onBeforeSend();
 		} catch (error) {
 			console.error('Error preparing agent request:', error);
-			currentStatus = 'Unable to prepare request.';
+			if (!preparation || isCurrentRequestPreparation(preparation)) {
+				currentStatus = 'Unable to prepare request.';
+			}
 			return false;
 		}
 	}
 
+	interface RequestPreparation {
+		id: number;
+		projectId: string;
+		projectEpoch: number;
+	}
+
+	function beginRequestPreparation(allowWhileLoading = false): RequestPreparation | null {
+		if ((!allowWhileLoading && isLoading) || isPreparingRequest) return null;
+
+		const preparation = {
+			id: ++requestPreparationSequence,
+			projectId,
+			projectEpoch: projectContextEpoch
+		};
+		isPreparingRequest = true;
+		return preparation;
+	}
+
+	function isCurrentRequestPreparation(preparation: RequestPreparation): boolean {
+		return (
+			preparation.id === requestPreparationSequence &&
+			isCurrentProjectContext(preparation.projectId, preparation.projectEpoch)
+		);
+	}
+
+	function finishRequestPreparation(preparation: RequestPreparation) {
+		if (preparation.id === requestPreparationSequence) {
+			isPreparingRequest = false;
+		}
+	}
+
 	async function sendMessage() {
-		if (!input.trim() || isLoading) return;
-
-		const ready = await ensureReadyForRequest();
-		if (!ready) return;
-
 		const userMessage = input.trim();
-		const fileToUpload = attachedFile;
-		input = '';
-		attachedFile = null;
-		if (fileInput) fileInput.value = '';
-		isLoading = true;
+		if (!userMessage) return;
 
-		// Upload file FIRST if attached (skip on retry - already uploaded)
-		// This ensures we don't show user message if upload fails
-		let uploadedFilename: string | undefined;
-		if (fileToUpload) {
-			try {
+		const preparation = beginRequestPreparation();
+		if (!preparation) return;
+
+		const fileToUpload = attachedFile;
+		try {
+			const ready = await ensureReadyForRequest(preparation);
+			if (!ready || !isCurrentRequestPreparation(preparation)) return;
+
+			input = '';
+			attachedFile = null;
+			if (fileInput) fileInput.value = '';
+
+			// Upload file FIRST if attached (skip on retry - already uploaded)
+			// This ensures we don't show user message if upload fails
+			let uploadedFilename: string | undefined;
+			if (fileToUpload) {
 				isUploading = true;
-				uploadedFilename = await uploadFile(fileToUpload);
+				uploadedFilename = await uploadFile(fileToUpload, preparation.projectId);
+				if (!isCurrentRequestPreparation(preparation)) return;
 				onUpdate(); // Refresh preview - uploaded file may be referenced
-			} catch (error) {
-				console.error('File upload failed:', error);
-				uiMessages = [
-					...uiMessages,
-					{
-						id: generateId(),
-						role: 'assistant',
-						parts: [{ type: 'text', text: `Sorry, the file upload failed. ${getErrorMessage(error)}` }]
-					}
-				];
-				isLoading = false;
-				isUploading = false;
-				return;
-			} finally {
 				isUploading = false;
 			}
-		}
 
-		// Add user message AFTER successful upload so failed uploads don't create a chat turn
-		let messageContent = userMessage;
-		if (fileToUpload) {
-			messageContent += ` [Attached: ${fileToUpload.name}]`;
-		}
-		if (uploadedFilename) {
-			messageContent += `\n\n[File uploaded: ${uploadedFilename} (${(fileToUpload!.size / 1024).toFixed(1)}KB)]`;
-		}
-		const nextUserMessage: UIChatMessage = {
-			id: generateId(),
-			role: 'user',
-			parts: [{ type: 'text', text: messageContent }]
-		};
-		uiMessages = [...uiMessages, nextUserMessage];
+			// Add user message AFTER successful upload so failed uploads don't create a chat turn
+			let messageContent = userMessage;
+			if (fileToUpload) {
+				messageContent += ` [Attached: ${fileToUpload.name}]`;
+			}
+			if (uploadedFilename) {
+				messageContent += `\n\n[File uploaded: ${uploadedFilename} (${(fileToUpload!.size / 1024).toFixed(1)}KB)]`;
+			}
+			const nextUserMessage: UIChatMessage = {
+				id: generateId(),
+				role: 'user',
+				parts: [{ type: 'text', text: messageContent }]
+			};
+			uiMessages = [...uiMessages, nextUserMessage];
 
-		scrollToBottom();
-
-		try {
-			await sendChatRequest(getCurrentMessagesForRequest(nextUserMessage));
+			scrollToBottom();
+			await sendChatRequest(
+				getCurrentMessagesForRequest(nextUserMessage),
+				preparation.projectId,
+				preparation.projectEpoch
+			);
 		} catch (error: any) {
+			if (!isCurrentRequestPreparation(preparation)) return;
 			console.error('Error sending message:', error);
 			const message = getErrorMessage(error);
 			resetRequestState();
@@ -1279,6 +1310,9 @@
 					parts: [{ type: 'text', text: message }]
 				}
 			];
+		} finally {
+			isUploading = false;
+			finishRequestPreparation(preparation);
 		}
 	}
 
@@ -1288,7 +1322,7 @@
 	 * accessibility findings. No-ops while a request is already in flight.
 	 */
 	export async function sendPrompt(text: string) {
-		if (isLoading) return;
+		if (isLoading || isPreparingRequest) return;
 		input = text;
 		await sendMessage();
 	}
@@ -1297,13 +1331,14 @@
 		const interaction = pendingToolInteraction;
 		if (!interaction) return;
 
-		const ready = await ensureReadyForRequest();
-		if (!ready) return;
+		const preparation = beginRequestPreparation(true);
+		if (!preparation) return;
 
 		try {
-			const targetProjectId = projectId;
-			const targetEpoch = projectContextEpoch;
-			const ws = await prepareSocketForModelTurn(targetProjectId, targetEpoch);
+			const ready = await ensureReadyForRequest(preparation);
+			if (!ready || !isCurrentRequestPreparation(preparation)) return;
+			const ws = await prepareSocketForModelTurn(preparation.projectId, preparation.projectEpoch);
+			if (!isCurrentRequestPreparation(preparation)) return;
 			const output = {
 				answer: '',
 				declined: true
@@ -1325,8 +1360,12 @@
 			toolStartTimes = {};
 			currentStatus = 'Continuing...';
 		} catch (error) {
-			console.error('Error denying tool:', error);
-			currentStatus = 'Unable to send response.';
+			if (isCurrentRequestPreparation(preparation)) {
+				console.error('Error denying tool:', error);
+				currentStatus = 'Unable to send response.';
+			}
+		} finally {
+			finishRequestPreparation(preparation);
 		}
 	}
 
@@ -1365,10 +1404,12 @@
 		const interaction = pendingToolInteraction;
 		if (!interaction || !interaction.toolCallId) return;
 
-		const ready = await ensureReadyForRequest();
-		if (!ready) return;
+		const preparation = beginRequestPreparation(true);
+		if (!preparation) return;
 
 		try {
+			const ready = await ensureReadyForRequest(preparation);
+			if (!ready || !isCurrentRequestPreparation(preparation)) return;
 			const questions = getPendingQuestions(interaction.input || {});
 			const primaryQuestion = questions[0]?.question;
 			const answer =
@@ -1381,9 +1422,8 @@
 				...(annotations && Object.keys(annotations).length > 0 ? { annotations } : {})
 			};
 
-			const targetProjectId = projectId;
-			const targetEpoch = projectContextEpoch;
-			const ws = await prepareSocketForModelTurn(targetProjectId, targetEpoch);
+			const ws = await prepareSocketForModelTurn(preparation.projectId, preparation.projectEpoch);
+			if (!isCurrentRequestPreparation(preparation)) return;
 			uiMessages = applyLocalToolOutput(uiMessages, interaction.toolCallId, output);
 			ws.send(JSON.stringify({
 				type: AgentMessageType.CF_AGENT_TOOL_RESULT,
@@ -1400,8 +1440,12 @@
 			toolStartTimes = {};
 			currentStatus = 'Continuing...';
 		} catch (error) {
-			console.error('Error answering question:', error);
-			currentStatus = 'Unable to send your answer.';
+			if (isCurrentRequestPreparation(preparation)) {
+				console.error('Error answering question:', error);
+				currentStatus = 'Unable to send your answer.';
+			}
+		} finally {
+			finishRequestPreparation(preparation);
 		}
 	}
 
@@ -1433,6 +1477,7 @@
 	}
 
 	function removeAttachment() {
+		if (isLoading || isPreparingRequest) return;
 		attachedFile = null;
 		if (fileInput) {
 			fileInput.value = '';
@@ -1489,6 +1534,7 @@
 			{#if pendingToolInteraction}
 				<AskUserQuestionCard
 					questions={getPendingQuestions(pendingToolInteraction.input || {})}
+					busy={isPreparingRequest}
 					onSubmit={submitUserQuestionAnswers}
 					onReject={rejectUserQuestion}
 				/>
@@ -1531,7 +1577,7 @@
 				}}
 				placeholder={messages.length > 0 ? "Ask a follow-up..." : "Describe what you'd like to build..."}
 				aria-label="Message to the assistant"
-				disabled={isLoading}
+				disabled={isLoading || isPreparingRequest}
 				class="input-field"
 				rows="1"
 			></textarea>
@@ -1547,7 +1593,7 @@
 			{:else}
 				<button
 					onclick={() => sendMessage()}
-					disabled={!input.trim()}
+					disabled={!input.trim() || isPreparingRequest}
 					class="send-button"
 					title="Send message"
 					aria-label="Send message"
@@ -1565,6 +1611,7 @@
 				<span class="filesize">({(attachedFile.size / 1024).toFixed(1)}KB)</span>
 				<button
 					class="remove-btn"
+					disabled={isLoading || isPreparingRequest}
 					onclick={removeAttachment}
 					title="Remove attachment"
 					aria-label={`Remove ${attachedFile.name}`}
@@ -1591,6 +1638,7 @@
 			/>
 			<button
 				class="icon-btn"
+				disabled={isLoading || isPreparingRequest}
 				title="Attach file"
 				aria-label="Attach file"
 				onclick={handleFileUpload}

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -537,6 +537,62 @@ describe('AgentChat', () => {
 		expect(ws.sent.length).toBe(sentAfterFirst);
 	});
 
+	it('admits only one turn while an asynchronous pre-send save is pending', async () => {
+		let resolvePreparation!: (ready: boolean) => void;
+		const onBeforeSend = vi.fn(
+			() => new Promise<boolean>((resolve) => {
+				resolvePreparation = resolve;
+			})
+		);
+		const { component } = renderExposed({ onBeforeSend });
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		const first = component.sendPrompt('first');
+		const duplicate = component.sendPrompt('second');
+		expect(onBeforeSend).toHaveBeenCalledOnce();
+		resolvePreparation(true);
+		await Promise.all([first, duplicate]);
+		await settle();
+
+		const requests = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.filter((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(requests).toHaveLength(1);
+		expect(requests[0].init.body).toContain('first');
+		expect(requests[0].init.body).not.toContain('second');
+	});
+
+	it('drops a prepared turn when its project changes before the save finishes', async () => {
+		let resolvePreparation!: (ready: boolean) => void;
+		const onBeforeSend = vi.fn(
+			() => new Promise<boolean>((resolve) => {
+				resolvePreparation = resolve;
+			})
+		);
+		const result = renderExposed({ projectId: 'proj-a', onBeforeSend });
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const projectASocket = FakeWebSocket.last();
+		projectASocket.open();
+		await settle();
+
+		const pending = result.component.sendPrompt('change the old project');
+		expect(onBeforeSend).toHaveBeenCalledOnce();
+		await result.rerender({ projectId: 'proj-b', onUpdate: result.onUpdate, onBeforeSend });
+		resolvePreparation(true);
+		await pending;
+		await settle();
+
+		expect(
+			projectASocket.sent.some(
+				(raw) => JSON.parse(raw).type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST
+			)
+		).toBe(false);
+		expect(screen.queryByText('change the old project')).not.toBeInTheDocument();
+	});
+
 	it('waits for the credential refresh before sending a new chat frame', async () => {
 		let resolveRefresh!: (response: Response) => void;
 		let refreshRequested = false;
@@ -647,7 +703,9 @@ describe('AgentChat', () => {
 
 		questionFrame('stream-1', 'tool-1');
 		await waitFor(() => expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument());
-		screen.getByRole('button', { name: 'Skip' }).click();
+		const skipButton = screen.getByRole('button', { name: 'Skip' });
+		skipButton.click();
+		skipButton.click();
 		await waitFor(() => expect(refreshCount).toBe(2));
 		await settle();
 
@@ -655,7 +713,9 @@ describe('AgentChat', () => {
 		await waitFor(() => expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument());
 		screen.getByRole('button', { name: 'A' }).click();
 		await settle();
-		screen.getByRole('button', { name: 'Reply' }).click();
+		const replyButton = screen.getByRole('button', { name: 'Reply' });
+		replyButton.click();
+		replyButton.click();
 		await waitFor(() => expect(refreshCount).toBe(3));
 		await settle();
 

--- a/packages/frontend/src/lib/components/AskUserQuestionCard.svelte
+++ b/packages/frontend/src/lib/components/AskUserQuestionCard.svelte
@@ -27,10 +27,12 @@
 
 	let {
 		questions = [],
+		busy = false,
 		onSubmit,
 		onReject
 	}: {
 		questions: UserQuestionPrompt[];
+		busy?: boolean;
 		onSubmit: (submission: UserQuestionSubmission) => void;
 		onReject: () => void;
 	} = $props();
@@ -49,6 +51,7 @@
 	}
 
 	function chooseOption(index: number, question: UserQuestionPrompt, label: string) {
+		if (busy) return;
 		if (question.multiSelect) {
 			const current = getSelectedAnswers(index);
 			selectedAnswers[index] = current.includes(label)
@@ -63,6 +66,7 @@
 	}
 
 	function toggleCustom(index: number, question: UserQuestionPrompt) {
+		if (busy) return;
 		showCustomInput[index] = !showCustomInput[index];
 		if (showCustomInput[index]) {
 			if (!question.multiSelect) {
@@ -80,6 +84,7 @@
 	}
 
 	function updateCustomAnswer(index: number, question: UserQuestionPrompt, value: string) {
+		if (busy) return;
 		customAnswers[index] = value;
 		if (!question.multiSelect && value.trim()) {
 			selectedAnswers[index] = [];
@@ -121,6 +126,7 @@
 	);
 
 	function submitAnswers() {
+		if (busy) return;
 		if (!canSubmit) {
 			validationMessage = 'Answer each question to continue.';
 			return;
@@ -144,7 +150,7 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter' && !event.shiftKey && canSubmit) {
+		if (event.key === 'Enter' && !event.shiftKey && canSubmit && !busy) {
 			event.preventDefault();
 			submitAnswers();
 		}
@@ -179,6 +185,7 @@
 							class:selected={isSelected(index, option.label)}
 							aria-pressed={isSelected(index, option.label)}
 							aria-describedby={validationMessage ? 'question-validation' : undefined}
+							disabled={busy}
 							onclick={() => chooseOption(index, question, option.label)}
 							title={option.description || ''}
 						>
@@ -195,6 +202,7 @@
 						class:selected={showCustomInput[index]}
 						aria-pressed={showCustomInput[index]}
 						aria-describedby={validationMessage ? 'question-validation' : undefined}
+						disabled={busy}
 						onclick={() => toggleCustom(index, question)}
 					>
 						<Pencil size={11} />
@@ -209,6 +217,7 @@
 						class="custom-input"
 						aria-label={`${question.question} answer`}
 						aria-describedby={validationMessage ? 'question-validation' : undefined}
+						disabled={busy}
 						placeholder={question.placeholder || 'Type your answer…'}
 						value={customAnswers[index] || ''}
 						oninput={(e) => updateCustomAnswer(index, question, (e.currentTarget as HTMLInputElement).value)}
@@ -220,6 +229,7 @@
 					class="freeform-input"
 					aria-label={`${question.question} answer`}
 					aria-describedby={validationMessage ? 'question-validation' : undefined}
+					disabled={busy}
 					rows="2"
 					placeholder={question.placeholder || 'Type your answer…'}
 					value={customAnswers[index] || ''}
@@ -234,11 +244,11 @@
 	{/if}
 
 	<div class="card-actions">
-		<button type="button" class="action-btn reject" onclick={onReject}>
+		<button type="button" class="action-btn reject" disabled={busy} onclick={onReject}>
 			<X size={15} />
 			<span>Skip</span>
 		</button>
-		<button type="button" class="action-btn submit" disabled={!canSubmit} onclick={submitAnswers}>
+		<button type="button" class="action-btn submit" disabled={!canSubmit || busy} onclick={submitAnswers}>
 			<Send size={14} />
 			<span>Reply</span>
 		</button>
@@ -360,6 +370,14 @@
 	.option-chip:hover {
 		background: rgba(255, 255, 255, 0.08);
 		border-color: rgba(255, 255, 255, 0.16);
+	}
+
+	.option-chip:disabled,
+	.custom-input:disabled,
+	.freeform-input:disabled,
+	.action-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 
 	.option-chip.selected {

--- a/packages/frontend/static/_headers
+++ b/packages/frontend/static/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+  X-Frame-Options: DENY
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ws: wss:; frame-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'


### PR DESCRIPTION
## What changed

- Serialize the async draft-flush/admission window for new turns and clarification replies.
- Invalidate prepared turns on project switches and stops so stale work cannot resume in a new project.
- Disable duplicate controls while preparation is pending.
- Add native static-shell security headers, `no-store` authentication responses, and hardened cache-safe public/preview 404 headers with `Vary: Accept`.

## Root cause

`onBeforeSend` was awaited before the loading state changed. Rapid actions could both pass the guard and create duplicate paid turns, while a project change could let the old continuation resume against the new context. Public response variants also lacked the headers needed for safe caching and browser isolation.

## Validation

- `bun run check` (695 app and 171 frontend tests; Svelte check and production build)
- Real local Workerd header readback
- Desktop/390px Playwright and public 404 keyboard check with no overflow, page errors, or CSP violations
- Independent blocker review: no blockers