### PR TITLE
Cut over Site Studio to tools.ailab.gc.cuny.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ never select ownership.
 
 When a browser session needs to sign in, Site Studio sends it to the protected
 Site Studio page on the standalone CAIL Doorway at
-`https://cail-doorway.ailab-452.workers.dev/site-studio/`; Doorway starts CUNY
+`https://tools.ailab.gc.cuny.edu/site-studio/`; Doorway starts CUNY
 sign-in and returns the browser to the current Site Studio page.
 
 Model traffic goes directly from the app Worker to the CAIL Gateway through
@@ -148,7 +148,7 @@ declared in `packages/app/wrangler.jsonc`, including:
 - R2, KV, Worker Loader, and Durable Object bindings
 
 The production frontend build uses `PUBLIC_BASE_PATH=/site-studio`, and the
-configured public base is `https://cail-doorway.ailab-452.workers.dev/site-studio`.
+configured public base is `https://tools.ailab.gc.cuny.edu/site-studio`.
 
 ## CI and production deploy
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@cloudflare/ai-chat": "0.9.3",
         "@cloudflare/codemode": "0.5.1",
         "@cuny-ai-lab/cail-client": "5.0.0",
-        "@cuny-ai-lab/cail-identity": "5.2.2",
+        "@cuny-ai-lab/cail-identity": "5.2.4",
         "@cuny-ai-lab/cail-log": "0.6.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "agents": "0.20.1",
@@ -243,7 +243,7 @@
 
     "@cuny-ai-lab/cail-client": ["@cuny-ai-lab/cail-client@5.0.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-client/5.0.0/d30e458cfad45a15427c80a7e69741e0f064c239", {}, "sha512-KbkPOqYhme4HK0g2xn1Gv3ey47iHeYcsfX7M5poPGOhO9WEXFc3Tw9JnqXt42F4xXCLqGtcQlQRc6HEYH2/Tzw=="],
 
-    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.2.2", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.2.2/fb51ea5800e517cdb5780709e92e6559f6139a5e", { "dependencies": { "jose": "6.2.3" } }, "sha512-IFDLK3CxXlntPMaEjYOziKLCEWRN6FOFuf2tIEAYmt0JHpJaqRnXswsUaxvmW3XQKs0R/yvJ5gCMCm0J9TykrQ=="],
+    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.2.4", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.2.4/490b795a23962fc8ac32bdc3392e136e5344e02d", { "dependencies": { "jose": "6.2.3", "zod": "4.4.3" } }, "sha512-/A0z1tpuadk/P1JQhVuduFu/Skw+qxTfg/6OjhlMyM9P3P2Y/jMKd0ZoXnze3FcVrRM6i9P1JxmNO/WwQZvl1g=="],
 
     "@cuny-ai-lab/cail-log": ["@cuny-ai-lab/cail-log@0.6.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-log/0.6.0/632c8a3d74bc4709c23b9636b73471c1291d7679", {}, "sha512-Hlj1K7TXL2XOI6nOkh5SKRafCldr87Zp+aHm73MqiV0hajAPMiqp7QuBlndzok7Vy0fIX7C6msi093s/a9Yesw=="],
 

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -13,7 +13,7 @@ email and profile names are display data only. The legacy session cookie is an
 import source only, never authentication or ownership proof. The app does not
 issue or consult a subject session cookie or subject session KV record.
 The browser handles that envelope by sending the user to Doorway's protected
-Site Studio path at `https://cail-doorway.ailab-452.workers.dev/site-studio/`.
+Site Studio path at `https://tools.ailab.gc.cuny.edu/site-studio/`.
 Doorway starts CUNY sign-in and returns the browser to the current Site Studio
 path.
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,7 @@
     "@cloudflare/ai-chat": "0.9.3",
     "@cloudflare/codemode": "0.5.1",
     "@cuny-ai-lab/cail-client": "5.0.0",
-    "@cuny-ai-lab/cail-identity": "5.2.2",
+    "@cuny-ai-lab/cail-identity": "5.2.4",
     "@cuny-ai-lab/cail-log": "0.6.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "agents": "0.20.1",

--- a/packages/app/src/app.test.ts
+++ b/packages/app/src/app.test.ts
@@ -13,7 +13,7 @@ import type { MutationCoordinator } from "./agents/mutation-coordinator";
 import app from "./app";
 
 const BASE = "https://site-studio.example";
-const ALLOWED_ORIGIN = "https://cail-doorway.ailab-452.workers.dev";
+const ALLOWED_ORIGIN = "https://tools.ailab.gc.cuny.edu";
 
 function createStoredR2Object(key: string): R2Object {
   const object = {

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -65,7 +65,7 @@ app.use("*", requestLogging());
 const allowedOrigins = new Set([
 	"http://localhost:5173",
 	"http://127.0.0.1:5173",
-	"https://cail-doorway.ailab-452.workers.dev"
+	"https://tools.ailab.gc.cuny.edu"
 ]);
 
 app.use("/api/*", cors({

--- a/packages/app/src/lib/csrf.test.ts
+++ b/packages/app/src/lib/csrf.test.ts
@@ -25,7 +25,7 @@ import {
 import { createTestR2Object, mintCsrfSession } from "./test-utils";
 
 const REQUEST_ORIGIN = "https://site-studio.example";
-const APP_PUBLIC_DOMAIN = "https://cail-doorway.ailab-452.workers.dev";
+const APP_PUBLIC_DOMAIN = "https://tools.ailab.gc.cuny.edu";
 const TOKEN = "a".repeat(64);
 
 it("uses a non-authority header that survives the shared Doorway", () => {
@@ -213,7 +213,7 @@ describe("setCsrfCookie (rule 3 delivery)", () => {
 
   it("keeps the cookie out of a hostile published page's browser path scope", async () => {
     const setCookie = await setCookieHeader(
-      "https://cail-doorway.ailab-452.workers.dev/site-studio/api/csrf",
+      "https://tools.ailab.gc.cuny.edu/site-studio/api/csrf",
       SITE_STUDIO_CSRF_COOKIE_PATH
     );
     expect(setCookie).toMatch(/(?:^|;\s*)Path=\/site-studio(?:;|$)/);
@@ -279,7 +279,7 @@ describe("verifyWsUpgrade (rule 4)", () => {
   it("rejects a loopback browser origin when the worker origin is production", () => {
     expect(verifyWsUpgrade({
       ...base,
-      requestOrigin: "https://cail-doorway.ailab-452.workers.dev",
+      requestOrigin: "https://tools.ailab.gc.cuny.edu",
       origin: "http://localhost:5173"
     })).toBe(false);
   });

--- a/packages/app/src/lib/migration.test.ts
+++ b/packages/app/src/lib/migration.test.ts
@@ -110,7 +110,7 @@ function createMockKV() {
 
 const ANON = "user_anon123";
 const SUBJECT = canonicalTestSubject("migration-owner");
-const PUBLISHED_BASE_URL = "https://cail-doorway.ailab-452.workers.dev/site-studio";
+const PUBLISHED_BASE_URL = "https://tools.ailab.gc.cuny.edu/site-studio";
 
 /** Copied objects are stored as strings by the mock. */
 function textOf(entry: { data: string } | undefined): string | undefined {

--- a/packages/app/src/lib/session.test.ts
+++ b/packages/app/src/lib/session.test.ts
@@ -17,7 +17,7 @@ import type { MutationCoordinator } from "../agents/mutation-coordinator";
 
 let identityIssuer: TestIdentityIssuer;
 let identityJwks: string;
-const PUBLISHED_BASE_URL = "https://cail-doorway.ailab-452.workers.dev/site-studio";
+const PUBLISHED_BASE_URL = "https://tools.ailab.gc.cuny.edu/site-studio";
 
 beforeAll(async () => {
   // Mint the exact production Doorway issuer configured by this suite.
@@ -150,7 +150,7 @@ function createCoordinatorNamespace(): MockCoordinator {
 function createEnv(overrides?: Partial<Env>): Env {
   const env: Env = {
     CAIL_LOG_ENV: "test",
-    APP_PUBLIC_DOMAIN: "https://cail-doorway.ailab-452.workers.dev",
+    APP_PUBLIC_DOMAIN: "https://tools.ailab.gc.cuny.edu",
     PUBLISHED_BASE_URL,
     // SAFETY: Session tests never load a Worker module through this binding.
     LOADER: {} as WorkerLoader,

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -57,7 +57,7 @@ describe("observability source contract", () => {
     // derivation, whose ownership subjects differ from every 4.x value. A
     // caret range here could silently move that contract.
     expect(source).toContain(
-      '"@cuny-ai-lab/cail-identity": "5.2.2"',
+      '"@cuny-ai-lab/cail-identity": "5.2.4"',
     );
     expect(source).toContain(
       '"@cuny-ai-lab/cail-client": "5.0.0"',

--- a/packages/app/src/routes/agents.test.ts
+++ b/packages/app/src/routes/agents.test.ts
@@ -16,7 +16,7 @@ const USER_ID = TEST_SUBJECTS.alice;
 const PROJECT_ID = "proj-1";
 const OPERATIONAL_SUBJECT = "cail-v1-0123456789abcdef0123456789abcdef";
 const OWN_ORIGIN = "https://site-studio.example";
-const APP_PUBLIC_DOMAIN = "https://cail-doorway.ailab-452.workers.dev";
+const APP_PUBLIC_DOMAIN = "https://tools.ailab.gc.cuny.edu";
 type AgentFetchState = { lastRequest: Request | null };
 const forwardedUrlSchema = z.object({ forwardedUrl: z.string() });
 

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -316,7 +316,7 @@ describe("route regressions", () => {
 
   it("links an unknown public site to the canonical Lab tools index", async () => {
     const env = createEnv(bucket);
-    env.APP_PUBLIC_DOMAIN = "https://cail-doorway.ailab-452.workers.dev";
+    env.APP_PUBLIC_DOMAIN = "https://tools.ailab.gc.cuny.edu";
 
     const response = await app.request(
       "https://site-studio-app.ailab-452.workers.dev/u/unknown/missing/",
@@ -327,7 +327,7 @@ describe("route regressions", () => {
     expect(response.status).toBe(404);
     const body = await response.text();
     expect(body).toContain("Explore CUNY AI Lab tools");
-    expect(body).toContain('href="https://cail-doorway.ailab-452.workers.dev/"');
+    expect(body).toContain('href="https://tools.ailab.gc.cuny.edu/"');
     expect(body).not.toContain("Go to site home");
   });
 
@@ -796,11 +796,11 @@ describe("route regressions", () => {
     });
 
     const response = await app.request(
-      "https://cail-doorway.ailab-452.workers.dev/u/janedoe/prefixed-root?ref=x",
+      "https://tools.ailab.gc.cuny.edu/u/janedoe/prefixed-root?ref=x",
       { redirect: "manual" },
       {
         ...createEnv(bucket),
-        PUBLISHED_BASE_URL: "https://cail-doorway.ailab-452.workers.dev/site-studio"
+        PUBLISHED_BASE_URL: "https://tools.ailab.gc.cuny.edu/site-studio"
       }
     );
 
@@ -817,11 +817,11 @@ describe("route regressions", () => {
     });
 
     const response = await app.request(
-      "https://cail-doorway.ailab-452.workers.dev/u/janedoe/prefixed-404/missing",
+      "https://tools.ailab.gc.cuny.edu/u/janedoe/prefixed-404/missing",
       { headers: { Accept: "text/html" } },
       {
         ...createEnv(bucket),
-        PUBLISHED_BASE_URL: "https://cail-doorway.ailab-452.workers.dev/site-studio"
+        PUBLISHED_BASE_URL: "https://tools.ailab.gc.cuny.edu/site-studio"
       }
     );
 

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -54,8 +54,8 @@
   ],
   "vars": {
     "CAIL_LOG_ENV": "production",
-    "APP_PUBLIC_DOMAIN": "https://cail-doorway.ailab-452.workers.dev",
-    "PUBLISHED_BASE_URL": "https://cail-doorway.ailab-452.workers.dev/site-studio",
+    "APP_PUBLIC_DOMAIN": "https://tools.ailab.gc.cuny.edu",
+    "PUBLISHED_BASE_URL": "https://tools.ailab.gc.cuny.edu/site-studio",
     // ---- CAIL backbone (see cail-gateway docs/INTEGRATION.md) ----
     // CAIL_API_BASE: the one public base URL of the CAIL Model API (serves
     // /v1/... model calls and /keys) in the institutional Cloudflare account.
@@ -77,7 +77,7 @@
     // from the gateway's curated catalog;
     // `@cf/meta/llama-4-scout-17b-16e-instruct` is the other vision model.
     "CAIL_IMAGE_CLASSIFIER": "@cf/moonshotai/kimi-k2.6",
-    "CAIL_IDENTITY_ISSUER": "https://cail-doorway.ailab-452.workers.dev/cail-sso",
+    "CAIL_IDENTITY_ISSUER": "https://tools.ailab.gc.cuny.edu/cail-sso",
     // Script-readable anti-CSRF delivery cookie scope. This deployment shares
     // its origin with sibling tools and untrusted published content, so runtime
     // validation requires this exact path and rejects a root-scoped cookie.

--- a/packages/frontend/src/lib/api/errors.test.ts
+++ b/packages/frontend/src/lib/api/errors.test.ts
@@ -40,7 +40,7 @@ describe('apiResponseFetch', () => {
 		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
 
 		expect(assignMock).toHaveBeenCalledWith(
-			'https://cail-doorway.ailab-452.workers.dev/site-studio/editor/project-1?panel=code'
+			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
 		);
 	});
 
@@ -58,7 +58,7 @@ describe('apiResponseFetch', () => {
 		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
 
 		expect(assignMock).toHaveBeenCalledWith(
-			'https://cail-doorway.ailab-452.workers.dev/site-studio/editor/project-1?panel=code'
+			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
 		);
 	});
 
@@ -80,7 +80,7 @@ describe('apiResponseFetch', () => {
 		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
 
 		expect(assignMock).toHaveBeenCalledWith(
-			'https://cail-doorway.ailab-452.workers.dev/site-studio/editor/project-1?panel=code'
+			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
 		);
 	});
 

--- a/packages/frontend/src/lib/api/errors.ts
+++ b/packages/frontend/src/lib/api/errors.ts
@@ -83,7 +83,7 @@ export class ApiError extends Error {
  * is not a login page. Doorway owns the protected `/site-studio/` route; send
  * the browser there and let Doorway's route policy start CUNY sign-in.
  */
-const CAIL_DOORWAY_ORIGIN = 'https://cail-doorway.ailab-452.workers.dev';
+const CAIL_DOORWAY_ORIGIN = 'https://tools.ailab.gc.cuny.edu';
 const SITE_STUDIO_DOORWAY_PATH = '/site-studio';
 
 function redirectToLogin(): void {

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -339,7 +339,7 @@ describe('AgentChat', () => {
 		mount();
 
 		await waitFor(() =>
-				expect(assignSpy).toHaveBeenCalledWith('https://cail-doorway.ailab-452.workers.dev/site-studio/')
+				expect(assignSpy).toHaveBeenCalledWith('https://tools.ailab.gc.cuny.edu/site-studio/')
 		);
 	});
 

--- a/scripts/live-product-e2e.mjs
+++ b/scripts/live-product-e2e.mjs
@@ -2,7 +2,7 @@ import WebSocket from 'ws';
 import { z } from 'zod';
 
 const PRODUCTION_SITE_URL = 'https://site-studio-app.ailab-452.workers.dev/site-studio/';
-const PRODUCTION_PUBLIC_ORIGIN = 'https://cail-doorway.ailab-452.workers.dev';
+const PRODUCTION_PUBLIC_ORIGIN = 'https://tools.ailab.gc.cuny.edu';
 const PRODUCTION_PUBLIC_PATH = '/site-studio';
 const PRODUCTION_IDENTITY_ISSUER = `${PRODUCTION_PUBLIC_ORIGIN}/cail-sso`;
 const CHAT_REQUEST = 'cf_agent_use_chat_request';


### PR DESCRIPTION
Switch Site Studio public URLs, CORS, redirects, publishing routes, and identity issuer to tools.ailab.gc.cuny.edu.

Update @cuny-ai-lab/cail-identity to 5.2.4 and align tests, E2E configuration, and operator documentation. Kale Deploy is not integrated in this repository; the existing kale-admin observability authority remains unmounted and default-deny.

Validation:
- bun run check
- bun audit --audit-level=high
- Wrangler dry-run
- local Worker health and unauthenticated fail-closed probes
- built bundle contains the new issuer and no old Doorway hostname

SSO login is outside acceptance for this cutover.