### PR TITLE
Serialize Site Studio main production releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
       - name: Install dependencies
@@ -26,3 +28,122 @@ jobs:
       - run: bun run check
       - name: Validate Worker bundle and config
         run: packages/app/node_modules/.bin/wrangler deploy --dry-run --config packages/app/wrangler.jsonc --outdir .wrangler-dry-run/app
+
+  deploy:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+    concurrency:
+      group: site-studio-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - name: Check out main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CAIL_PACKAGES_TOKEN }}
+
+      - name: Confirm main has not advanced
+        run: |
+          set -euo pipefail
+          current_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+          [[ "$current_sha" == "$GITHUB_SHA" ]]
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Build the production assets
+        run: bun run --cwd packages/app predeploy
+
+      - name: Deploy the exact main commit
+        working-directory: packages/app
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == refs/heads/main ]]
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+          bunx wrangler deploy \
+            --strict \
+            --tag "$GITHUB_SHA" \
+            --message "main $GITHUB_SHA"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Read back the deployed version
+        id: version
+        working-directory: packages/app
+        run: |
+          set -euo pipefail
+          versions="$(bunx wrangler versions list --name site-studio-app --json 2>/dev/null)"
+          version_id="$(jq -r --arg tag "$GITHUB_SHA" --arg message "main $GITHUB_SHA" '
+            [ .[]
+              | select(.annotations["workers/tag"] == $tag)
+              | select(.annotations["workers/message"] == $message)
+            ]
+            | sort_by(.metadata.created_on)
+            | last
+            | .id // empty
+          ' <<<"$versions")"
+          [[ "$version_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+          version="$(bunx wrangler versions view "$version_id" --name site-studio-app --json 2>/dev/null)"
+          jq -e --arg tag "$GITHUB_SHA" --arg message "main $GITHUB_SHA" '
+            .annotations["workers/tag"] == $tag
+            and .annotations["workers/message"] == $message
+          ' <<<"$version" >/dev/null
+          deployments="$(bunx wrangler deployments list --name site-studio-app --json 2>/dev/null)"
+          deployment_id="$(jq -r --arg id "$version_id" --arg message "main $GITHUB_SHA" '
+            [ .[] ]
+            | sort_by(.created_on)
+            | last
+            | select(.annotations["workers/message"] == $message)
+            | select((.versions | length) == 1)
+            | select(.versions[0].version_id == $id and .versions[0].percentage == 100)
+            | .id // empty
+          ' <<<"$deployments")"
+          [[ "$deployment_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+          printf 'version_id=%s\n' "$version_id" >> "$GITHUB_OUTPUT"
+          echo "deployed version $version_id"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Probe production readiness
+        env:
+          EXPECTED_VERSION_ID: ${{ steps.version.outputs.version_id }}
+          HEALTH_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/api/health
+          API_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/api/csrf
+          ROOT_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/
+        run: |
+          set -euo pipefail
+          # The deploy API returns before the public Worker route has finished
+          # propagating. Poll that real boundary at a two-second cadence for
+          # two minutes; a failed probe fails the deployment job.
+          for attempt in $(seq 1 60); do
+            health="$(curl -fsS --max-time 10 "$HEALTH_URL" 2>/dev/null || true)"
+            if jq -e --arg id "$EXPECTED_VERSION_ID" '
+              .status == "ok"
+              and .product_id == "site-studio"
+              and .version_id == $id
+            ' <<<"$health" >/dev/null; then
+              curl -fsS --max-time 10 -o /dev/null "$ROOT_URL"
+              api_response="$(curl -sS --max-time 10 -D - -o /dev/null -w '\n%{http_code}' "$API_URL")"
+              [[ "$(tail -n 1 <<<"$api_response")" == 401 ]]
+              grep -iq '^cache-control: no-store' <<<"$api_response"
+              echo "production readiness passed for $EXPECTED_VERSION_ID"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "production readiness did not serve the expected version" >&2
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,11 @@ Local ports:
 - Use `bun run e2e:live` for the direct signed-identity production product
   path; it owns only its random project and is not evidence of a CUNY/Doorway
   browser login
+- Production release is CI-only: `.github/workflows/ci.yml` verifies PRs and
+  main, then serializes the main build/deploy. Exact-SHA readback and health,
+  root, and unauthenticated no-store-401 probes are release gates. There is no
+  checked-in staging Worker/storage topology, so there is no PR production
+  preview.
 - Preserve same-origin assumptions for preview and thumbnail capture unless deliberately redesigned
 - Use Svelte 5 runes patterns in frontend code
 - Default to execute-plus-clarify, not approval-first UX

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ declared in `packages/app/wrangler.jsonc`, including:
 The production frontend build uses `PUBLIC_BASE_PATH=/site-studio`, and the
 configured public base is `https://cail-doorway.ailab-452.workers.dev/site-studio`.
 
+## CI and production deploy
+
+Merges to `main` release after the repository checks and a live health check.
+Site Studio has no separate checked-in staging Worker; local checks are not a
+production preview.
+
 See [docs/security-and-recovery.md](docs/security-and-recovery.md) for the
 remaining trust and recovery boundaries.
 


### PR DESCRIPTION
### What changed
- Pin CI actions and keep repository verification as the required PR/main gate.
- Build and serialize main production deployment with a current-main guard and exact SHA tag/message.
- Read back the version and latest 100% deployment, then probe exact health version, root, and unauthenticated no-store API behavior.
- Document that Site Studio has no checked-in staging Worker/storage topology, so there is no PR production preview.

### Validation
- bun run check
- Independent read-only release review
- YAML/bash/readback and diff checks