### PR TITLE
Fix stale editor updates after async mutations

### DIFF
--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -108,7 +108,8 @@
 		'rename_file',
 		'delete_file',
 		'scaffold_template',
-		'add_page'
+		'add_page',
+		'generate_image'
 	]);
 
 	function generateId(): string {

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -433,6 +433,44 @@ describe('AgentChat', () => {
 		expect(screen.getByText('Hello, world')).toBeInTheDocument();
 	});
 
+	it('refreshes the editor after a generated image is saved', async () => {
+		const { component, onUpdate } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('Add a hero image');
+		await settle();
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({
+				type: 'tool-input-available',
+				toolCallId: 'image-call',
+				toolName: 'generate_image',
+				input: { prompt: 'A hero image' }
+			})
+		});
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({
+				type: 'tool-output-available',
+				toolCallId: 'image-call',
+				output: { ok: true, path: 'images/hero.png' }
+			})
+		});
+		await settle();
+
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+	});
+
 	it('parses SSE-framed stream chunks', async () => {
 		mount();
 		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));

--- a/packages/frontend/src/routes/editor/[projectId]/+page.svelte
+++ b/packages/frontend/src/routes/editor/[projectId]/+page.svelte
@@ -80,6 +80,7 @@
 
 	// Handle-claim dialog, shown when publishing requires a public handle
 	let showHandleDialog = $state(false);
+	let pendingHandleProjectId = $state<string | null>(null);
 
 	// Images dialog: upload photos, replace placeholders, hand insertion to chat
 	let showImagesDialog = $state(false);
@@ -594,33 +595,50 @@
 	}
 
 	async function handlePublishProject() {
-		if (!currentProject) return;
+		if (!currentProject || publishingProjectId !== null || showHandleDialog) return;
+		const targetProjectId = currentProject.id;
 		try {
-			publishingProjectId = currentProject.id;
-			const result = await publishProject(currentProject.id);
+			publishingProjectId = targetProjectId;
+			const result = await publishProject(targetProjectId);
 
 			if (!result.ok) {
 				// The user has no public handle yet — collect one, then retry the
 				// publish automatically once it's claimed.
 				if (result.reason === 'handle_required') {
+					pendingHandleProjectId = targetProjectId;
 					showHandleDialog = true;
 				}
 				return;
 			}
 
-			applyPublishResult(result.url, result.a11yFindings ?? []);
+			applyPublishResult(targetProjectId, result.url, result.a11yFindings ?? []);
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to publish project.');
 		} finally {
-			publishingProjectId = null;
+			if (publishingProjectId === targetProjectId) {
+				publishingProjectId = null;
+			}
 		}
 	}
 
-	function applyPublishResult(url: string, findings: A11yFinding[]) {
-		if (!currentProject) return;
-		const updated = { ...currentProject, published: true, publishedUrl: url };
-		currentProject = updated;
-		allProjects = allProjects.map((p) => (p.id === updated.id ? updated : p));
+	function applyPublishResult(targetProjectId: string, url: string, findings: A11yFinding[]) {
+		const target = allProjects.find((project) => project.id === targetProjectId)
+			?? (currentProject?.id === targetProjectId ? currentProject : null);
+		if (!target) return;
+		const updated = { ...target, published: true, publishedUrl: url };
+		allProjects = allProjects.map((project) => (project.id === targetProjectId ? updated : project));
+		const isCurrentProject = currentProject?.id === targetProjectId;
+		if (isCurrentProject) {
+			currentProject = updated;
+		}
+
+		// Accessibility notes belong to the project that was published. Do not
+		// open a dialog against a different project if the user switched while the
+		// publish request was in flight.
+		if (!isCurrentProject) {
+			toast.success('Site published. It is now live.');
+			return;
+		}
 
 		if (findings.length > 0) {
 			a11yFindings = findings;
@@ -635,19 +653,23 @@
 	async function handleClaimed(_handle: string) {
 		// Handle claimed — close the dialog and complete the original publish.
 		showHandleDialog = false;
-		if (!currentProject) return;
+		const targetProjectId = pendingHandleProjectId;
+		pendingHandleProjectId = null;
+		if (!targetProjectId || publishingProjectId !== null) return;
 		try {
-			publishingProjectId = currentProject.id;
-			const result = await publishProject(currentProject.id);
+			publishingProjectId = targetProjectId;
+			const result = await publishProject(targetProjectId);
 			if (result.ok) {
-				applyPublishResult(result.url, result.a11yFindings ?? []);
+				applyPublishResult(targetProjectId, result.url, result.a11yFindings ?? []);
 			} else {
 				toast.error('Publishing failed after claiming your handle. Please try again.');
 			}
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to publish project.');
 		} finally {
-			publishingProjectId = null;
+			if (publishingProjectId === targetProjectId) {
+				publishingProjectId = null;
+			}
 		}
 	}
 
@@ -672,24 +694,32 @@
 	}
 
 	async function handleUnpublishProject() {
-		if (!currentProject) return;
-		if (!window.confirm(`Make "${currentProject.name}" private? Its public URL will stop working.`)) return;
+		if (!currentProject || publishingProjectId !== null || showHandleDialog) return;
+		const targetProjectId = currentProject.id;
+		const targetProjectName = currentProject.name;
+		if (!window.confirm(`Make "${targetProjectName}" private? Its public URL will stop working.`)) return;
 		try {
-			publishingProjectId = currentProject.id;
-			await unpublishProject(currentProject.id);
+			publishingProjectId = targetProjectId;
+			await unpublishProject(targetProjectId);
 
-			// Update the current project
-			const updated = { ...currentProject, published: false, publishedUrl: undefined };
-			currentProject = updated;
-			// Update in allProjects list too
-			allProjects = allProjects.map(p =>
-				p.id === updated.id ? updated : p
-			);
+			const target = allProjects.find((project) => project.id === targetProjectId)
+				?? (currentProject?.id === targetProjectId ? currentProject : null);
+			if (target) {
+				const updated = { ...target, published: false, publishedUrl: undefined };
+				allProjects = allProjects.map((project) =>
+					project.id === targetProjectId ? updated : project
+				);
+				if (currentProject?.id === targetProjectId) {
+					currentProject = updated;
+				}
+			}
 			toast.success('Site is private. Its public URL no longer works.');
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : "Couldn't make the site private.");
 		} finally {
-			publishingProjectId = null;
+			if (publishingProjectId === targetProjectId) {
+				publishingProjectId = null;
+			}
 		}
 	}
 
@@ -773,7 +803,10 @@
 
 <HandleClaimDialog
 	open={showHandleDialog}
-	onOpenChange={(open) => (showHandleDialog = open)}
+	onOpenChange={(open) => {
+		showHandleDialog = open;
+		if (!open) pendingHandleProjectId = null;
+	}}
 	onClaimed={handleClaimed}
 />
 


### PR DESCRIPTION
## What changed

- Refresh the editor after `generate_image` writes a project image.
- Keep publish, handle-claim retry, and unpublish updates tied to the project that started the request.
- Add a regression test for generated-image refreshes.

## Why

The chat refresh allowlist omitted `generate_image`, leaving newly generated images out of the editor until a later refresh. Publish and unpublish callbacks used the mutable current project, so switching projects while a request was in flight could apply the result to the wrong project.

## Validation

- `bun run check`
- `bun run lint`
- `bun run --cwd packages/frontend test`
- `bun run --cwd packages/frontend build`
- `git diff --check`

Local Workerd/Playwright and authenticated production flows were not run; no authenticated or paid calls were made.