### PR TITLE
Poll auth boundaries during release propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,46 +146,58 @@ jobs:
           set -euo pipefail
           # The deploy API returns before the public Worker route has finished
           # propagating. Poll that real boundary at a two-second cadence for
-          # two minutes; a failed probe fails the deployment job.
+          # two minutes; stale responses keep polling and a failed final probe
+          # fails the deployment job.
+          worker_body="$(mktemp)"
+          worker_headers="$(mktemp)"
+          doorway_body="$(mktemp)"
+          doorway_headers="$(mktemp)"
+          trap 'rm -f "$worker_body" "$worker_headers" "$doorway_body" "$doorway_headers"' EXIT
+
+          probe_auth_envelope() {
+            local url="$1"
+            local body="$2"
+            local headers="$3"
+            local response_status
+
+            response_status="$(curl -sS --max-time 10 -D "$headers" -o "$body" -w '%{http_code}' "$url" || printf '000')"
+            if ! [[ "$response_status" == 401 ]]; then
+              return 1
+            fi
+            if ! jq -e '
+              .error.code == "authentication_required"
+              and .error.message == "Please sign in to continue."
+              and .error.launch == "/launch/site-studio"
+            ' "$body" >/dev/null 2>&1; then
+              return 1
+            fi
+            if ! grep -iq '^cache-control: no-store' "$headers"; then
+              return 1
+            fi
+          }
+
           for attempt in $(seq 1 60); do
             health="$(curl -fsS --max-time 10 "$HEALTH_URL" 2>/dev/null || true)"
-            if jq -e --arg id "$EXPECTED_VERSION_ID" '
+            if ! jq -e --arg id "$EXPECTED_VERSION_ID" '
               .status == "ok"
               and .product_id == "site-studio"
               and .version_id == $id
-            ' <<<"$health" >/dev/null; then
-              curl -fsS --max-time 10 -o /dev/null "$ROOT_URL"
+            ' <<<"$health" >/dev/null 2>&1; then
+              sleep 2
+              continue
+            fi
 
-              worker_body="$(mktemp)"
-              worker_headers="$(mktemp)"
-              doorway_body="$(mktemp)"
-              doorway_headers="$(mktemp)"
-              trap 'rm -f "$worker_body" "$worker_headers" "$doorway_body" "$doorway_headers"' EXIT
+            if ! curl -fsS --max-time 10 -o /dev/null "$ROOT_URL"; then
+              sleep 2
+              continue
+            fi
 
-              worker_status="$(curl -sS --max-time 10 -D "$worker_headers" -o "$worker_body" -w '%{http_code}' "$API_URL")"
-              [[ "$worker_status" == 401 ]]
-              jq -e '
-                .error.code == "authentication_required"
-                and .error.message == "Please sign in to continue."
-                and .error.launch == "/launch/site-studio"
-              ' "$worker_body" >/dev/null
-              grep -iq '^cache-control: no-store' "$worker_headers"
-
-              # Doorway owns the browser auth boundary. Probe its exact JSON
-              # contract anonymously; this does not require an interactive SSO
-              # session and prevents a flat/redirected auth response from
-              # reaching the frontend after a release.
-              doorway_status="$(curl -sS --max-time 10 -D "$doorway_headers" -o "$doorway_body" -w '%{http_code}' "$DOORWAY_API_URL")"
-              [[ "$doorway_status" == 401 ]]
-              jq -e '
-                .error.code == "authentication_required"
-                and .error.message == "Please sign in to continue."
-                and .error.launch == "/launch/site-studio"
-              ' "$doorway_body" >/dev/null
-              grep -iq '^cache-control: no-store' "$doorway_headers"
+            if probe_auth_envelope "$API_URL" "$worker_body" "$worker_headers" \
+              && probe_auth_envelope "$DOORWAY_API_URL" "$doorway_body" "$doorway_headers"; then
               echo "production readiness passed for $EXPECTED_VERSION_ID"
               exit 0
             fi
+
             sleep 2
           done
           echo "production readiness did not serve the expected version" >&2

--- a/scripts/ci-workflow-security.test.mjs
+++ b/scripts/ci-workflow-security.test.mjs
@@ -73,4 +73,15 @@ test("CI protects action and package credentials in one validation job", async (
   assert.match(deployJob, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
   assert.equal(validationJob.split("CLOUDFLARE_API_TOKEN:").length - 1, 0);
   assert.equal(deployJob.split("CLOUDFLARE_API_TOKEN:").length - 1, 3);
+  assert.match(deployJob, /probe_auth_envelope\(\) \{/);
+  assert.match(
+    deployJob,
+    /probe_auth_envelope "\$API_URL" "\$worker_body" "\$worker_headers" \\\n\s+&& probe_auth_envelope "\$DOORWAY_API_URL" "\$doorway_body" "\$doorway_headers"/,
+    "readiness must require exact direct-worker and Doorway auth envelopes",
+  );
+  assert.match(
+    deployJob,
+    /if ! jq -e --arg id "\$EXPECTED_VERSION_ID"[\s\S]*?sleep 2\n\s+continue\n\s+fi/,
+    "stale health must keep polling instead of failing the job",
+  );
 });


### PR DESCRIPTION
## Summary
- keep the exact nested Worker and Doorway 401/no-store contract as the release gate
- retry stale health, asset, flat/old auth, or transient fetch responses inside the existing 60×2-second propagation window
- retain identity secret-name readiness and add workflow regression assertions

## Verification
- independent reviewer PASS on `0d6fa76e966456f6ec5cc7624382042e8ae97c64`
- `bun run test:workflow` PASS
- extracted readiness shell `bash -n` PASS
- `git diff --check` PASS
- live extracted probe PASS against deployed version `8061b417-6b1a-4732-bcd9-dee9a7083fdb`

The prior exact-main deployment initially observed an old edge response before propagation; rerun 32439337463 passed after propagation. This change keeps that transient state polling rather than failing early or weakening the envelope contract.