### PR TITLE
Use the canonical Gateway in Site Studio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,15 @@ jobs:
             .annotations["workers/tag"] == $tag
             and .annotations["workers/message"] == $message
           ' <<<"$version" >/dev/null
+          jq -e '
+            (.resources.bindings // []) as $bindings |
+            ([ $bindings[] | select(.name == "CAIL_API_BASE") ] | length) == 1 and
+            ([ $bindings[]
+              | select(.name == "CAIL_API_BASE"
+                and .type == "plain_text"
+                and .text == "https://tools.ailab.gc.cuny.edu")
+            ] | length) == 1
+          ' <<<"$version" >/dev/null
           deployments="$(bunx wrangler deployments list --name site-studio-app --json 2>/dev/null)"
           deployment_id="$(jq -r --arg id "$version_id" --arg message "main $GITHUB_SHA" '
             [ .[] ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ sign-in and returns the browser to the current Site Studio page.
 
 Model traffic goes directly from the app Worker to the CAIL Gateway through
 `@cuny-ai-lab/cail-client` and `@ai-sdk/openai-compatible` at
-`{CAIL_API_BASE}/v1`. The app forwards only the separately verified,
+the canonical `https://tools.ailab.gc.cuny.edu/v1` API. The checked-in
+`CAIL_API_BASE` is the canonical origin; the shared client owns the `/v1`
+model and quota paths. The app forwards only the separately verified,
 subject-bound gateway identity and stamps `X-CAIL-App: site-studio`. Site Studio
 has no provider keys and does not impose an output-token or model-step cap.
 Billed model POSTs use `maxRetries: 0` because an uncertain automatic retry can

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@ai-sdk/provider": "3.0.14",
         "@cloudflare/ai-chat": "0.9.3",
         "@cloudflare/codemode": "0.5.1",
-        "@cuny-ai-lab/cail-client": "5.0.0",
+        "@cuny-ai-lab/cail-client": "6.0.0",
         "@cuny-ai-lab/cail-identity": "5.2.5",
         "@cuny-ai-lab/cail-log": "0.6.0",
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -242,7 +242,7 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
-    "@cuny-ai-lab/cail-client": ["@cuny-ai-lab/cail-client@5.0.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-client/5.0.0/d30e458cfad45a15427c80a7e69741e0f064c239", {}, "sha512-KbkPOqYhme4HK0g2xn1Gv3ey47iHeYcsfX7M5poPGOhO9WEXFc3Tw9JnqXt42F4xXCLqGtcQlQRc6HEYH2/Tzw=="],
+    "@cuny-ai-lab/cail-client": ["@cuny-ai-lab/cail-client@6.0.0", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-client/6.0.0/64ad481bee8426cfe99494c7a638272026e10624", { "dependencies": { "zod": "4.4.3" } }, "sha512-/3oqsdunTg3QDnolyVIPPZzzQvSZ3O3aFe/qtHRoz3BJVxqfCZRoYdsMorb7oUV0FCT5L5v55QAggSV2Z5atRA=="],
 
     "@cuny-ai-lab/cail-identity": ["@cuny-ai-lab/cail-identity@5.2.5", "https://npm.pkg.github.com/download/@cuny-ai-lab/cail-identity/5.2.5/6c3b216acc750451eabb9ed9b32179460a8445d0", { "dependencies": { "jose": "6.2.3", "zod": "4.4.3" } }, "sha512-MqCXFwDCp2fO/m7RLPeKLg4mZSa/ArBoXt52Gl29YlWxiqM9YZMKdieV46/mrHPGbZkTEHHljZgHLUzvdnoGYQ=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,7 @@
     "@ai-sdk/provider": "3.0.14",
     "@cloudflare/ai-chat": "0.9.3",
     "@cloudflare/codemode": "0.5.1",
-    "@cuny-ai-lab/cail-client": "5.0.0",
+    "@cuny-ai-lab/cail-client": "6.0.0",
     "@cuny-ai-lab/cail-identity": "5.2.5",
     "@cuny-ai-lab/cail-log": "0.6.0",
     "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -35,11 +35,12 @@ describe("observability source contract", () => {
     expect(source).not.toContain("analytics_engine_datasets");
   });
 
-  it("pins the app to the canonical production CAIL Model API Worker", () => {
+  it("pins the app to the canonical production CAIL Gateway origin", () => {
     const source = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
-    expect(source).toMatch(
-      /"CAIL_API_BASE"\s*:\s*"https:\/\/cail-model-api\.ailab-452\.workers\.dev"/,
+    expect(source).toContain(
+      '"CAIL_API_BASE": "https://tools.ailab.gc.cuny.edu"',
     );
+    expect(source).not.toContain("cail-model-api.ailab-452.workers.dev");
   });
 
   it.each([
@@ -60,7 +61,7 @@ describe("observability source contract", () => {
       '"@cuny-ai-lab/cail-identity": "5.2.5"',
     );
     expect(source).toContain(
-      '"@cuny-ai-lab/cail-client": "5.0.0"',
+      '"@cuny-ai-lab/cail-client": "6.0.0"',
     );
     expect(source).not.toContain("cail-sandbox-client");
   });

--- a/packages/app/src/routes/quota.test.ts
+++ b/packages/app/src/routes/quota.test.ts
@@ -8,7 +8,8 @@ describe("quota route", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("proxies the verified JWT Cloudflare estimate without changing the wire shape", async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Request(input).url).toBe("https://cail.example/v1/quota");
       const headers = new Headers(init?.headers);
       expect(headers.get("Authorization")).toBe("Bearer verified-jwt");
       expect(headers.get("X-CAIL-App")).toBe("site-studio");

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -57,11 +57,11 @@
     "APP_PUBLIC_DOMAIN": "https://tools.ailab.gc.cuny.edu",
     "PUBLISHED_BASE_URL": "https://tools.ailab.gc.cuny.edu/site-studio",
     // ---- CAIL backbone (see cail-gateway docs/INTEGRATION.md) ----
-    // CAIL_API_BASE: the one public base URL of the CAIL Model API (serves
-    // /v1/... model calls and /keys) in the institutional Cloudflare account.
-    // Chat calls hit {CAIL_API_BASE}/v1/chat/completions; image
-    // generation hits the native {CAIL_API_BASE}/v1/run.
-    "CAIL_API_BASE": "https://cail-model-api.ailab-452.workers.dev",
+    // CAIL_API_BASE: the canonical CAIL Gateway origin. The shared client owns
+    // its /v1 model and quota paths. Chat calls hit
+    // {CAIL_API_BASE}/v1/chat/completions; image generation hits the native
+    // {CAIL_API_BASE}/v1/run.
+    "CAIL_API_BASE": "https://tools.ailab.gc.cuny.edu",
     // CAIL_MODEL: Workers AI catalog id. CAIL policy (2026-07-04): Cloudflare
     // models only — any override must also be a `@cf/...` id. Default is the
     // agentic-coding flagship; `@cf/openai/gpt-oss-120b` is the cheaper fallback.

--- a/scripts/ci-workflow-security.test.mjs
+++ b/scripts/ci-workflow-security.test.mjs
@@ -68,6 +68,9 @@ test("CI protects action and package credentials in one validation job", async (
   assert.match(deployJob, /deployments list --name site-studio-app --json/);
   assert.ok(deployJob.includes("workers/message"));
   assert.match(deployJob, /versions view "\$version_id" --name site-studio-app --json/);
+  assert.match(deployJob, /\.name == "CAIL_API_BASE"/);
+  assert.match(deployJob, /\.type == "plain_text"/);
+  assert.match(deployJob, /\.text == "https:\/\/tools\.ailab\.gc\.cuny\.edu"/);
   assert.match(deployJob, /\.versions\[0\]\.version_id == \$id and \.versions\[0\]\.percentage == 100/);
   assert.match(deployJob, /select\(\.annotations\["workers\/message"\] == \$message\)/);
   assert.match(deployJob, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);


### PR DESCRIPTION
## Summary
- point Site Studio at the canonical tools Gateway origin
- upgrade to cail-client 6.0.0 so quota and model calls use the shared /v1 contract
- assert the exact Gateway binding in release readback

## Verification
- app: 700 tests
- frontend: 181 tests and zero Svelte diagnostics
- production frontend build and Wrangler dry deploy
- quota regression proves exact /v1/quota
- independent review: PASS, no P0-P3 findings