### PR TITLE
Require ETags for Site Studio editor saves

### DIFF
--- a/packages/app/src/agents/site-builder-concurrency.test.ts
+++ b/packages/app/src/agents/site-builder-concurrency.test.ts
@@ -167,6 +167,32 @@ describe("Site Builder file write concurrency", () => {
     });
   });
 
+  it("SS-40: write_file creates an absent file only through put-if-absent", async () => {
+    storage.readFileWithEtag.mockResolvedValueOnce(null);
+    storage.writeFileIfAbsent.mockResolvedValueOnce("etag-1");
+
+    const result = await projectTool("write_file").execute({
+      path: "new.txt",
+      content: "new content",
+      mode: "replace"
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      path: "new.txt",
+      created: true,
+      changed: true
+    });
+    expect(storage.writeFileIfAbsent).toHaveBeenCalledWith(
+      "user-1",
+      "project-1",
+      "new.txt",
+      "new content"
+    );
+    expect(storage.writeFileIfMatch).not.toHaveBeenCalled();
+    expect(storage.createSnapshot).toHaveBeenCalledOnce();
+  });
+
   it("SS-40: edit_file reapplies an exact replacement after a concurrent write", async () => {
     storage.readFileWithEtag
       .mockResolvedValueOnce({ content: "hello world", etag: "etag-1" })

--- a/packages/app/src/lib/owner-mutations.ts
+++ b/packages/app/src/lib/owner-mutations.ts
@@ -20,7 +20,7 @@ export type OwnerMutation =
   | { type: "delete-project"; projectId: string }
   | { type: "publish-project"; projectId: string; desiredSlug: string; publishedBaseUrl: string; handle: string }
   | { type: "unpublish-project"; projectId: string; unpublishedAt: string }
-  | { type: "write-file"; projectId: string; path: string; content: string; baseEtag?: string }
+  | { type: "write-file"; projectId: string; path: string; content: string; baseEtag: string }
   | { type: "write-file-if-absent"; projectId: string; path: string; content: string }
   | { type: "delete-file"; projectId: string; path: string }
   | { type: "rename-file"; projectId: string; oldPath: string; newPath: string }
@@ -417,10 +417,15 @@ export class OwnerMutationService {
         return { ok: true };
       case "write-file": {
         await this.requireProject(ownerId, operation.projectId);
-        const etag = operation.baseEtag === undefined
-          ? await this.storage.writeFile(ownerId, operation.projectId, operation.path, operation.content)
-          : await this.storage.writeFileIfMatch(ownerId, operation.projectId, operation.path, operation.content, operation.baseEtag);
-        return { etag };
+        return {
+          etag: await this.storage.writeFileIfMatch(
+            ownerId,
+            operation.projectId,
+            operation.path,
+            operation.content,
+            operation.baseEtag,
+          ),
+        };
       }
       case "write-file-if-absent":
         await this.requireProject(ownerId, operation.projectId);

--- a/packages/app/src/routes/files.ts
+++ b/packages/app/src/routes/files.ts
@@ -26,7 +26,7 @@ import { getLoggingContext, serializeSiteStudioLoggingContext, type LoggingVaria
 const saveFileSchema = z.object({
   path: z.string().min(1),
   content: z.string(),
-  baseEtag: z.string().optional()
+  baseEtag: z.string().min(1)
 });
 
 const renameFileSchema = z.object({
@@ -227,44 +227,27 @@ export function createFileRouter() {
       jsonError("Binary files cannot be saved through the text editor endpoint.", 415);
     }
 
-    // SS-40: editor saves can carry the ETag they loaded. A stale tab must get
-    // a conflict response instead of silently overwriting a newer agent/editor
-    // write. Legacy clients without an ETag retain the original write behavior.
-    if (baseEtag !== undefined) {
-      const result = await executeOwnerMutation(c.env, user.id, {
-        type: "write-file",
-        projectId,
-        path: filePath,
-        content,
-        baseEtag
-      }, serializeSiteStudioLoggingContext(getLoggingContext(c, user.operationalSubject)));
-      if (!("etag" in result)) throw new Error("Unexpected mutation result");
-      const etag = result.etag;
-      if (etag === null) {
-        const current = await storage.readFileWithEtag(user.id, projectId, filePath);
-        return c.json({
-          error: "file_conflict",
-          message: "This file changed since you opened it. Reload to get the latest version.",
-          etag: current?.etag ?? null
-        }, 409);
-      }
-
-      return c.json({
-        success: true,
-        path: filePath,
-        message: "File saved successfully",
-        etag
-      });
-    }
-
+    // Editor saves always carry the ETag returned by the corresponding read.
+    // Creation is a separate write-file-if-absent mutation; this route never
+    // turns missing concurrency state into an unconditional overwrite.
     const result = await executeOwnerMutation(c.env, user.id, {
       type: "write-file",
       projectId,
       path: filePath,
-      content
+      content,
+      baseEtag
     }, serializeSiteStudioLoggingContext(getLoggingContext(c, user.operationalSubject)));
-    if (!("etag" in result) || result.etag === null) throw new Error("Unexpected mutation result");
+    if (!("etag" in result)) throw new Error("Unexpected mutation result");
     const etag = result.etag;
+    if (etag === null) {
+      const current = await storage.readFileWithEtag(user.id, projectId, filePath);
+      return c.json({
+        error: "file_conflict",
+        message: "This file changed since you opened it. Reload to get the latest version.",
+        etag: current?.etag ?? null
+      }, 409);
+    }
+
     return c.json({
       success: true,
       path: filePath,

--- a/packages/app/src/routes/input-validation.test.ts
+++ b/packages/app/src/routes/input-validation.test.ts
@@ -266,9 +266,10 @@ describe("SS-6 input validation (bad body → 400, not 500)", () => {
     });
 
     it("valid body → still succeeds", async () => {
+      const baseEtag = await storage.writeFile(userId, "proj-x", "page.html", "<h1>Before</h1>");
       const res = await app.request(
         url,
-        jsonBody(JSON.stringify({ path: "page.html", content: "<h1>Hi</h1>" })),
+        jsonBody(JSON.stringify({ path: "page.html", content: "<h1>Hi</h1>", baseEtag })),
         createEnv(bucket)
       );
       expect(res.status).toBe(200);

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -425,7 +425,11 @@ describe("route regressions", () => {
       "http://site-studio.test/api/projects/protproj/file",
       {
         method: "POST",
-        body: JSON.stringify({ path: ".metadata.json", content: '{"published":true,"slug":"pwned"}' }),
+        body: JSON.stringify({
+          path: ".metadata.json",
+          content: '{"published":true,"slug":"pwned"}',
+          baseEtag: "protected-file-etag"
+        }),
         headers: { "Content-Type": "application/json", ...csrf.headers }
       },
       createEnv(bucket)
@@ -1241,6 +1245,47 @@ describe("served-bytes security headers (§3¾)", () => {
       etag: currentEtag
     });
     await expect(storage.readFile(userId, "editor-conflict", "index.html")).resolves.toBe("newer");
+  });
+
+  it("SS-40: POST file rejects a missing base ETag without overwriting", async () => {
+    await storage.createProject(userId, "editor-missing-etag", "Editor Missing ETag");
+    await storage.writeFile(userId, "editor-missing-etag", "index.html", "current");
+
+    const response = await app.request(
+      "http://site-studio.test/api/projects/editor-missing-etag/file",
+      {
+        method: "POST",
+        body: JSON.stringify({ path: "index.html", content: "unguarded save" }),
+        headers: { "Content-Type": "application/json", ...csrf.headers }
+      },
+      createEnv(bucket)
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid file payload" });
+    await expect(storage.readFile(userId, "editor-missing-etag", "index.html")).resolves.toBe("current");
+  });
+
+  it("SS-40: POST file cannot create a file through a fabricated base ETag", async () => {
+    await storage.createProject(userId, "editor-no-create", "Editor No Create");
+
+    const response = await app.request(
+      "http://site-studio.test/api/projects/editor-no-create/file",
+      {
+        method: "POST",
+        body: JSON.stringify({ path: "new.html", content: "new", baseEtag: "not-an-existing-etag" }),
+        headers: { "Content-Type": "application/json", ...csrf.headers }
+      },
+      createEnv(bucket)
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "file_conflict",
+      message: "This file changed since you opened it. Reload to get the latest version.",
+      etag: null
+    });
+    await expect(storage.fileExists(userId, "editor-no-create", "new.html")).resolves.toBe(false);
   });
 
   it("SS-40: POST file accepts a matching base ETag and returns the new ETag", async () => {

--- a/packages/app/src/storage/r2.test.ts
+++ b/packages/app/src/storage/r2.test.ts
@@ -1516,7 +1516,8 @@ describe("OwnerMutationService recovery journal", () => {
       type: "write-file",
       projectId: "site",
       path: "index.html",
-      content: "orphan"
+      content: "orphan",
+      baseEtag: "missing-project-etag"
     })).rejects.toBeInstanceOf(ProjectNotFoundError);
     expect(await storage.fileExists("user-a", "site", "index.html")).toBe(false);
   });

--- a/packages/frontend/src/lib/editor/draft-store.test.ts
+++ b/packages/frontend/src/lib/editor/draft-store.test.ts
@@ -17,7 +17,7 @@ type DraftPayload = {
 	projectId: string;
 	filePath: string;
 	content: string | number;
-	baseEtag: string | { value: string };
+	baseEtag: string | null | { value: string };
 	updatedAt: string | number;
 };
 
@@ -73,6 +73,23 @@ describe('draft-store', () => {
 				content: 42,
 				baseEtag: { value: 'etag-2' },
 				updatedAt: 20260714
+			})
+		);
+
+		expect(await loadDraft(storage, snapshot.projectId, snapshot.filePath, secret)).toBeNull();
+	});
+
+	it('rejects a legacy draft without a concurrency token', async () => {
+		const storage = memoryStorage();
+		await saveDraft(storage, snapshot, 'etag-1', secret);
+		const [storageKey] = [...storage.values.keys()];
+		if (!storageKey) throw new Error('draft storage key was not written');
+		storage.setItem(
+			storageKey,
+			await encryptedDraft(secret, {
+				...snapshot,
+				baseEtag: null,
+				updatedAt: '2026-07-14T12:00:00.000Z'
 			})
 		);
 

--- a/packages/frontend/src/lib/editor/draft-store.ts
+++ b/packages/frontend/src/lib/editor/draft-store.ts
@@ -2,7 +2,7 @@ import type { SaveSnapshot } from './autosave';
 import { z } from 'zod';
 
 export interface StoredDraft extends SaveSnapshot {
-	baseEtag: string | null;
+	baseEtag: string;
 	updatedAt: string;
 }
 
@@ -21,7 +21,7 @@ const storedDraftSchema = z.object({
 	projectId: z.string(),
 	filePath: z.string(),
 	content: z.string(),
-	baseEtag: z.string().nullable(),
+	baseEtag: z.string().min(1),
 	updatedAt: z.string()
 });
 
@@ -61,7 +61,7 @@ async function storageKey(secret: string, projectId: string, filePath: string): 
 export async function saveDraft(
 	storage: Pick<Storage, 'setItem'>,
 	snapshot: SaveSnapshot,
-	baseEtag: string | null,
+	baseEtag: string,
 	secret: string,
 	now: () => string = () => new Date().toISOString()
 ): Promise<void> {
@@ -119,7 +119,7 @@ export async function clearDraft(
 export async function rebaseDraft(
 	storage: Pick<Storage, 'getItem' | 'setItem'>,
 	snapshot: SaveSnapshot,
-	previousBaseEtag: string | null,
+	previousBaseEtag: string,
 	nextBaseEtag: string,
 	secret: string
 ): Promise<void> {

--- a/packages/frontend/src/lib/editor/file-open-state.test.ts
+++ b/packages/frontend/src/lib/editor/file-open-state.test.ts
@@ -9,25 +9,29 @@ import { canQueueFileSave, type FileOpenStatus } from './file-open-state';
 // decision through canQueueFileSave; these tests pin that seam.
 describe('canQueueFileSave (SS-47)', () => {
 	it('allows saving only a fully loaded text file', () => {
-		expect(canQueueFileSave('loaded', true)).toBe(true);
+		expect(canQueueFileSave('loaded', true, 'etag-1')).toBe(true);
 	});
 
 	it('blocks saving after a failed load — the buffer does not hold this file', () => {
-		expect(canQueueFileSave('failed', true)).toBe(false);
+		expect(canQueueFileSave('failed', true, null)).toBe(false);
 	});
 
 	it('blocks saving while the selected file is still loading — the buffer holds the previous file', () => {
-		expect(canQueueFileSave('loading', true)).toBe(false);
+		expect(canQueueFileSave('loading', true, null)).toBe(false);
 	});
 
 	it('blocks saving when nothing is selected', () => {
-		expect(canQueueFileSave('idle', true)).toBe(false);
+		expect(canQueueFileSave('idle', true, null)).toBe(false);
+	});
+
+	it('blocks saving a loaded text file without its concurrency token', () => {
+		expect(canQueueFileSave('loaded', true, null)).toBe(false);
 	});
 
 	it('never allows text-saving a non-text file, in any state', () => {
 		const statuses: FileOpenStatus[] = ['idle', 'loading', 'loaded', 'failed'];
 		for (const status of statuses) {
-			expect(canQueueFileSave(status, false)).toBe(false);
+			expect(canQueueFileSave(status, false, 'etag-1')).toBe(false);
 		}
 	});
 });

--- a/packages/frontend/src/lib/editor/file-open-state.ts
+++ b/packages/frontend/src/lib/editor/file-open-state.ts
@@ -22,8 +22,8 @@ export type FileOpenStatus = 'idle' | 'loading' | 'loaded' | 'failed';
  * previous file, and after 'failed' it holds nothing trustworthy — a queued
  * save in either state would write stale (or empty) content over the newly
  * selected file: silent cross-file data destruction. A failed load also nulls
- * the file's etag, so nothing would even catch the overwrite as a conflict.
+ * the file's etag, which blocks the save here and at the API boundary.
  */
-export function canQueueFileSave(status: FileOpenStatus, isText: boolean): boolean {
-	return status === 'loaded' && isText;
+export function canQueueFileSave(status: FileOpenStatus, isText: boolean, etag: string | null): boolean {
+	return status === 'loaded' && isText && etag !== null;
 }

--- a/packages/frontend/src/lib/editor/keepalive-save.test.ts
+++ b/packages/frontend/src/lib/editor/keepalive-save.test.ts
@@ -37,16 +37,4 @@ describe('buildKeepaliveSave', () => {
 		});
 	});
 
-	it.each([null, undefined])('omits a %s base etag', (baseEtag) => {
-		const { init } = buildKeepaliveSave(snapshot, {
-			csrfToken: 'csrf-token',
-			url: '/api/projects/project-1/file',
-			baseEtag
-		});
-
-		expect(parseBody(init)).toEqual({
-			path: 'index.html',
-			content: '<h1>Hello</h1>'
-		});
-	});
 });

--- a/packages/frontend/src/lib/editor/keepalive-save.ts
+++ b/packages/frontend/src/lib/editor/keepalive-save.ts
@@ -3,13 +3,13 @@ import type { SaveSnapshot } from './autosave';
 interface KeepaliveSaveOptions {
 	csrfToken: string;
 	url: string;
-	baseEtag?: string | null;
+	baseEtag: string;
 }
 
 interface KeepalivePayload {
 	path: string;
 	content: string;
-	baseEtag?: string;
+	baseEtag: string;
 }
 
 interface KeepaliveRequest {
@@ -23,11 +23,9 @@ export function buildKeepaliveSave(
 ): KeepaliveRequest {
 	const payload: KeepalivePayload = {
 		path: snapshot.filePath,
-		content: snapshot.content
+		content: snapshot.content,
+		baseEtag: options.baseEtag
 	};
-	if (options.baseEtag) {
-		payload.baseEtag = options.baseEtag;
-	}
 
 	const init: RequestInit = {
 		method: 'POST',

--- a/packages/frontend/src/routes/editor/[projectId]/+page.svelte
+++ b/packages/frontend/src/routes/editor/[projectId]/+page.svelte
@@ -33,7 +33,7 @@
 		content: string;
 		contentType?: string;
 		isText?: boolean;
-		etag?: string;
+		etag: string;
 	}
 
 	interface SaveConflictResponse {
@@ -41,23 +41,23 @@
 	}
 
 	interface SaveResponse {
-		etag?: string;
+		etag: string;
 	}
 
 	interface SavePayload {
 		path: string;
 		content: string;
-		baseEtag?: string;
+		baseEtag: string;
 	}
 
 	const loadedFileResponseSchema = z.object({
 		content: z.string(),
 		contentType: z.string().optional(),
 		isText: z.boolean().optional(),
-		etag: z.string().optional()
+		etag: z.string().min(1)
 	});
 	const saveConflictResponseSchema = z.object({ error: z.string().optional() });
-	const saveResponseSchema = z.object({ etag: z.string().optional() });
+	const saveResponseSchema = z.object({ etag: z.string().min(1) });
 
 	function parseLoadedFileResponse(payload: string): LoadedFileResponse {
 		const parsed = loadedFileResponseSchema.safeParse(JSON.parse(payload));
@@ -189,7 +189,7 @@
 
 		const handleBeforeUnload = () => {
 			const snapshot = autosave.pending();
-			if (!snapshot) return;
+			if (!snapshot || currentFileEtag === null) return;
 
 			const request = buildKeepaliveSave(snapshot, {
 				csrfToken: getCsrfTokenFromCookie() ?? '',
@@ -314,7 +314,7 @@
 				toast.error("We restored your unsaved changes. They won't replace a newer saved copy.");
 			} else {
 				fileContent = data.content;
-				currentFileEtag = data.etag ?? null;
+				currentFileEtag = data.etag;
 			}
 			currentFileOpenStatus = 'loaded';
 		} catch (error) {
@@ -337,7 +337,7 @@
 	function getCurrentSaveSnapshot(): SaveSnapshot | null {
 		// SS-47: only snapshot when the buffer provably holds the current file's
 		// loaded text (see $lib/editor/file-open-state.ts).
-		if (!projectId || !currentFile || !canQueueFileSave(currentFileOpenStatus, currentFileIsText)) {
+		if (!projectId || !currentFile || !canQueueFileSave(currentFileOpenStatus, currentFileIsText, currentFileEtag)) {
 			return null;
 		}
 
@@ -351,13 +351,14 @@
 	async function persistFile(snapshot: SaveSnapshot): Promise<boolean> {
 		const { projectId: targetProjectId, filePath, content } = snapshot;
 		const requestBaseEtag = currentFileEtag;
+		if (requestBaseEtag === null) return false;
 
 		try {
 			const savePayload: SavePayload = {
 				path: filePath,
-				content
+				content,
+				baseEtag: requestBaseEtag
 			};
-			if (currentFileEtag !== null) savePayload.baseEtag = currentFileEtag;
 
 			const response = await csrfFetch(resolvePath(`/api/projects/${targetProjectId}/file`), {
 				method: 'POST',
@@ -376,18 +377,12 @@
 			if (!response.ok) throw new Error('Failed to save file');
 
 			const data = parseSaveResponse(await response.text());
-			if (
-				targetProjectId === projectId &&
-				filePath === currentFile &&
-				data.etag !== undefined
-			) {
+			if (targetProjectId === projectId && filePath === currentFile) {
 				currentFileEtag = data.etag;
 			}
 			await draftWriteQueue;
 			if (draftSecret) {
-				if (data.etag !== undefined) {
-					await rebaseDraft(localStorage, snapshot, requestBaseEtag, data.etag, draftSecret);
-				}
+				await rebaseDraft(localStorage, snapshot, requestBaseEtag, data.etag, draftSecret);
 				await clearDraft(localStorage, snapshot, draftSecret);
 			}
 
@@ -422,10 +417,10 @@
 	function onEditorChange(content: string) {
 		fileContent = content;
 		const snapshot = getCurrentSaveSnapshot();
-		if (!snapshot) return;
+		const baseEtag = currentFileEtag;
+		if (!snapshot || baseEtag === null) return;
 
 		if (draftSecret) {
-			const baseEtag = currentFileEtag;
 			draftWriteQueue = draftWriteQueue
 				.then(() => saveDraft(localStorage, snapshot, baseEtag, draftSecret))
 				.catch((error) => {


### PR DESCRIPTION
## Outcome

Existing editor saves now require the ETag returned by the file read and always use R2 conditional writes. Missing tokens fail validation, stale tokens return `409 file_conflict`, and file creation remains the separate `write-file-if-absent` mutation used by the Site Builder agent.

The frontend requires nonempty ETags in loaded/save responses, autosave, encrypted drafts, and unload keepalive requests. Legacy nullable drafts are rejected under the greenfield contract.

## Verification

- `bun run check` — 703 app tests, 181 frontend tests, zero Svelte diagnostics, production build
- `bun run test:workflow`
- `bunx wrangler deploy --dry-run`
- real local Worker/R2/DO/auth/CSRF sequence: create 200; read 200; missing ETag 400; stale 409; current 200; reused old ETag 409; content preserved
- independent review: PASS, no P0-P3 findings