### PR TITLE
Adopt canonical CAIL auth envelopes in Site Studio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,24 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
+      - name: Read back identity configuration readiness
+        working-directory: packages/app
+        run: |
+          set -euo pipefail
+          # Secret values are never read back. The API exposes names only; the
+          # presence check catches a release with no verifier key configured.
+          secrets="$(bunx wrangler secret list --name site-studio-app --format json 2>/dev/null)"
+          jq -e 'any(.[]; .name == "CAIL_IDENTITY_JWKS")' <<<"$secrets" >/dev/null
+          echo "CAIL_IDENTITY_JWKS is configured"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
       - name: Probe production readiness
         env:
           EXPECTED_VERSION_ID: ${{ steps.version.outputs.version_id }}
           HEALTH_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/api/health
           API_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/api/csrf
+          DOORWAY_API_URL: https://tools.ailab.gc.cuny.edu/site-studio/api/csrf
           ROOT_URL: https://site-studio-app.ailab-452.workers.dev/site-studio/
         run: |
           set -euo pipefail
@@ -142,9 +155,34 @@ jobs:
               and .version_id == $id
             ' <<<"$health" >/dev/null; then
               curl -fsS --max-time 10 -o /dev/null "$ROOT_URL"
-              api_response="$(curl -sS --max-time 10 -D - -o /dev/null -w '\n%{http_code}' "$API_URL")"
-              [[ "$(tail -n 1 <<<"$api_response")" == 401 ]]
-              grep -iq '^cache-control: no-store' <<<"$api_response"
+
+              worker_body="$(mktemp)"
+              worker_headers="$(mktemp)"
+              doorway_body="$(mktemp)"
+              doorway_headers="$(mktemp)"
+              trap 'rm -f "$worker_body" "$worker_headers" "$doorway_body" "$doorway_headers"' EXIT
+
+              worker_status="$(curl -sS --max-time 10 -D "$worker_headers" -o "$worker_body" -w '%{http_code}' "$API_URL")"
+              [[ "$worker_status" == 401 ]]
+              jq -e '
+                .error.code == "authentication_required"
+                and .error.message == "Please sign in to continue."
+                and .error.launch == "/launch/site-studio"
+              ' "$worker_body" >/dev/null
+              grep -iq '^cache-control: no-store' "$worker_headers"
+
+              # Doorway owns the browser auth boundary. Probe its exact JSON
+              # contract anonymously; this does not require an interactive SSO
+              # session and prevents a flat/redirected auth response from
+              # reaching the frontend after a release.
+              doorway_status="$(curl -sS --max-time 10 -D "$doorway_headers" -o "$doorway_body" -w '%{http_code}' "$DOORWAY_API_URL")"
+              [[ "$doorway_status" == 401 ]]
+              jq -e '
+                .error.code == "authentication_required"
+                and .error.message == "Please sign in to continue."
+                and .error.launch == "/launch/site-studio"
+              ' "$doorway_body" >/dev/null
+              grep -iq '^cache-control: no-store' "$doorway_headers"
               echo "production readiness passed for $EXPECTED_VERSION_ID"
               exit 0
             fi

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@cloudflare/ai-chat": "0.9.3",
         "@cloudflare/codemode": "0.5.1",
         "@cuny-ai-lab/cail-client": "5.0.0",
-        "@cuny-ai-lab/cail-identity": "5.2.4",
+        "@cuny-ai-lab/cail-identity": "5.2.5",
         "@cuny-ai-lab/cail-log": "0.6.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "agents": "0.20.1",
@@ -47,6 +47,7 @@
         "@codemirror/lang-html": "6.4.11",
         "@codemirror/lang-javascript": "6.2.5",
         "@codemirror/view": "6.43.6",
+        "@cuny-ai-lab/cail-identity": "5.2.5",
         "clsx": "2.1.1",
         "codemirror": "6.0.2",
         "diff": "9.0.0",
@@ -243,7 +244,7 @@
 
     "@cuny-ai-lab/cail-client": ["@cuny-ai-lab/cail-client@5.0.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-client/5.0.0/d30e458cfad45a15427c80a7e69741e0f064c239", {}, "sha512-KbkPOqYhme4HK0g2xn1Gv3ey47iHeYcsfX7M5poPGOhO9WEXFc3Tw9JnqXt42F4xXCLqGtcQlQRc6HEYH2/Tzw=="],
 
-    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.2.4", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.2.4/490b795a23962fc8ac32bdc3392e136e5344e02d", { "dependencies": { "jose": "6.2.3", "zod": "4.4.3" } }, "sha512-/A0z1tpuadk/P1JQhVuduFu/Skw+qxTfg/6OjhlMyM9P3P2Y/jMKd0ZoXnze3FcVrRM6i9P1JxmNO/WwQZvl1g=="],
+    "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.2.5", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.2.5/6c3b216acc750451eabb9ed9b32179460a8445d0", { "dependencies": { "jose": "6.2.3", "zod": "4.4.3" } }, "sha512-MqCXFwDCp2fO/m7RLPeKLg4mZSa/ArBoXt52Gl29YlWxiqM9YZMKdieV46/mrHPGbZkTEHHljZgHLUzvdnoGYQ=="],
 
     "@cuny-ai-lab/cail-log": ["@cuny-ai-lab/cail-log@0.6.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-log/0.6.0/632c8a3d74bc4709c23b9636b73471c1291d7679", {}, "sha512-Hlj1K7TXL2XOI6nOkh5SKRafCldr87Zp+aHm73MqiV0hajAPMiqp7QuBlndzok7Vy0fIX7C6msi093s/a9Yesw=="],
 

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -7,15 +7,15 @@ bindings, secrets, backups, or deployed versions.
 
 Product routes accept only a verified `X-CAIL-Identity-JWT`: RS256, required
 `kid`, configured public JWKS, one exact deployment issuer, and scalar audience
-`cail:site-studio`. Missing or invalid identity returns the CAIL
-`authentication_required` envelope. The JWT subject is the durable owner key;
+`cail:site-studio`. Missing or invalid identity returns the exact nested CAIL
+`authentication_required` envelope (`code`, `message`, and the fixed
+`/launch/site-studio` path). The JWT subject is the durable owner key;
 email and profile names are display data only. The legacy session cookie is an
 import source only, never authentication or ownership proof. The app does not
 issue or consult a subject session cookie or subject session KV record.
-The browser handles that envelope by sending the user to Doorway's protected
-Site Studio path at `https://tools.ailab.gc.cuny.edu/site-studio/`.
-Doorway starts CUNY sign-in and returns the browser to the current Site Studio
-path.
+The browser handles that envelope by sending the user to the fixed Doorway
+launch at `https://tools.ailab.gc.cuny.edu/launch/site-studio`; it never turns a
+response-provided URL or current-page query into a redirect target.
 
 The CAIL Gateway credential is a separate verified JWT with gateway audience,
 bound to the same subject. The Worker removes caller authority and routing

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,7 @@
     "@cloudflare/ai-chat": "0.9.3",
     "@cloudflare/codemode": "0.5.1",
     "@cuny-ai-lab/cail-client": "5.0.0",
-    "@cuny-ai-lab/cail-identity": "5.2.4",
+    "@cuny-ai-lab/cail-identity": "5.2.5",
     "@cuny-ai-lab/cail-log": "0.6.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "agents": "0.20.1",

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -65,6 +65,7 @@ import {
   withCorrelationFetch,
 } from "../lib/logging";
 import { getAgentConnectionIdentityJwt } from "../lib/agent-identity";
+import { cailAuthRequiredResponse } from "../lib/cail-identity";
 import {
   executeOwnerMutation,
   type OwnerMutation,
@@ -1318,7 +1319,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
 
     const identityJwt = getAgentConnectionIdentityJwt(request);
     if (!identityJwt) {
-      return noStoreJson({ error: "authentication_required" }, 401);
+      return cailAuthRequiredResponse();
     }
 
     // The route has already enforced the verified app identity, project

--- a/packages/app/src/lib/cail-identity.test.ts
+++ b/packages/app/src/lib/cail-identity.test.ts
@@ -54,7 +54,7 @@ function requestWithToken(token: string): Request {
 // Hand-rolled negative-path fixture for the one shape the testing kit cannot
 // express: mintIdentityJwt only signs RS256, so the alg-tampering contract
 // violation needs a local signer. (The array-audience negative moved onto the
-// kit in cail-identity 5.2.2.)
+// kit in cail-identity 5.2.5.)
 // ---------------------------------------------------------------------------
 
 function base64url(bytes: Uint8Array): string {
@@ -316,9 +316,12 @@ describe("cailAuthRequiredResponse", () => {
     const response = cailAuthRequiredResponse();
     expect(response.status).toBe(401);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    await expect(response.json()).resolves.toMatchObject({
-      error: "authentication_required",
-      login_url: "/site-studio/",
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "authentication_required",
+        message: "Please sign in to continue.",
+        launch: "/launch/site-studio",
+      },
     });
   });
 });

--- a/packages/app/src/lib/cail-identity.ts
+++ b/packages/app/src/lib/cail-identity.ts
@@ -18,7 +18,9 @@
 import {
   CAIL_CANONICAL_ISSUER,
   CAIL_GATEWAY_AUDIENCE,
+  createCailAuthError,
   readIdentityKeyring,
+  serializeCailAuthError,
   verifyKeyringGatewayJwt,
   type CailIdentity,
   type IdentityVerifierConfig,
@@ -41,9 +43,10 @@ export type RequestIdentityResolution =
 /** The header the SSO gate injects. Bare `X-CAIL-*` headers are never trusted. */
 export const CAIL_IDENTITY_HEADER = "X-CAIL-Identity-JWT";
 export const CAIL_IDENTITY_AUDIENCE = "cail:site-studio";
+export const SITE_STUDIO_LAUNCH_PATH = "/launch/site-studio" as const;
 
 /**
- * cail-identity 5.2.2 validates the canonical issuer, audience, and every JWKS key
+ * cail-identity 5.2.5 validates the canonical issuer, audience, and every JWKS key
  * once and returns a frozen snapshot. The snapshot is cached per (jwks, issuer)
  * so a request does not re-import keys; a configuration failure yields `null`
  * here and an "invalid" resolution, never a silently anonymous request.
@@ -119,13 +122,13 @@ export async function getRequestIdentity(
  * redirects to the protected Doorway Site Studio path.
  */
 export function cailAuthRequiredResponse(): Response {
+  const body = createCailAuthError(
+    "authentication_required",
+    "Please sign in to continue.",
+    SITE_STUDIO_LAUNCH_PATH,
+  );
   return new Response(
-    JSON.stringify({
-      error: "authentication_required",
-      message:
-        "Sign in with CUNY Login to use Site Studio.",
-      login_url: "/site-studio/",
-    }),
+    serializeCailAuthError(body),
     {
       status: 401,
       headers: {

--- a/packages/app/src/lib/session.test.ts
+++ b/packages/app/src/lib/session.test.ts
@@ -299,9 +299,16 @@ describe("authMiddleware", () => {
 
     const response = await app.request("http://site-studio.test/api/test", {}, env);
     expect(response.status).toBe(401);
-    // SAFETY: The authentication error response has a string error field.
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("authentication_required");
+    // SAFETY: The authentication error response has the canonical nested CAIL
+    // error object and a fixed Doorway launch path.
+    const body = (await response.json()) as {
+      error: { code: string; message: string; launch: string };
+    };
+    expect(body.error).toEqual({
+      code: "authentication_required",
+      message: "Please sign in to continue.",
+      launch: "/launch/site-studio",
+    });
   });
 
   it("rejects a presented invalid identity token", async () => {

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -57,7 +57,7 @@ describe("observability source contract", () => {
     // derivation, whose ownership subjects differ from every 4.x value. A
     // caret range here could silently move that contract.
     expect(source).toContain(
-      '"@cuny-ai-lab/cail-identity": "5.2.4"',
+      '"@cuny-ai-lab/cail-identity": "5.2.5"',
     );
     expect(source).toContain(
       '"@cuny-ai-lab/cail-client": "5.0.0"',

--- a/packages/app/src/routes/agents.ts
+++ b/packages/app/src/routes/agents.ts
@@ -3,6 +3,7 @@ import type { Env, SiteBuilderAgentProps } from "../types";
 import type { SiteBuilderObservabilitySnapshot } from "../agents/site-builder";
 import { CSRF_ERROR_BODY, getCsrfToken, verifyWsUpgrade } from "../lib/csrf";
 import { jsonError } from "../lib/http";
+import { cailAuthRequiredResponse } from "../lib/cail-identity";
 import { getCailGatewayJwt, getUser } from "../lib/session";
 import { sanitizeProjectId } from "../lib/path";
 import { R2ProjectStorage } from "../storage/r2";
@@ -195,13 +196,7 @@ export function createAgentRouter(resolveAgent: AgentResolver = resolveAgentByNa
   async function refreshAgentCredential(c: Context<{ Bindings: Env; Variables: AgentRouterVariables }>) {
     const gatewayJwt = getCailGatewayJwt(c);
     if (!gatewayJwt) {
-      return new Response(JSON.stringify({ error: "authentication_required" }), {
-        status: 401,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": "no-store",
-        },
-      });
+      return cailAuthRequiredResponse();
     }
 
     const user = getUser(c);

--- a/packages/app/src/routes/quota.ts
+++ b/packages/app/src/routes/quota.ts
@@ -5,6 +5,7 @@ import type { Env } from "../types";
 import { getCailGatewayJwt } from "../lib/session";
 import { CAIL_APP_SLUG } from "../lib/model";
 import { jsonError } from "../lib/http";
+import { cailAuthRequiredResponse } from "../lib/cail-identity";
 
 export function createQuotaRouter() {
   const app = new Hono<{ Bindings: Env; Variables: { cailIdentityJwt: string } }>();
@@ -12,7 +13,7 @@ export function createQuotaRouter() {
   app.get("/api/quota", async (c) => {
     c.header("Cache-Control", "private, no-store");
     const jwt = getCailGatewayJwt(c);
-    if (!jwt) jsonError("authentication_required", 401);
+    if (!jwt) return cailAuthRequiredResponse();
     if (!c.env.CAIL_API_BASE) jsonError("Site Studio isn't set up correctly right now. Email ailab@gc.cuny.edu.", 503);
 
     try {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -33,6 +33,7 @@
     "@codemirror/lang-html": "6.4.11",
     "@codemirror/lang-javascript": "6.2.5",
     "@codemirror/view": "6.43.6",
+    "@cuny-ai-lab/cail-identity": "5.2.5",
     "clsx": "2.1.1",
     "codemirror": "6.0.2",
     "diff": "9.0.0",

--- a/packages/frontend/src/lib/api/csrf.test.ts
+++ b/packages/frontend/src/lib/api/csrf.test.ts
@@ -72,6 +72,38 @@ describe('csrf token client', () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it('uses the shared canonical error handler for a Doorway authentication failure', async () => {
+		const assignMock = vi.fn();
+		vi.stubGlobal('window', {
+			document,
+			location: { assign: assignMock }
+		});
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 'authentication_required',
+						message: 'Please sign in to continue.',
+						launch: '/launch/site-studio'
+					}
+				}),
+				{
+				status: 401,
+				headers: { 'Content-Type': 'application/json' }
+				}
+			)
+		);
+
+		await expect(getCsrfToken()).rejects.toMatchObject({
+			statusCode: 401,
+			code: 'authentication_required',
+			message: 'Please sign in to continue.'
+		});
+		expect(assignMock).toHaveBeenCalledWith(
+			'https://tools.ailab.gc.cuny.edu/launch/site-studio'
+		);
+	});
+
 	it('dedupes concurrent fetches into a single in-flight request', async () => {
 		let resolveFetch!: (r: Response) => void;
 		fetchMock.mockReturnValue(

--- a/packages/frontend/src/lib/api/csrf.ts
+++ b/packages/frontend/src/lib/api/csrf.ts
@@ -1,6 +1,7 @@
 import { resolvePath } from '$lib/utils/paths';
 import { browserWindow } from '$lib/contracts';
 import { z } from 'zod';
+import { handleApiErrorResponse } from './error-handler';
 
 /**
  * Anti-CSRF token client (CAIL INTEGRATION.md §3¾).
@@ -89,7 +90,7 @@ export async function getCsrfToken(): Promise<string> {
 			});
 
 			if (!response.ok) {
-				throw new Error(`Failed to fetch CSRF token (status ${response.status})`);
+				await handleApiErrorResponse(response);
 			}
 
 			// The token is delivered as a Set-Cookie, not a body — re-read it.
@@ -124,7 +125,7 @@ export async function refreshCsrfToken(): Promise<string> {
 	invalidateCsrfToken();
 	const response = await fetch(resolvePath('/api/csrf'), { credentials: 'include' });
 	if (!response.ok) {
-		throw new Error(`Failed to refresh CSRF token (status ${response.status})`);
+		await handleApiErrorResponse(response);
 	}
 	const token = getCsrfTokenFromCookie();
 	if (!token) {

--- a/packages/frontend/src/lib/api/error-handler.ts
+++ b/packages/frontend/src/lib/api/error-handler.ts
@@ -1,0 +1,158 @@
+import {
+	CAIL_CANONICAL_ORIGIN,
+	CAIL_AUTH_ERROR_CODES,
+	parseCailAuthErrorJson,
+	type CailAuthError
+} from '@cuny-ai-lab/cail-identity';
+import { browserWindow } from '$lib/contracts';
+import { z } from 'zod';
+
+export interface ValidationDetail {
+	path: string;
+	message: string;
+}
+
+interface DirectApiErrorEnvelope {
+	source: 'direct';
+	error: string;
+	message?: string;
+	code?: string;
+	details?: ValidationDetail[];
+}
+
+interface CanonicalApiErrorEnvelope {
+	source: 'canonical';
+	error: CailAuthError;
+}
+
+export type ApiErrorEnvelope = DirectApiErrorEnvelope | CanonicalApiErrorEnvelope;
+
+const AUTHENTICATION_REQUIRED = 'authentication_required';
+const SESSION_INVALID = 'session_invalid';
+const SIGN_IN_CODES = new Set([AUTHENTICATION_REQUIRED, SESSION_INVALID]);
+const CANONICAL_ERROR_CODES: ReadonlySet<string> = new Set(CAIL_AUTH_ERROR_CODES);
+const SITE_STUDIO_LAUNCH_PATH = '/launch/site-studio';
+
+const directApiErrorEnvelopeSchema = z.object({
+	error: z.string().refine(
+		(code) => !CANONICAL_ERROR_CODES.has(code),
+		'Auth errors must use the canonical nested envelope'
+	),
+	message: z.string().optional(),
+	code: z.string().optional(),
+	details: z.array(z.object({ path: z.string(), message: z.string() })).optional()
+});
+
+/** Parse canonical auth envelopes through the shared cail-identity primitive. */
+export function parseApiErrorEnvelope(payload: string): ApiErrorEnvelope {
+	const canonical = parseCailAuthErrorJson(payload);
+	if (canonical !== null) {
+		return { source: 'canonical', error: canonical.error };
+	}
+
+	const direct = directApiErrorEnvelopeSchema.safeParse(JSON.parse(payload));
+	if (direct.success) {
+		return { source: 'direct', ...direct.data };
+	}
+
+	throw new Error('Invalid API error envelope');
+}
+
+export class ApiError extends Error {
+	constructor(
+		public statusCode: number,
+		message: string,
+		public code?: string,
+		public details?: ValidationDetail[]
+	) {
+		super(message);
+		this.name = 'ApiError';
+	}
+
+	isValidationError(): boolean {
+		return this.statusCode === 400 && !!this.details && this.details.length > 0;
+	}
+
+	getUserMessage(): string {
+		if (this.isValidationError() && this.details) {
+			return this.details[0].message;
+		}
+		return this.message;
+	}
+
+	getValidationMessages(): string {
+		if (!this.details || this.details.length === 0) {
+			return this.message;
+		}
+		return this.details.map((detail) => `${detail.path}: ${detail.message}`).join('; ');
+	}
+
+	getRecoveryAction(): 'sign-in' | 'request-access' | 'retry' | 'none' {
+		if (this.code && SIGN_IN_CODES.has(this.code)) return 'sign-in';
+		if (this.code === 'admission_required') return 'request-access';
+		if (this.code === 'admission_unavailable') return 'retry';
+		return 'none';
+	}
+}
+
+function maybeRedirectToLogin(status: number, errorData: ApiErrorEnvelope): void {
+	if (
+		status !== 401 ||
+		errorData.source !== 'canonical' ||
+		!SIGN_IN_CODES.has(errorData.error.code)
+	) {
+		return;
+	}
+
+	const browser = browserWindow();
+	if (!browser) return;
+
+	// The shared parser validates the received launch field, but Site Studio's
+	// route is fixed. Never turn a response value or current URL into a redirect.
+	const target = new URL(SITE_STUDIO_LAUNCH_PATH, CAIL_CANONICAL_ORIGIN);
+	browser.location.assign(target.href);
+}
+
+function toApiError(response: Response, errorData: ApiErrorEnvelope): ApiError {
+	const message =
+		errorData.source === 'canonical'
+			? errorData.error.message
+			: errorData.message || errorData.error || 'Something went wrong. Try again.';
+	const code = errorData.source === 'canonical' ? errorData.error.code : errorData.code || errorData.error;
+	const details = errorData.source === 'canonical' ? undefined : errorData.details;
+
+	return new ApiError(response.status, message, code, details);
+}
+
+export async function handleApiErrorResponse(response: Response): Promise<never> {
+	let errorData: ApiErrorEnvelope;
+
+	try {
+		errorData = parseApiErrorEnvelope(await response.text());
+	} catch {
+		throw new ApiError(response.status, "That didn't work. Try again.", 'NETWORK_ERROR');
+	}
+
+	maybeRedirectToLogin(response.status, errorData);
+	throw toApiError(response, errorData);
+}
+
+export async function redirectCanonicalAuthentication(
+	response: Response
+): Promise<CailAuthError | null> {
+	if (response.status !== 401) return null;
+
+	try {
+		const errorData = parseApiErrorEnvelope(await response.clone().text());
+		if (
+			errorData.source !== 'canonical' ||
+			!SIGN_IN_CODES.has(errorData.error.code)
+		) {
+			return null;
+		}
+		maybeRedirectToLogin(response.status, errorData);
+		return errorData.error;
+	} catch {
+		return null;
+	}
+}

--- a/packages/frontend/src/lib/api/errors.test.ts
+++ b/packages/frontend/src/lib/api/errors.test.ts
@@ -1,107 +1,209 @@
 // @vitest-environment node
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, apiResponseFetch } from './errors';
+import {
+	ApiError,
+	apiResponseFetch,
+	handleApiError
+} from './errors';
+
+const AUTHENTICATION_REQUIRED = {
+	error: {
+		code: 'authentication_required',
+		message: 'Please sign in to continue.',
+		launch: '/launch/site-studio'
+	}
+} as const;
+const SESSION_INVALID = {
+	error: {
+		code: 'session_invalid',
+		message: 'Your sign-in has expired or is no longer valid. Sign in again.',
+		launch: '/launch/site-studio'
+	}
+} as const;
+const ADMISSION_REQUIRED = {
+	error: {
+		code: 'admission_required',
+		message:
+			'Your CAIL Lab membership is not currently active. Request access or contact the Lab administrator.'
+	}
+} as const;
+const ADMISSION_UNAVAILABLE = {
+	error: {
+		code: 'admission_unavailable',
+		message: 'Membership verification is temporarily unavailable. Try again later.'
+	}
+} as const;
 
 let fetchMock: ReturnType<typeof vi.fn>;
 let assignMock: ReturnType<typeof vi.fn>;
 
-describe('apiResponseFetch', () => {
+async function thrownApiError(response: Response): Promise<ApiError> {
+	try {
+		await handleApiError(response);
+	} catch (error) {
+		expect(error).toBeInstanceOf(ApiError);
+		// SAFETY: handleApiError throws ApiError for a parsed canonical envelope.
+		return error as ApiError;
+	}
+	throw new Error('Expected handleApiError to throw');
+}
+
+describe('canonical Doorway API errors', () => {
 	beforeEach(() => {
 		fetchMock = vi.fn();
 		assignMock = vi.fn();
 		vi.stubGlobal('fetch', fetchMock);
 		vi.stubGlobal('window', {
 			location: {
-				origin: 'https://studio.example.edu',
-				pathname: '/editor/project-1',
+				origin: 'https://tools.ailab.gc.cuny.edu',
+				pathname: '/site-studio/editor/project-1',
 				search: '?panel=code',
 				assign: assignMock
 			}
 		});
 	});
 
-	it.each([
-		['protocol-relative', '//evil.example/login'],
-		['backslash-normalized', '/\\evil.example/login'],
-		['dot-segment scheme-relative', '/..//evil.example/login'],
-		['encoded dot-segment scheme-relative', '/foo/%2e%2e//evil.example/login'],
-		['absolute', 'https://evil.example/login'],
-		['non-path relative', 'login'],
-		['non-URL scheme', 'javascript:alert(1)']
-	])('ignores a %s login URL and uses the protected Site Studio path', async (_label, loginUrl) => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('redirects a canonical authentication_required response to the fixed Site Studio launch', async () => {
 		fetchMock.mockResolvedValue(
-			new Response(JSON.stringify({ error: 'authentication_required', login_url: loginUrl }), {
+			new Response(JSON.stringify(AUTHENTICATION_REQUIRED), {
 				status: 401,
 				headers: { 'Content-Type': 'application/json' }
 			})
 		);
 
-		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
-
-		expect(assignMock).toHaveBeenCalledWith(
-			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
-		);
-	});
-
-	it('preserves the current Site Studio path and query instead of trusting envelope URLs', async () => {
-		fetchMock.mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					error: 'authentication_required',
-					login_url: '/site-studio/?profile=production#ignored'
-				}),
-				{ status: 401, headers: { 'Content-Type': 'application/json' } }
-			)
-		);
-
-		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
-
-		expect(assignMock).toHaveBeenCalledWith(
-			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
-		);
-	});
-
-	afterEach(() => {
-		vi.unstubAllGlobals();
-	});
-
-	it('redirects to login and throws ApiError for authentication_required envelopes', async () => {
-		fetchMock.mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					error: 'authentication_required',
-					login_url: '/login'
-				}),
-				{ status: 401, headers: { 'Content-Type': 'application/json' } }
-			)
-		);
-
-		await expect(apiResponseFetch('/api/projects')).rejects.toBeInstanceOf(ApiError);
-
-		expect(assignMock).toHaveBeenCalledWith(
-			'https://tools.ailab.gc.cuny.edu/site-studio/editor/project-1?panel=code'
-		);
-	});
-
-	it('returns a non-envelope 401 response without redirecting', async () => {
-		const response = new Response(JSON.stringify({ error: 'unauthorized' }), {
-			status: 401,
-			headers: { 'Content-Type': 'application/json' }
+		await expect(apiResponseFetch('/site-studio/api/projects')).rejects.toMatchObject({
+			statusCode: 401,
+			code: 'authentication_required',
+			message: 'Please sign in to continue.'
 		});
-		fetchMock.mockResolvedValue(response);
 
-		await expect(apiResponseFetch('/api/projects')).resolves.toBe(response);
+		expect(assignMock).toHaveBeenCalledWith(
+			'https://tools.ailab.gc.cuny.edu/launch/site-studio'
+		);
+	});
 
+	it('redirects a canonical session_invalid response to the fixed Site Studio launch', async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify(SESSION_INVALID), {
+				status: 401,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+
+		await expect(apiResponseFetch('/site-studio/api/projects')).rejects.toMatchObject({
+			statusCode: 401,
+			code: 'session_invalid',
+			message: 'Your sign-in has expired or is no longer valid. Sign in again.'
+		});
+		expect(assignMock).toHaveBeenCalledWith(
+			'https://tools.ailab.gc.cuny.edu/launch/site-studio'
+		);
+	});
+
+	it('uses the fixed launch when a canonical response names another safe route', async () => {
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 'authentication_required',
+						message: 'Please sign in to continue.',
+						launch: '/launch/agent-studio'
+					}
+				}),
+				{ status: 401, headers: { 'Content-Type': 'application/json' } }
+			)
+		);
+
+		await expect(apiResponseFetch('/site-studio/api/projects')).rejects.toBeInstanceOf(ApiError);
+		expect(assignMock).toHaveBeenCalledWith(
+			'https://tools.ailab.gc.cuny.edu/launch/site-studio'
+		);
+	});
+
+	it.each([
+		'https://evil.example/login',
+		'//evil.example/login',
+		'/\\evil.example/login',
+		'/launch/site-studio?next=https://evil.example'
+	])('ignores an untrusted launch value (%s)', async (launch) => {
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 'authentication_required',
+						message: 'Please sign in to continue.',
+						launch
+					}
+				}),
+				{ status: 401, headers: { 'Content-Type': 'application/json' } }
+			)
+		);
+
+		await expect(apiResponseFetch('/site-studio/api/projects')).resolves.toBeInstanceOf(Response);
 		expect(assignMock).not.toHaveBeenCalled();
 	});
 
-	it('returns a malformed 401 response without redirecting', async () => {
-		const response = new Response('not-json', { status: 401 });
-		fetchMock.mockResolvedValue(response);
+	it.each(['authentication_required', 'session_invalid', 'admission_required', 'admission_unavailable'])(
+		'does not treat the removed flat %s envelope as a direct-service response',
+		async (code) => {
+			const response = new Response(JSON.stringify({ error: code }), {
+				status: 401,
+				headers: { 'Content-Type': 'application/json' }
+			});
+			fetchMock.mockResolvedValue(response);
 
-		await expect(apiResponseFetch('/api/projects')).resolves.toBe(response);
+			await expect(apiResponseFetch('/site-studio/api/projects')).resolves.toBe(response);
+			expect(assignMock).not.toHaveBeenCalled();
+		}
+	);
 
+	it('maps admission_required to request-access recovery UX', async () => {
+		const error = await thrownApiError(
+			new Response(JSON.stringify(ADMISSION_REQUIRED), {
+				status: 403,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		expect(error).toMatchObject({
+			statusCode: 403,
+			code: 'admission_required',
+			message:
+				'Your CAIL Lab membership is not currently active. Request access or contact the Lab administrator.'
+		});
+		expect(error.getRecoveryAction()).toBe('request-access');
+	});
+
+	it('maps admission_unavailable to retryable service UX', async () => {
+		const error = await thrownApiError(
+			new Response(JSON.stringify(ADMISSION_UNAVAILABLE), {
+				status: 503,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		expect(error).toMatchObject({
+			statusCode: 503,
+			code: 'admission_unavailable',
+			message: 'Membership verification is temporarily unavailable. Try again later.'
+		});
+		expect(error.getRecoveryAction()).toBe('retry');
+	});
+
+	it('returns malformed and ordinary direct-service responses without an auth redirect', async () => {
+		const malformed = new Response('not-json', { status: 401 });
+		fetchMock.mockResolvedValue(malformed);
+		await expect(apiResponseFetch('/site-studio/api/projects')).resolves.toBe(malformed);
+
+		const direct = new Response(JSON.stringify({ error: 'unauthorized' }), {
+			status: 401,
+			headers: { 'Content-Type': 'application/json' }
+		});
+		fetchMock.mockResolvedValue(direct);
+		await expect(apiResponseFetch('/site-studio/api/projects')).resolves.toBe(direct);
 		expect(assignMock).not.toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/src/lib/api/errors.ts
+++ b/packages/frontend/src/lib/api/errors.ts
@@ -1,202 +1,58 @@
-/**
- * Frontend API error handling utilities
- * Corresponds to backend ApiError class for consistent error handling
- */
+/** Shared frontend API error handling for Doorway and the direct Worker. */
 
 import { csrfFetch } from './csrf';
-import { browserWindow, type JsonValue } from '$lib/contracts';
-import { z } from 'zod';
+import { type JsonValue } from '$lib/contracts';
+import {
+	ApiError,
+	handleApiErrorResponse,
+	redirectCanonicalAuthentication
+} from './error-handler';
 
-export interface ValidationDetail {
-	path: string;
-	message: string;
-}
-
-interface ApiErrorEnvelope {
-	error?: string;
-	message?: string;
-	code?: string;
-	details?: ValidationDetail[];
-}
-
-const apiErrorEnvelopeSchema = z.object({
-	error: z.string().optional(),
-	message: z.string().optional(),
-	code: z.string().optional(),
-	details: z.array(z.object({ path: z.string(), message: z.string() })).optional()
-});
-
-function parseApiErrorEnvelope(payload: string): ApiErrorEnvelope {
-	const parsed = apiErrorEnvelopeSchema.safeParse(JSON.parse(payload));
-	if (!parsed.success) throw new Error('Invalid API error envelope');
-	return parsed.data;
-}
+export {
+	ApiError,
+	parseApiErrorEnvelope,
+	type ApiErrorEnvelope,
+	type ValidationDetail
+} from './error-handler';
 
 /**
- * Structured API error that matches backend error responses
- */
-export class ApiError extends Error {
-	constructor(
-		public statusCode: number,
-		message: string,
-		public code?: string,
-		public details?: ValidationDetail[]
-	) {
-		super(message);
-		this.name = 'ApiError';
-	}
-
-	/**
-	 * Check if this is a validation error (400 with details)
-	 */
-	isValidationError(): boolean {
-		return this.statusCode === 400 && !!this.details && this.details.length > 0;
-	}
-
-	/**
-	 * Get a user-friendly error message
-	 */
-	getUserMessage(): string {
-		if (this.isValidationError() && this.details) {
-			// For validation errors, show the first validation message
-			return this.details[0].message;
-		}
-		return this.message;
-	}
-
-	/**
-	 * Get all validation errors as a formatted string
-	 */
-	getValidationMessages(): string {
-		if (!this.details || this.details.length === 0) {
-			return this.message;
-		}
-		return this.details.map(d => `${d.path}: ${d.message}`).join('; ');
-	}
-}
-
-/**
- * Redirect the browser to the standalone CAIL Doorway login, preserving where
- * to return.
- *
- * Site Studio is served directly by its Worker, so `/login` on either service
- * is not a login page. Doorway owns the protected `/site-studio/` route; send
- * the browser there and let Doorway's route policy start CUNY sign-in.
- */
-const CAIL_DOORWAY_ORIGIN = 'https://tools.ailab.gc.cuny.edu';
-const SITE_STUDIO_DOORWAY_PATH = '/site-studio';
-
-function redirectToLogin(): void {
-	const browser = browserWindow();
-	if (!browser) return;
-	const currentPath = browser.location.pathname;
-	const safeCurrentPath = currentPath.startsWith('/') && !currentPath.startsWith('//')
-		? currentPath
-		: '/';
-	const doorwayPath = safeCurrentPath === SITE_STUDIO_DOORWAY_PATH ||
-		safeCurrentPath.startsWith(`${SITE_STUDIO_DOORWAY_PATH}/`)
-		? safeCurrentPath
-		: `${SITE_STUDIO_DOORWAY_PATH}${safeCurrentPath}`;
-	const target = new URL(doorwayPath, CAIL_DOORWAY_ORIGIN);
-	// Doorway stores this classified protected path as the login return target;
-	// its route policy keeps the path on Site Studio and forwards it after auth.
-	target.search = browser.location.search;
-	target.hash = '';
-	browser.location.assign(target.href);
-}
-
-function isAuthenticationRequiredEnvelope(status: number, errorData: ApiErrorEnvelope): boolean {
-	return status === 401 && errorData?.error === 'authentication_required';
-}
-
-function maybeRedirectToLogin(status: number, errorData: ApiErrorEnvelope): void {
-	if (!isAuthenticationRequiredEnvelope(status, errorData)) {
-		return;
-	}
-
-	redirectToLogin();
-}
-
-function toApiError(response: Response, errorData: ApiErrorEnvelope): ApiError {
-	const message = errorData.message || errorData.error || 'Something went wrong. Try again.';
-	const code = errorData.code || errorData.error;
-	const details = errorData.details;
-
-	return new ApiError(response.status, message, code, details);
-}
-
-/**
- * Parse error response from API and throw ApiError.
- * Handles both structured API errors and generic network errors.
- *
- * CAIL `authentication_required` (401) redirects browsers to the SSO login so
- * the user can sign in with CUNY Login (docs/INTEGRATION.md §2). Other CAIL
- * envelopes (quota_exceeded, invalid_api_key, upstream_auth_error, …) pass
- * through unmodified as ApiError so callers can show `message` as-is.
+ * Parse an error response from either the canonical Doorway envelope or the
+ * direct Worker's non-gate API envelope, redirecting canonical auth failures.
  */
 export async function handleApiError(response: Response): Promise<never> {
-	let errorData: ApiErrorEnvelope;
-
-	try {
-		errorData = parseApiErrorEnvelope(await response.text());
-	} catch {
-		// Response doesn't contain JSON, throw generic error
-		throw new ApiError(
-			response.status,
-			"That didn't work. Try again.",
-			'NETWORK_ERROR'
-		);
-	}
-
-	// CAIL envelopes carry a machine code in `error` and a human sentence in
-	// `message`. Redirect to login on authentication_required.
-	maybeRedirectToLogin(response.status, errorData);
-
-	throw toApiError(response, errorData);
+	return handleApiErrorResponse(response);
 }
 
 /**
- * Wrapper for fetch callers that need the raw Response (blob downloads, 415
- * branching) while still honoring the shared 401 authentication redirect.
+ * Wrapper for callers that need the raw Response (blob downloads or status
+ * branching) while still honoring the canonical Doorway auth redirect.
  */
 export async function apiResponseFetch(
 	input: RequestInfo | URL,
 	init?: RequestInit
 ): Promise<Response> {
 	const response = await csrfFetch(input, init);
-
-	if (response.status !== 401) {
-		return response;
+	const authError = await redirectCanonicalAuthentication(response);
+	if (authError) {
+		throw new ApiError(
+			response.status,
+			authError.message,
+			authError.code
+		);
 	}
-
-	let errorData: ApiErrorEnvelope;
-	try {
-		errorData = parseApiErrorEnvelope(await response.clone().text());
-	} catch {
-		return response;
-	}
-
-	if (!isAuthenticationRequiredEnvelope(response.status, errorData)) {
-		return response;
-	}
-
-	maybeRedirectToLogin(response.status, errorData);
-	throw toApiError(response, errorData);
+	return response;
 }
 
 /**
- * Wrapper for fetch that automatically handles errors
- * Returns the parsed JSON response or throws ApiError
- *
- * Routes through `csrfFetch` so state-changing methods carry the anti-CSRF
- * header (CAIL INTEGRATION.md §3¾); GET/HEAD pass through without it.
+ * Wrapper for fetch that automatically handles errors and returns parsed JSON.
+ * State-changing calls route through csrfFetch; GET/HEAD calls carry only
+ * credentials.
  */
 export async function apiFetch<T = JsonValue>(
 	url: string,
 	options?: RequestInit
 ): Promise<T> {
 	const response = await csrfFetch(url, options);
-
 	if (!response.ok) {
 		await handleApiError(response);
 	}
@@ -204,18 +60,12 @@ export async function apiFetch<T = JsonValue>(
 	return response.json();
 }
 
-/**
- * Check if an error is an ApiError instance
- */
 export type CaughtError = ApiError | Error | string | null | undefined;
 
 export function isApiError(error: CaughtError): error is ApiError {
 	return error instanceof ApiError;
 }
 
-/**
- * Get a user-friendly error message from any error
- */
 export function getErrorMessage(error: CaughtError): string {
 	if (isApiError(error)) {
 		return error.getUserMessage();

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -828,7 +828,7 @@ import {
 				return;
 			}
 			const caughtError = error instanceof Error ? error : undefined;
-			if (isApiError(caughtError) && caughtError.statusCode === 401 && caughtError.code === 'authentication_required') {
+			if (isApiError(caughtError) && caughtError.statusCode === 401 && caughtError.getRecoveryAction() === 'sign-in') {
 				return;
 			}
 

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -329,7 +329,13 @@ describe('AgentChat', () => {
 			}
 			if (url.endsWith('/get-messages')) {
 				return new Response(
-					JSON.stringify({ error: 'authentication_required', login_url: '/login' }),
+					JSON.stringify({
+						error: {
+							code: 'authentication_required',
+							message: 'Please sign in to continue.',
+							launch: '/launch/site-studio'
+						}
+					}),
 					{ status: 401, headers: { 'Content-Type': 'application/json' } }
 				);
 			}
@@ -339,7 +345,7 @@ describe('AgentChat', () => {
 		mount();
 
 		await waitFor(() =>
-				expect(assignSpy).toHaveBeenCalledWith('https://tools.ailab.gc.cuny.edu/site-studio/')
+				expect(assignSpy).toHaveBeenCalledWith('https://tools.ailab.gc.cuny.edu/launch/site-studio')
 		);
 	});
 

--- a/packages/frontend/src/lib/components/ProjectDashboard.svelte
+++ b/packages/frontend/src/lib/components/ProjectDashboard.svelte
@@ -4,6 +4,7 @@
 	import { base } from '$app/paths';
 	import { resolvePath } from '$lib/utils/paths';
 	import { fetchProjects, publishProject, unpublishProject, type Project } from '$lib/api/projects';
+	import { getErrorMessage, isApiError } from '$lib/api/errors';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { MoreVertical, Plus, FolderOpen, Globe, GlobeLock, ExternalLink } from 'lucide-svelte';
@@ -18,6 +19,7 @@
 	let projects = $state<Project[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
+	let errorRecovery = $state<'request-access' | 'retry' | null>(null);
 	let publishingProjectId = $state<string | null>(null);
 
 	let showNewProjectDialog = $state(false);
@@ -67,9 +69,17 @@
 		try {
 			loading = true;
 			error = null;
+			errorRecovery = null;
 			projects = await fetchProjects();
 		} catch (e) {
-			error = "We couldn't load your projects. Check your connection and try again.";
+			const caught = e instanceof Error ? e : undefined;
+			error = isApiError(caught)
+				? getErrorMessage(caught)
+				: "We couldn't load your projects. Check your connection and try again.";
+			if (isApiError(caught)) {
+				const action = caught.getRecoveryAction();
+				errorRecovery = action === 'request-access' || action === 'retry' ? action : null;
+			}
 			console.error('Error loading projects:', e);
 		} finally {
 			loading = false;
@@ -201,7 +211,16 @@
 	{:else if error}
 		<div class="error-state" role="alert">
 			<p>{error}</p>
-			<Button onclick={loadProjects}>Retry</Button>
+			<div class="error-actions">
+				{#if errorRecovery === 'request-access'}
+					<a class="request-access-link" href="https://ailab.gc.cuny.edu/request-access">Request access</a>
+				{:else}
+					<Button onclick={loadProjects}>Retry</Button>
+				{/if}
+				{#if errorRecovery === 'request-access'}
+					<Button variant="outline" onclick={loadProjects}>Retry</Button>
+				{/if}
+			</div>
 		</div>
 	{:else if projects.length === 0}
 		<div class="empty-state">
@@ -346,6 +365,27 @@
 		text-align: center;
 		max-width: 400px;
 		margin: 0 auto;
+	}
+
+	.error-actions {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.request-access-link {
+		padding: 0.5rem 0.875rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		color: var(--color-primary);
+		font-weight: 500;
+		text-decoration: none;
+	}
+
+	.request-access-link:hover {
+		background: var(--color-bg-secondary);
 	}
 
 	.empty-state {

--- a/scripts/ci-workflow-security.test.mjs
+++ b/scripts/ci-workflow-security.test.mjs
@@ -72,5 +72,5 @@ test("CI protects action and package credentials in one validation job", async (
   assert.match(deployJob, /select\(\.annotations\["workers\/message"\] == \$message\)/);
   assert.match(deployJob, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
   assert.equal(validationJob.split("CLOUDFLARE_API_TOKEN:").length - 1, 0);
-  assert.equal(deployJob.split("CLOUDFLARE_API_TOKEN:").length - 1, 2);
+  assert.equal(deployJob.split("CLOUDFLARE_API_TOKEN:").length - 1, 3);
 });


### PR DESCRIPTION
## Summary
- adopt @cuny-ai-lab/cail-identity 5.2.5 for strict nested auth envelopes across Worker and frontend
- route authentication/session expiry through the fixed Doorway Site Studio launch and handle CSRF failures through the shared parser
- provide admission request-access/retry UX, exact envelope tests, no-open-redirect coverage, and release readiness probes

## Verification
- `CI=1 bun run check` (lint, app 700 tests, frontend 181 tests, svelte-check, production build)
- `bun run test:workflow`
- Wrangler deploy dry-run
- independent reviewer PASS on `ef498ded1ff3bd4fd82bbf9bd621dceefbf96168`
- live Doorway anonymous CSRF probe returns exact nested 401/no-store

The deployed direct Worker remains on the pre-change flat envelope until this PR is merged and released; the new CI readiness probe asserts both direct Worker and Doorway nested bodies and will fail closed until the release serves the reviewed contract.