### PR TITLE
Harden Site Studio action attempt records

### DIFF
--- a/packages/app/src/action-attempt-contract.test.ts
+++ b/packages/app/src/action-attempt-contract.test.ts
@@ -3,6 +3,7 @@ import {
   ACTION_ATTEMPT_ADMIN_SCHEMA_VERSION,
   ACTION_ATTEMPT_RETENTION_HOURS,
   ACTION_ATTEMPT_SCHEMA_VERSION,
+  isActionAttemptTerminalConsistent,
   summarizeDurableActionReliability,
   type ActionAttemptAdminRead,
   type DurableActionAttempt,
@@ -67,6 +68,90 @@ function read(attempts: readonly DurableActionAttempt[]): ActionAttemptAdminRead
 }
 
 describe("durable action reliability contract", () => {
+  const admittedAt = "2026-07-13T10:00:00.000Z";
+  const terminalAt = "2026-07-13T10:00:01.000Z";
+
+  it.each([
+    ["ok", "completed", undefined],
+    ["client_error", "client_error", "invalid_request"],
+    ["error", "application_failure", "application.failure"],
+    ["error", "upstream_failure", "upstream-failure"],
+    ["denied", "denied", "permission_denied"],
+    ["denied", "quota_blocked", "quota.blocked"],
+    ["denied", "rate_limited", "rate-limited"],
+    ["cancelled", "cancelled", "cancelled"],
+    ["timeout", "timeout", "timeout"],
+    ["outcome_unknown", "unknown", "unknown"],
+  ] as const)("accepts the exact terminal pair %s/%s", (outcome, reason, errorType) => {
+    expect(isActionAttemptTerminalConsistent({
+      admittedAt,
+      terminalAt,
+      durationMs: 1_000,
+      outcome,
+      reason,
+      errorType,
+    })).toBe(true);
+  });
+
+  it.each([
+    ["ok", "upstream_failure"],
+    ["error", "completed"],
+    ["denied", "timeout"],
+    ["outcome_unknown", "application_failure"],
+  ] as const)("rejects the contradictory terminal pair %s/%s", (outcome, reason) => {
+    expect(isActionAttemptTerminalConsistent({
+      admittedAt,
+      terminalAt,
+      durationMs: 1_000,
+      outcome,
+      reason,
+    })).toBe(false);
+  });
+
+  it("rejects bad timestamps, duration drift, and invalid error types", () => {
+    const valid = {
+      admittedAt,
+      terminalAt,
+      durationMs: 1_000,
+      outcome: "error" as const,
+      reason: "application_failure" as const,
+      errorType: "application_failure",
+    };
+    expect(isActionAttemptTerminalConsistent({ ...valid, admittedAt: "not-a-time" })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, terminalAt: "not-a-time" })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, terminalAt: admittedAt })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, durationMs: Number.NaN })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, durationMs: -1 })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, durationMs: 999 })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, errorType: "" })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, errorType: "Uppercase" })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({ ...valid, errorType: "x".repeat(65) })).toBe(false);
+    for (const errorType of [null, true, false, 123, ["x"], Symbol("x")]) {
+      // @ts-expect-error Deliberate malformed RPC/row fixture for runtime validation.
+      expect(isActionAttemptTerminalConsistent({ ...valid, errorType })).toBe(false);
+    }
+    // @ts-expect-error Deliberate malformed RPC/row fixture for runtime validation.
+    expect(isActionAttemptTerminalConsistent({ ...valid, terminalAt: new Date(terminalAt) })).toBe(false);
+    // @ts-expect-error Deliberate malformed RPC/row fixture for runtime validation.
+    expect(isActionAttemptTerminalConsistent({ ...valid, admittedAt: 0 })).toBe(false);
+    expect(isActionAttemptTerminalConsistent({
+      ...valid,
+      outcome: "ok",
+      reason: "completed",
+      errorType: "unexpected",
+    })).toBe(false);
+  });
+
+  it("accepts an immediate terminal with an exact zero duration", () => {
+    expect(isActionAttemptTerminalConsistent({
+      admittedAt,
+      terminalAt: admittedAt,
+      durationMs: 0,
+      outcome: "cancelled",
+      reason: "cancelled",
+    })).toBe(true);
+  });
+
   it("keeps build and publish denominators separate and excludes the terminal grace tail", () => {
     const result = summarizeDurableActionReliability({
       read: read([
@@ -107,11 +192,48 @@ describe("durable action reliability contract", () => {
     })).toThrow("durable action route is not recognized");
     expect(() => summarizeDurableActionReliability({
       ...base,
+      read: read([{ ...valid, admittedAt: "2026-07-13" }]),
+    })).toThrow("durable action admission time is invalid");
+    const malformedAdmission: DurableActionAttempt = {
+      ...valid,
+      // @ts-expect-error Deliberate corrupt-row fixture for runtime validation.
+      admittedAt: 0,
+    };
+    expect(() => summarizeDurableActionReliability({
+      ...base,
+      read: read([malformedAdmission]),
+    })).toThrow("durable action admission time is invalid");
+    expect(() => summarizeDurableActionReliability({
+      ...base,
       read: read([{ ...valid, outcome: undefined }]),
     })).toThrow("durable action terminal must be atomic");
     expect(() => summarizeDurableActionReliability({
       ...base,
+      read: read([{
+        ...valid,
+        terminalAt: undefined,
+        outcome: undefined,
+        reason: undefined,
+        durationMs: undefined,
+        errorType: "orphan_error",
+      }]),
+    })).toThrow("durable action terminal must be atomic");
+    expect(() => summarizeDurableActionReliability({
+      ...base,
       read: read([{ ...valid, durationMs: 999 }]),
+    })).toThrow("durable action terminal is contradictory");
+    expect(() => summarizeDurableActionReliability({
+      ...base,
+      read: read([{ ...valid, errorType: "Uppercase" }]),
+    })).toThrow("durable action terminal is contradictory");
+    const malformedOutcome: DurableActionAttempt = {
+      ...valid,
+      // @ts-expect-error Deliberate corrupt-row fixture for runtime validation.
+      outcome: "__proto__",
+    };
+    expect(() => summarizeDurableActionReliability({
+      ...base,
+      read: read([malformedOutcome]),
     })).toThrow("durable action terminal is contradictory");
   });
 });

--- a/packages/app/src/agents/site-builder-concurrency.test.ts
+++ b/packages/app/src/agents/site-builder-concurrency.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import { quotaExceededEnvelope } from "@cuny-ai-lab/cail-client/testing";
 import { z } from "zod";
 import type { OwnerMutation, OwnerMutationResult } from "../lib/owner-mutations";
@@ -144,6 +145,14 @@ describe("Site Builder event ID contract", () => {
     })).toThrow("invalid Site Studio action admission");
     expect(sql).not.toHaveBeenCalled();
 
+    expect(() => agent.recordActionAdmission({
+      actionId: UUID_V4,
+      action: "build",
+      route: "/api/agents/site-builder/{project_id}",
+      admittedAt: "2026-08-02",
+    })).toThrow("invalid Site Studio action admission");
+    expect(sql).not.toHaveBeenCalled();
+
     expect(() => agent.recordActionTerminal({
       actionId: UUID_V7,
       outcome: "cancelled",
@@ -152,6 +161,33 @@ describe("Site Builder event ID contract", () => {
       durationMs: 1_000,
     })).toThrow("invalid Site Studio action terminal");
     expect(sql).not.toHaveBeenCalled();
+
+    expect(() => agent.recordActionTerminal({
+      actionId: UUID_V4,
+      outcome: "error",
+      reason: "application_failure",
+      terminalAt: "2026-08-02T00:00:01.000Z",
+      durationMs: 1_000,
+      errorType: "Uppercase",
+    })).toThrow("invalid Site Studio action terminal");
+    expect(sql).not.toHaveBeenCalled();
+
+    expect(() => agent.recordActionTerminal({
+      actionId: UUID_V4,
+      outcome: "error",
+      reason: "completed",
+      terminalAt: "2026-08-02T00:00:01.000Z",
+      durationMs: 1_000,
+    })).toThrow("action terminal requires a durable admission");
+    expect(sql).toHaveBeenCalled();
+  });
+
+  it("keeps durable action recording off the browser-callable RPC surface", () => {
+    const source = readFileSync(new URL("./site-builder.ts", import.meta.url), "utf8");
+
+    expect(source).toContain("callable()(SiteBuilderAgent.prototype.getObservability");
+    expect(source).not.toContain("callable()(SiteBuilderAgent.prototype.recordActionAdmission");
+    expect(source).not.toContain("callable()(SiteBuilderAgent.prototype.recordActionTerminal");
   });
 });
 

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -43,6 +43,9 @@ import {
   ACTION_ATTEMPT_ADMIN_SCHEMA_VERSION,
   ACTION_ATTEMPT_RETENTION_HOURS,
   ACTION_ATTEMPT_SCHEMA_VERSION,
+  isActionAttemptTimestamp,
+  isActionAttemptTerminalConsistent,
+  isActionAttemptTerminalWellFormed,
   type ActionAttemptAdmission,
   type ActionAttemptAdminRead,
   type ActionAttemptTerminal,
@@ -80,7 +83,6 @@ type Scope = {
 };
 
 type ChatHandler = AIChatAgent<Env>["onChatMessage"];
-type CompatibleReasonByOutcome = Readonly<Record<CailOutcome, ReadonlySet<CailTerminalReason>>>;
 
 type SiteBuilderObservabilityToolCall = {
   toolCallId: string;
@@ -1371,7 +1373,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
     if (
       !SITE_STUDIO_EVENT_ID_RE.test(admission.actionId)
       || admission.route !== expectedRoute
-      || !Number.isFinite(Date.parse(admission.admittedAt))
+      || !isActionAttemptTimestamp(admission.admittedAt)
     ) {
       throw new TypeError("invalid Site Studio action admission");
     }
@@ -1393,11 +1395,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
   recordActionTerminal(terminal: ActionAttemptTerminal): void {
     if (
       !SITE_STUDIO_EVENT_ID_RE.test(terminal.actionId)
-      || !Number.isFinite(Date.parse(terminal.terminalAt))
-      || !Number.isFinite(terminal.durationMs)
-      || terminal.durationMs < 0
-      || (terminal.errorType !== undefined
-        && !/^[a-z0-9][a-z0-9_.-]{0,63}$/.test(terminal.errorType))
+      || !isActionAttemptTerminalWellFormed(terminal)
     ) {
       throw new TypeError("invalid Site Studio action terminal");
     }
@@ -1406,22 +1404,10 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
       SELECT * FROM site_studio_action_attempts WHERE action_id = ${terminal.actionId}
     `][0];
     if (!existing) throw new TypeError("action terminal requires a durable admission");
-    const expectedDuration = Date.parse(terminal.terminalAt) - Date.parse(existing.admitted_at);
-    const compatibleReason = {
-      ok: new Set<CailTerminalReason>(["completed"]),
-      client_error: new Set<CailTerminalReason>(["client_error"]),
-      error: new Set<CailTerminalReason>(["application_failure", "upstream_failure"]),
-      denied: new Set<CailTerminalReason>(["denied", "quota_blocked", "rate_limited"]),
-      cancelled: new Set<CailTerminalReason>(["cancelled"]),
-      timeout: new Set<CailTerminalReason>(["timeout"]),
-      outcome_unknown: new Set<CailTerminalReason>(["unknown"]),
-    } satisfies CompatibleReasonByOutcome;
-    if (
-      expectedDuration < 0
-      || terminal.durationMs !== expectedDuration
-      || !compatibleReason[terminal.outcome].has(terminal.reason)
-      || (terminal.outcome === "ok" && terminal.errorType !== undefined)
-    ) {
+    if (!isActionAttemptTerminalConsistent({
+      ...terminal,
+      admittedAt: existing.admitted_at,
+    })) {
       throw new TypeError("action terminal contradicts its durable admission");
     }
     if (existing.terminal_at !== null) {
@@ -1977,30 +1963,6 @@ callable()(SiteBuilderAgent.prototype.getObservability, {
   access: {
     has: (object: SiteBuilderAgent) => "getObservability" in object,
     get: (object: SiteBuilderAgent) => object.getObservability,
-  },
-  addInitializer: () => undefined,
-  metadata: {},
-});
-callable()(SiteBuilderAgent.prototype.recordActionAdmission, {
-  kind: "method",
-  name: "recordActionAdmission",
-  static: false,
-  private: false,
-  access: {
-    has: (object: SiteBuilderAgent) => "recordActionAdmission" in object,
-    get: (object: SiteBuilderAgent) => object.recordActionAdmission,
-  },
-  addInitializer: () => undefined,
-  metadata: {},
-});
-callable()(SiteBuilderAgent.prototype.recordActionTerminal, {
-  kind: "method",
-  name: "recordActionTerminal",
-  static: false,
-  private: false,
-  access: {
-    has: (object: SiteBuilderAgent) => "recordActionTerminal" in object,
-    get: (object: SiteBuilderAgent) => object.recordActionTerminal,
   },
   addInitializer: () => undefined,
   metadata: {},

--- a/packages/observability-core/src/action-attempt.ts
+++ b/packages/observability-core/src/action-attempt.ts
@@ -2,6 +2,7 @@ import type {
   CailOutcome,
   CailTerminalReason,
 } from "@cuny-ai-lab/cail-log";
+import { z } from "zod";
 
 export const ACTION_ATTEMPT_SCHEMA_VERSION = "site-studio.action-attempt.v1" as const;
 export const ACTION_ATTEMPT_ADMIN_SCHEMA_VERSION =
@@ -55,6 +56,63 @@ export type ActionAttemptRecorder = Readonly<{
   terminal(terminal: ActionAttemptTerminal): void;
 }>;
 
+const ACTION_TERMINAL_REASONS_BY_OUTCOME = Object.freeze({
+  ok: Object.freeze(["completed"]),
+  client_error: Object.freeze(["client_error"]),
+  error: Object.freeze(["application_failure", "upstream_failure"]),
+  denied: Object.freeze(["denied", "quota_blocked", "rate_limited"]),
+  cancelled: Object.freeze(["cancelled"]),
+  timeout: Object.freeze(["timeout"]),
+  outcome_unknown: Object.freeze(["unknown"]),
+} as const satisfies Readonly<Record<CailOutcome, readonly CailTerminalReason[]>>);
+
+const ACTION_TERMINAL_ERROR_TYPE_RE = /^[a-z0-9][a-z0-9_.-]{0,63}$/;
+const ACTION_ATTEMPT_TIMESTAMP_SCHEMA = z.iso.datetime({ offset: true });
+const ACTION_TERMINAL_FACTS_SCHEMA = z.object({
+  terminalAt: ACTION_ATTEMPT_TIMESTAMP_SCHEMA,
+  durationMs: z.number().finite().nonnegative(),
+  outcome: z.string(),
+  reason: z.string(),
+  errorType: z.string().regex(ACTION_TERMINAL_ERROR_TYPE_RE).optional(),
+});
+
+type ActionAttemptTerminalFacts = Readonly<Omit<ActionAttemptTerminal, "actionId">>;
+
+/** Accept only the ISO datetime form written by the action lifecycle. */
+export function isActionAttemptTimestamp(value: string): boolean {
+  return ACTION_ATTEMPT_TIMESTAMP_SCHEMA.safeParse(value).success;
+}
+
+/** Validate the terminal fields that do not depend on a durable admission. */
+export function isActionAttemptTerminalWellFormed(
+  terminal: ActionAttemptTerminalFacts,
+): boolean {
+  return ACTION_TERMINAL_FACTS_SCHEMA.safeParse(terminal).success;
+}
+
+/** Validate a terminal against the admission whose duration it closes. */
+export function isActionAttemptTerminalConsistent(
+  terminal: ActionAttemptTerminalFacts & Readonly<{ admittedAt: string }>,
+): boolean {
+  if (
+    !isActionAttemptTerminalWellFormed(terminal)
+    || !isActionAttemptTimestamp(terminal.admittedAt)
+  ) return false;
+  const admittedAt = Date.parse(terminal.admittedAt);
+  const terminalAt = Date.parse(terminal.terminalAt);
+  const compatibleReasons = Object.hasOwn(
+    ACTION_TERMINAL_REASONS_BY_OUTCOME,
+    terminal.outcome,
+  )
+    ? ACTION_TERMINAL_REASONS_BY_OUTCOME[terminal.outcome]
+    : undefined;
+  return Number.isFinite(admittedAt)
+    && terminalAt >= admittedAt
+    && terminal.durationMs === terminalAt - admittedAt
+    && compatibleReasons?.some((reason) => reason === terminal.reason) === true
+    && (terminal.outcome !== "ok" || terminal.errorType === undefined);
+}
+
 export type ActionReliabilitySummary = Readonly<{
   action: SiteStudioActionKind;
   eligibleAdmissions: number;
@@ -101,10 +159,10 @@ export function summarizeDurableActionReliability(options: Readonly<{
     if (attempt.route !== SITE_STUDIO_ACTION_ROUTES[attempt.action]) {
       throw new TypeError("durable action route is not recognized");
     }
-    const admittedAt = Date.parse(attempt.admittedAt);
-    if (!Number.isFinite(admittedAt)) {
+    if (!isActionAttemptTimestamp(attempt.admittedAt)) {
       throw new TypeError("durable action admission time is invalid");
     }
+    const admittedAt = Date.parse(attempt.admittedAt);
     if (
       attempt.action === options.action
       && admittedAt >= options.windowStartMs
@@ -124,28 +182,21 @@ export function summarizeDurableActionReliability(options: Readonly<{
       attempt.durationMs,
     ];
     const present = terminalFields.filter((value) => value !== undefined).length;
-    if (present !== 0 && present !== terminalFields.length) {
+    if (
+      (present === 0 && attempt.errorType !== undefined)
+      || (present !== 0 && present !== terminalFields.length)
+    ) {
       throw new TypeError("durable action terminal must be atomic");
     }
     if (present === terminalFields.length) {
-      const terminalAt = Date.parse(attempt.terminalAt!);
-      const admittedAt = Date.parse(attempt.admittedAt);
-      const compatibleReason = {
-        ok: new Set<CailTerminalReason>(["completed"]),
-        client_error: new Set<CailTerminalReason>(["client_error"]),
-        error: new Set<CailTerminalReason>(["application_failure", "upstream_failure"]),
-        denied: new Set<CailTerminalReason>(["denied", "quota_blocked", "rate_limited"]),
-        cancelled: new Set<CailTerminalReason>(["cancelled"]),
-        timeout: new Set<CailTerminalReason>(["timeout"]),
-        outcome_unknown: new Set<CailTerminalReason>(["unknown"]),
-      } satisfies Readonly<Record<CailOutcome, ReadonlySet<CailTerminalReason>>>;
-      if (
-        !Number.isFinite(terminalAt)
-        || terminalAt < admittedAt
-        || attempt.durationMs !== terminalAt - admittedAt
-        || !compatibleReason[attempt.outcome!].has(attempt.reason!)
-        || (attempt.outcome === "ok" && attempt.errorType !== undefined)
-      ) {
+      if (!isActionAttemptTerminalConsistent({
+        admittedAt: attempt.admittedAt,
+        terminalAt: attempt.terminalAt!,
+        outcome: attempt.outcome!,
+        reason: attempt.reason!,
+        durationMs: attempt.durationMs!,
+        errorType: attempt.errorType,
+      })) {
         throw new TypeError("durable action terminal is contradictory");
       }
       coveredActions += 1;


### PR DESCRIPTION
## Summary
- share one strict admission/terminal timestamp and outcome contract between the durable writer and reliability reader
- reject malformed, partial, contradictory, and orphaned action-attempt data
- remove admission and terminal writers from the browser-callable Agents RPC surface while preserving Worker-to-Durable-Object RPC

## Verification
- `bun run check` (720 app tests, 181 frontend tests, type checks, Svelte checks, production build)
- `bun run test:workflow`
- production Worker dry build
- independent review: PASS, no remaining findings
