### PR TITLE
Reconcile persisted chat turns after stream completion

### DIFF
--- a/packages/app/src/agents/site-builder-concurrency.test.ts
+++ b/packages/app/src/agents/site-builder-concurrency.test.ts
@@ -8,6 +8,7 @@ import {
   createProjectTools,
   describeModelStreamError,
   SiteBuilderAgent,
+  SITE_STUDIO_CANCEL_TURN_TYPE,
   SITE_STUDIO_EVENT_ID_RE,
   summarizeError,
   type ProjectStorageLike,
@@ -381,6 +382,19 @@ describe("Site Builder connection logging concurrency", () => {
   function setConnections(agent: SiteBuilderAgent, connections: Iterable<ReturnType<typeof fakeConnection>>) {
     Object.assign(agent, { getConnections: () => connections });
   }
+
+  it("resets the full agent turn for the Site Studio stop frame", async () => {
+    const agent = createTestAgent();
+    const resetTurnState = vi.fn();
+    Object.defineProperty(agent, "resetTurnState", { value: resetTurnState });
+
+    await agent.onMessage(
+      fakeConnection(),
+      JSON.stringify({ type: SITE_STUDIO_CANCEL_TURN_TYPE }),
+    );
+
+    expect(resetTurnState).toHaveBeenCalledOnce();
+  });
 
   it("retains socket A while missing and changed subjects clear/isolate later sockets", () => {
     const subjectA = "cail-v1-0123456789abcdef0123456789abcdef";

--- a/packages/app/src/agents/site-builder-concurrency.test.ts
+++ b/packages/app/src/agents/site-builder-concurrency.test.ts
@@ -8,6 +8,7 @@ import {
   createProjectTools,
   describeModelStreamError,
   SiteBuilderAgent,
+  SITE_STUDIO_CHAT_CANCELLED_TYPE,
   SITE_STUDIO_CANCEL_TURN_TYPE,
   SITE_STUDIO_EVENT_ID_RE,
   summarizeError,
@@ -386,7 +387,9 @@ describe("Site Builder connection logging concurrency", () => {
   it("resets the full agent turn for the Site Studio stop frame", async () => {
     const agent = createTestAgent();
     const resetTurnState = vi.fn();
+    const broadcast = vi.fn();
     Object.defineProperty(agent, "resetTurnState", { value: resetTurnState });
+    Object.defineProperty(agent, "broadcast", { value: broadcast });
 
     await agent.onMessage(
       fakeConnection(),
@@ -394,6 +397,7 @@ describe("Site Builder connection logging concurrency", () => {
     );
 
     expect(resetTurnState).toHaveBeenCalledOnce();
+    expect(broadcast).toHaveBeenCalledWith(JSON.stringify({ type: SITE_STUDIO_CHAT_CANCELLED_TYPE }));
   });
 
   it("retains socket A while missing and changed subjects clear/isolate later sockets", () => {

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -85,10 +85,21 @@ export { describeModelStreamError } from "../lib/model-stream-error";
  */
 export const SITE_STUDIO_CHAT_COMMITTED_TYPE = "site_studio_chat_committed" as const;
 export const SITE_STUDIO_CANCEL_TURN_TYPE = "site_studio_cancel_turn" as const;
+export const SITE_STUDIO_CHAT_CANCELLED_TYPE = "site_studio_chat_cancelled" as const;
 
 const siteStudioCancelTurnSchema = z.object({
   type: z.literal(SITE_STUDIO_CANCEL_TURN_TYPE),
 }).strict();
+
+function isSiteStudioCancelTurn(message: WSMessage): boolean {
+  const encodedMessage = z.string().safeParse(message);
+  if (!encodedMessage.success) return false;
+  try {
+    return siteStudioCancelTurnSchema.safeParse(JSON.parse(encodedMessage.data)).success;
+  } catch {
+    return false;
+  }
+}
 
 type Scope = {
   userId: string;
@@ -1325,17 +1336,14 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
     connection: Connection<SiteStudioConnectionLoggingState>,
     message: WSMessage,
   ): void | Promise<void> {
-    const encodedMessage = z.string().safeParse(message);
-    if (encodedMessage.success) {
+    if (isSiteStudioCancelTurn(message)) {
+      this.resetTurnState();
       try {
-        const parsed = siteStudioCancelTurnSchema.safeParse(JSON.parse(encodedMessage.data));
-        if (parsed.success) {
-          this.resetTurnState();
-          return;
-        }
+        this.broadcast(JSON.stringify({ type: SITE_STUDIO_CHAT_CANCELLED_TYPE }));
       } catch {
-        // The parent agent owns all non-Site-Studio protocol handling.
+        console.error("Failed to broadcast Site Studio chat cancellation");
       }
+      return;
     }
     return super.onMessage(connection, message);
   }

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -8,6 +8,7 @@ import {
   getCurrentAgent,
   type Connection,
   type ConnectionContext,
+  type WSMessage,
 } from "agents";
 import { DynamicWorkerExecutor } from "@cloudflare/codemode";
 import { createCodeTool } from "@cloudflare/codemode/ai";
@@ -83,6 +84,11 @@ export { describeModelStreamError } from "../lib/model-stream-error";
  * UI messages already exposed by `cf_agent_chat_messages`/`get-messages`.
  */
 export const SITE_STUDIO_CHAT_COMMITTED_TYPE = "site_studio_chat_committed" as const;
+export const SITE_STUDIO_CANCEL_TURN_TYPE = "site_studio_cancel_turn" as const;
+
+const siteStudioCancelTurnSchema = z.object({
+  type: z.literal(SITE_STUDIO_CANCEL_TURN_TYPE),
+}).strict();
 
 type Scope = {
   userId: string;
@@ -1308,6 +1314,29 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
     const identityJwt = getAgentConnectionIdentityJwt(ctx.request);
     connection.setState(createSiteStudioConnectionLoggingState(ctx.request, undefined, identityJwt ?? undefined));
 
+  }
+
+  /**
+   * Stop is a turn-level operation, not merely a request-id cancellation.
+   * Resetting at the agent boundary also invalidates a queued client-tool
+   * continuation before it can mint and start a successor request.
+   */
+  override onMessage(
+    connection: Connection<SiteStudioConnectionLoggingState>,
+    message: WSMessage,
+  ): void | Promise<void> {
+    if (typeof message === "string") {
+      try {
+        const parsed = siteStudioCancelTurnSchema.safeParse(JSON.parse(message));
+        if (parsed.success) {
+          this.resetTurnState();
+          return;
+        }
+      } catch {
+        // The parent agent owns all non-Site-Studio protocol handling.
+      }
+    }
+    return super.onMessage(connection, message);
   }
 
   override onRequest(request: Request): Response | Promise<Response> {

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -77,6 +77,13 @@ import {
 
 export { describeModelStreamError } from "../lib/model-stream-error";
 
+/**
+ * Post-persistence chat commit frames are deliberately separate from the
+ * streaming response protocol.  The frame contains only the same persisted
+ * UI messages already exposed by `cf_agent_chat_messages`/`get-messages`.
+ */
+export const SITE_STUDIO_CHAT_COMMITTED_TYPE = "site_studio_chat_committed" as const;
+
 type Scope = {
   userId: string;
   projectId: string;
@@ -1273,7 +1280,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
   private observabilityEvents: SiteBuilderObservabilityEvent[] = [];
   private observabilityRequests = new Map<string, SiteBuilderObservabilityRequest>();
   private observabilitySequence = 0;
-  private buildActionAwaitingPersistence: SiteStudioActionLifecycle | null = null;
+  private buildActionsAwaitingPersistence = new Map<string, SiteStudioActionLifecycle>();
   /**
    * Operational subject is deliberately not stored on the Durable Object.
    * Each connection receives the route's middleware-verified subject and JWT
@@ -1465,9 +1472,33 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
     this.messages = [];
   }
 
-  /** Complete the build only after AIChatAgent has persisted its response. */
+  /**
+   * Complete the build only after AIChatAgent has persisted its response.
+   *
+   * When a successful assistant message was persisted, the commit frame is
+   * sent before the action-lifecycle early return: the UI uses it as the
+   * authoritative repair path when a streamed tool or terminal chunk was
+   * malformed or missed. Error frames remain transient, and aborted turns use
+   * the existing cancellation path. Do not include
+   * `result.message`, errors, attachments, or provider/model data here;
+   * `this.messages` is the already-sanitized persisted history exposed elsewhere.
+   */
   protected override onChatResponse(result: ChatResponseResult): void {
-    const pending = this.buildActionAwaitingPersistence;
+    // Only successful persisted turns get a commit; errors stay transient and
+    // aborted turns use the existing cancellation path.
+    if (result.status === "completed") {
+      try {
+        this.broadcast(JSON.stringify({
+          type: SITE_STUDIO_CHAT_COMMITTED_TYPE,
+          requestId: result.requestId,
+          messages: this.messages,
+        }));
+      } catch {
+        console.error("Failed to broadcast persisted chat commit");
+      }
+    }
+
+    const pending = this.buildActionsAwaitingPersistence.get(result.requestId);
     if (!pending) return;
     if (result.status === "completed") {
       pending.completeSuccess();
@@ -1479,7 +1510,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
         "chat_response_failed",
       );
     }
-    this.buildActionAwaitingPersistence = null;
+    this.buildActionsAwaitingPersistence.delete(result.requestId);
   }
 
   async onChatMessage(
@@ -1614,7 +1645,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
             rawFinishReason: event.rawFinishReason ?? null,
           });
           if (buildAction.wasAdmitted()) {
-            this.buildActionAwaitingPersistence = buildAction;
+            this.buildActionsAwaitingPersistence.set(requestId, buildAction);
           }
           if (onFinish) {
             onFinish(event);
@@ -1625,7 +1656,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
             steps: steps.length
           }, "warn");
           buildAction.completeFailure({ outcome: "cancelled", reason: "cancelled" });
-          this.buildActionAwaitingPersistence = null;
+          this.buildActionsAwaitingPersistence.delete(requestId);
         },
         onError: (error) => {
           const described = describeModelStreamError(error.error);
@@ -1638,7 +1669,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
               : { outcome: "error", reason: "upstream_failure" },
             described.quota ? "quota_exceeded" : errorCodeFrom(error.error),
           );
-          this.buildActionAwaitingPersistence = null;
+          this.buildActionsAwaitingPersistence.delete(requestId);
         }
       });
 
@@ -1658,7 +1689,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
               : { outcome: "error", reason: "upstream_failure" },
             described.quota ? "quota_exceeded" : errorCodeFrom(error),
           );
-          this.buildActionAwaitingPersistence = null;
+          this.buildActionsAwaitingPersistence.delete(requestId);
           return described.message;
         }
       });
@@ -1670,7 +1701,7 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
         { outcome: "error", reason: "application_failure" },
         errorCodeFrom(error),
       );
-      this.buildActionAwaitingPersistence = null;
+      this.buildActionsAwaitingPersistence.delete(requestId);
       return new Response(JSON.stringify({ error: "Failed to process request" }), {
         status: 500,
         headers: { "Content-Type": "application/json" }

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -1325,9 +1325,10 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
     connection: Connection<SiteStudioConnectionLoggingState>,
     message: WSMessage,
   ): void | Promise<void> {
-    if (typeof message === "string") {
+    const encodedMessage = z.string().safeParse(message);
+    if (encodedMessage.success) {
       try {
-        const parsed = siteStudioCancelTurnSchema.safeParse(JSON.parse(message));
+        const parsed = siteStudioCancelTurnSchema.safeParse(JSON.parse(encodedMessage.data));
         if (parsed.success) {
           this.resetTurnState();
           return;

--- a/packages/frontend/src/lib/agents/chat.ts
+++ b/packages/frontend/src/lib/agents/chat.ts
@@ -7,11 +7,13 @@ export const AgentMessageType = {
 	CF_AGENT_USE_CHAT_RESPONSE: 'cf_agent_use_chat_response',
 	CF_AGENT_CHAT_CLEAR: 'cf_agent_chat_clear',
 	CF_AGENT_CHAT_REQUEST_CANCEL: 'cf_agent_chat_request_cancel',
+	CF_AGENT_STREAM_RESUME_REQUEST: 'cf_agent_stream_resume_request',
 	CF_AGENT_STREAM_RESUMING: 'cf_agent_stream_resuming',
 	CF_AGENT_STREAM_RESUME_ACK: 'cf_agent_stream_resume_ack',
 	CF_AGENT_STREAM_RESUME_NONE: 'cf_agent_stream_resume_none',
 	CF_AGENT_TOOL_RESULT: 'cf_agent_tool_result',
-	CF_AGENT_MESSAGE_UPDATED: 'cf_agent_message_updated'
+	CF_AGENT_MESSAGE_UPDATED: 'cf_agent_message_updated',
+	SITE_STUDIO_CHAT_COMMITTED: 'site_studio_chat_committed'
 } as const;
 
 export type ToolPartState =
@@ -114,6 +116,8 @@ export interface AgentSocketMessage {
 	messages?: UIChatMessage[];
 	message?: UIChatMessage;
 	id?: string;
+	requestId?: string;
+	probeId?: string;
 	continuation?: boolean;
 	body?: string;
 	done?: boolean;
@@ -125,11 +129,21 @@ const agentSocketMessageSchema = z.object({
 	messages: uiChatMessagesSchema.optional(),
 	message: uiChatMessageSchema.optional(),
 	id: z.string().optional(),
+	requestId: z.string().optional(),
+	probeId: z.string().optional(),
 	continuation: z.boolean().optional(),
 	body: z.string().optional(),
 	done: z.boolean().optional(),
 	error: z.boolean().optional()
 }).catchall(jsonValueSchema);
+
+const siteStudioChatCommittedFrameSchema = z.object({
+	type: z.literal(AgentMessageType.SITE_STUDIO_CHAT_COMMITTED),
+	requestId: z.string().min(1),
+	messages: uiChatMessagesSchema
+}).strict();
+
+export type SiteStudioChatCommittedFrame = z.infer<typeof siteStudioChatCommittedFrameSchema>;
 
 export interface ActiveStreamMessage {
 	id: string;
@@ -294,6 +308,17 @@ export function parseAgentSocketMessage(payload: string): AgentSocketMessage {
 	const parsed = agentSocketMessageSchema.safeParse(JSON.parse(payload));
 	if (!parsed.success) throw new Error('Invalid agent socket payload');
 	return parsed.data;
+}
+
+/**
+ * Parse the post-persistence Site Studio commit frame. A commit can replace
+ * the visible transcript, so it must not accept an ambiguous payload.
+ */
+export function parseSiteStudioChatCommittedFrame(
+	payload: AgentSocketMessage
+): SiteStudioChatCommittedFrame | null {
+	const parsed = siteStudioChatCommittedFrameSchema.safeParse(payload);
+	return parsed.success ? parsed.data : null;
 }
 
 /** Parse a streamed UI chunk, including the server's optional `data:` prefix. */

--- a/packages/frontend/src/lib/agents/chat.ts
+++ b/packages/frontend/src/lib/agents/chat.ts
@@ -11,6 +11,7 @@ export const AgentMessageType = {
 	CF_AGENT_STREAM_RESUMING: 'cf_agent_stream_resuming',
 	CF_AGENT_STREAM_RESUME_ACK: 'cf_agent_stream_resume_ack',
 	CF_AGENT_STREAM_RESUME_NONE: 'cf_agent_stream_resume_none',
+	CF_AGENT_STREAM_PENDING: 'cf_agent_stream_pending',
 	CF_AGENT_TOOL_RESULT: 'cf_agent_tool_result',
 	CF_AGENT_MESSAGE_UPDATED: 'cf_agent_message_updated',
 	SITE_STUDIO_CANCEL_TURN: 'site_studio_cancel_turn',

--- a/packages/frontend/src/lib/agents/chat.ts
+++ b/packages/frontend/src/lib/agents/chat.ts
@@ -13,6 +13,7 @@ export const AgentMessageType = {
 	CF_AGENT_STREAM_RESUME_NONE: 'cf_agent_stream_resume_none',
 	CF_AGENT_TOOL_RESULT: 'cf_agent_tool_result',
 	CF_AGENT_MESSAGE_UPDATED: 'cf_agent_message_updated',
+	SITE_STUDIO_CANCEL_TURN: 'site_studio_cancel_turn',
 	SITE_STUDIO_CHAT_COMMITTED: 'site_studio_chat_committed'
 } as const;
 
@@ -149,6 +150,7 @@ export interface ActiveStreamMessage {
 	id: string;
 	messageId: string;
 	continuation: boolean;
+	hadError: boolean;
 	parts: UIMessagePart[];
 	metadata?: Record<string, JsonValue>;
 }

--- a/packages/frontend/src/lib/agents/chat.ts
+++ b/packages/frontend/src/lib/agents/chat.ts
@@ -14,6 +14,7 @@ export const AgentMessageType = {
 	CF_AGENT_TOOL_RESULT: 'cf_agent_tool_result',
 	CF_AGENT_MESSAGE_UPDATED: 'cf_agent_message_updated',
 	SITE_STUDIO_CANCEL_TURN: 'site_studio_cancel_turn',
+	SITE_STUDIO_CHAT_CANCELLED: 'site_studio_chat_cancelled',
 	SITE_STUDIO_CHAT_COMMITTED: 'site_studio_chat_committed'
 } as const;
 

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -1078,6 +1078,12 @@ import {
 				if (data.message) uiMessages = mergeUpdatedMessage(uiMessages, data.message);
 				scrollToBottom();
 				break;
+			case AgentMessageType.SITE_STUDIO_CHAT_CANCELLED:
+				if (currentRequestId) {
+					settledRequestIds = new Set([...settledRequestIds, currentRequestId].slice(-8));
+				}
+				resetRequestState();
+				break;
 			case AgentMessageType.SITE_STUDIO_CHAT_COMMITTED: {
 				const committed = parseSiteStudioChatCommittedFrame(data);
 				if (!committed || committed.requestId !== currentRequestId) {

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -24,6 +24,7 @@ import {
 		isToolPart,
 		mergeUpdatedMessage,
 		parseAgentSocketMessage,
+		parseSiteStudioChatCommittedFrame,
 		parseUIChatMessages,
 		parseUIStreamChunk,
 		type AgentSocketMessage,
@@ -120,6 +121,14 @@ import {
 	// SS-9: request ids the user explicitly cancelled. Late CF_AGENT_USE_CHAT_RESPONSE
 	// frames for these ids must be dropped rather than resuming a stopped stream.
 	let cancelledRequestIds = $state<Set<string>>(new Set());
+	// Keep only a small recent window: late stream/terminal frames for committed
+	// turns must not recreate stale UI, without retaining request ids forever.
+	let settledRequestIds = $state<Set<string>>(new Set());
+	// A reconnect probe belongs to one socket and one pending request. The server
+	// echoes its probe id on STREAM_RESUME_NONE; the acknowledged id suppresses
+	// duplicate proactive and probe-triggered STREAM_RESUMING frames.
+	let streamResumeProbe = $state<{ probeId: string; requestId: string } | null>(null);
+	let streamResumeAcknowledgedRequestId = $state<string | null>(null);
 	// SS-11: guard so we refresh the CSRF cookie at most once per reconnect cycle
 	// (a stale-token handshake 403 closes the socket before OPEN; refreshing once
 	// before the next attempt avoids a refresh-storm while still self-healing).
@@ -527,6 +536,11 @@ import {
 	// error bubble. Cleared when a connection succeeds or the component tears down.
 	let isReconnecting = $state(false);
 
+	function clearSocketResumeState() {
+		streamResumeProbe = null;
+		streamResumeAcknowledgedRequestId = null;
+	}
+
 	function closeSocket() {
 		connectionEpoch += 1;
 		if (reconnectTimer) {
@@ -549,6 +563,7 @@ import {
 		socketProjectId = null;
 		socketPromise = null;
 		socketPromiseProjectId = null;
+		clearSocketResumeState();
 	}
 
 	function handleSocketClose(event: Event) {
@@ -570,6 +585,7 @@ import {
 		socketProjectId = null;
 		socketPromise = null;
 		socketPromiseProjectId = null;
+		clearSocketResumeState();
 
 		// Clean up listeners on the closed socket
 		if (closedSocket) {
@@ -734,6 +750,7 @@ import {
 
 		const nextPromise = new Promise<WebSocket>((resolve, reject) => {
 			const onOpen = () => {
+				const reconnecting = reconnectAttempts > 0;
 				nextSocket.removeEventListener('error', onError);
 				if (
 					!isCurrentProjectContext(targetProjectId, targetEpoch) ||
@@ -758,6 +775,23 @@ import {
 				reconnectAttempts = 0; // Reset on successful connection
 				csrfRefreshedThisCycle = false; // Fresh cycle next time we need one
 				isReconnecting = false; // SS-10: silent reconnect succeeded
+				clearSocketResumeState();
+				if (reconnecting && isLoading && currentRequestId) {
+					const requestId = currentRequestId;
+					const probeId = generateId();
+					streamResumeProbe = { probeId, requestId };
+					try {
+						nextSocket.send(
+							JSON.stringify({
+								type: AgentMessageType.CF_AGENT_STREAM_RESUME_REQUEST,
+								probeId
+							})
+						);
+					} catch (error) {
+						streamResumeProbe = null;
+						console.error('Error requesting stream resume:', error);
+					}
+				}
 				resolve(nextSocket);
 			};
 
@@ -777,6 +811,7 @@ import {
 				if (socket === nextSocket) {
 					socket = null;
 					socketProjectId = null;
+					clearSocketResumeState();
 				}
 				reject(new Error('Unable to connect to the agent'));
 			};
@@ -1006,12 +1041,71 @@ import {
 				if (data.message) uiMessages = mergeUpdatedMessage(uiMessages, data.message);
 				scrollToBottom();
 				break;
-			case AgentMessageType.CF_AGENT_STREAM_RESUME_NONE:
-				expectingContinuation = false;
+			case AgentMessageType.SITE_STUDIO_CHAT_COMMITTED: {
+				const committed = parseSiteStudioChatCommittedFrame(data);
+				if (!committed || committed.requestId !== currentRequestId) {
+					break;
+				}
+
+				if (streamResumeProbe?.requestId === committed.requestId) {
+					streamResumeProbe = null;
+				}
+				settledRequestIds = new Set([...settledRequestIds, committed.requestId].slice(-8));
+				uiMessages = committed.messages;
+				historyLoadFailed = false;
+				// The commit is also the authoritative repair signal for mutations
+				// whose streamed tool output was malformed or never reached the UI.
+				onUpdate();
+				scrollToBottom();
 				resetRequestState();
 				break;
+			}
+			case AgentMessageType.CF_AGENT_STREAM_RESUME_NONE: {
+				const pendingResume = streamResumeProbe;
+				if (!pendingResume || currentRequestId !== pendingResume.requestId) {
+					break;
+				}
+				// The SDK omits probeId on some resume-none paths; reject only an
+				// explicitly present probe that belongs to another request.
+				if (data.probeId && data.probeId !== pendingResume.probeId) {
+					break;
+				}
+
+				streamResumeProbe = null;
+				settledRequestIds = new Set([...settledRequestIds, pendingResume.requestId].slice(-8));
+				expectingContinuation = false;
+				resetRequestState();
+				onUpdate();
+				const targetProjectId = projectId;
+				const targetEpoch = projectContextEpoch;
+				if (targetProjectId) {
+					void loadChatHistory(targetProjectId, targetEpoch);
+				}
+				break;
+			}
 			case AgentMessageType.CF_AGENT_STREAM_RESUMING: {
 				if (!data.id) break;
+				if (cancelledRequestIds.has(data.id)) {
+					if (streamResumeProbe?.requestId === data.id) {
+						streamResumeProbe = null;
+					}
+					settledRequestIds = new Set([...settledRequestIds, data.id].slice(-8));
+					try {
+						sendSocketMessage({
+							type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+							id: data.id
+						});
+					} catch (error) {
+						console.error('Error resending cancelled request:', error);
+					}
+					break;
+				}
+				if (settledRequestIds.has(data.id)) break;
+				if (streamResumeProbe?.requestId === data.id) {
+					streamResumeProbe = null;
+				}
+				if (streamResumeAcknowledgedRequestId === data.id) break;
+				streamResumeAcknowledgedRequestId = data.id;
 				const continuation = expectingContinuation;
 				expectingContinuation = false;
 				currentRequestId = data.id;
@@ -1030,7 +1124,7 @@ import {
 				if (!data.id) break;
 				// SS-9: drop frames for a request the user stopped. Without this a late
 				// frame would recreate activeStream below and resume appending text.
-				if (data.id && cancelledRequestIds.has(data.id)) {
+				if (cancelledRequestIds.has(data.id) || settledRequestIds.has(data.id)) {
 					break;
 				}
 
@@ -1075,7 +1169,14 @@ import {
 					if (activeStream) {
 						flushActiveStreamToMessages(activeStream);
 					}
-					resetRequestState();
+					if (data.error) {
+						settledRequestIds = new Set([...settledRequestIds, data.id].slice(-8));
+						resetRequestState();
+					} else {
+						// The post-persistence commit frame is the terminal authority. Keep
+						// the request id alive so a following commit can replace this partial
+						// stream even when the terminal chunk itself was invalid or missing.
+					}
 				}
 				break;
 			}
@@ -1157,6 +1258,7 @@ import {
 		// SS-9: remember the cancelled id so a late CF_AGENT_USE_CHAT_RESPONSE frame
 		// for it can't recreate activeStream and resume appending after the stop.
 		cancelledRequestIds.add(currentRequestId);
+		settledRequestIds = new Set([...settledRequestIds, currentRequestId].slice(-8));
 
 		try {
 			sendSocketMessage({

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -1127,7 +1127,6 @@ import {
 					break;
 				}
 				if (cancelledContinuationPending) {
-					cancelledContinuationPending = false;
 					cancelResumedRequest(data.id);
 					break;
 				}
@@ -1162,7 +1161,6 @@ import {
 					break;
 				}
 				if (cancelledContinuationPending) {
-					cancelledContinuationPending = false;
 					cancelResumedRequest(data.id);
 					break;
 				}

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -114,6 +114,8 @@ import {
 	let activeStream = $state<ActiveStreamMessage | null>(null);
 	let currentRequestId = $state<string | null>(null);
 	let expectingContinuation = $state(false);
+	let cancelledContinuationPending = $state(false);
+	let cancelTurnDeliveryPending = false;
 	let ignoreNextSocketClose = $state(false);
 	let requestStartedAt = $state<number | null>(null);
 	let clockNow = $state(Date.now());
@@ -269,6 +271,22 @@ import {
 		requestStartedAt = null;
 		toolStartTimes = {};
 		isReconnecting = false;
+	}
+
+	function cancelResumedRequest(requestId: string) {
+		if (streamResumeProbe?.requestId === requestId) {
+			streamResumeProbe = null;
+		}
+		cancelledRequestIds.add(requestId);
+		settledRequestIds = new Set([...settledRequestIds, requestId].slice(-8));
+		try {
+			sendSocketMessage({
+				type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+				id: requestId
+			});
+		} catch (error) {
+			console.error('Error resending cancelled request:', error);
+		}
 	}
 
 	function getRunningToolFromParts(parts: UIMessagePart[]): RunningToolState | null {
@@ -493,6 +511,7 @@ import {
 			id: requestId,
 			messageId: lastAssistant?.id || generateId(),
 			continuation,
+			hadError: false,
 			parts: lastAssistant ? cloneParts(lastAssistant.parts) : []
 		};
 		if (lastAssistant?.metadata) stream.metadata = { ...lastAssistant.metadata };
@@ -776,6 +795,13 @@ import {
 				csrfRefreshedThisCycle = false; // Fresh cycle next time we need one
 				isReconnecting = false; // SS-10: silent reconnect succeeded
 				clearSocketResumeState();
+				try {
+					flushPendingTurnCancellation(nextSocket);
+				} catch (error) {
+					// Keep the marker pending. prepareSocketForModelTurn retries it before
+					// any new model request can use this connection.
+					console.error('Error stopping pending agent turn:', error);
+				}
 				if (reconnecting && isLoading && currentRequestId) {
 					const requestId = currentRequestId;
 					const probeId = generateId();
@@ -886,6 +912,12 @@ import {
 		socket.send(JSON.stringify(payload));
 	}
 
+	function flushPendingTurnCancellation(targetSocket: WebSocket) {
+		if (!cancelTurnDeliveryPending || targetSocket.readyState !== WebSocket.OPEN) return;
+		targetSocket.send(JSON.stringify({ type: AgentMessageType.SITE_STUDIO_CANCEL_TURN }));
+		cancelTurnDeliveryPending = false;
+	}
+
 	async function refreshAgentCredential(targetProjectId: string, targetEpoch: number): Promise<void> {
 		const response = await apiResponseFetch(
 			resolvePath(`/api/agents/site-builder/${targetProjectId}/refresh-credential`),
@@ -904,6 +936,7 @@ import {
 		targetEpoch: number
 	): Promise<WebSocket> {
 		const ws = await ensureSocket(targetProjectId, targetEpoch);
+		flushPendingTurnCancellation(ws);
 		await refreshAgentCredential(targetProjectId, targetEpoch);
 		if (
 			!isCurrentProjectContext(targetProjectId, targetEpoch) ||
@@ -933,6 +966,9 @@ import {
 		isLoading = true;
 		activeStream = null;
 		expectingContinuation = false;
+		// Any pending server-side turn reset was sent before this request. From
+		// here, request identity rejects late frames from the cancelled successor.
+		cancelledContinuationPending = false;
 		// SS-9: a genuinely new request starts fresh; drop stale cancellation markers.
 		cancelledRequestIds = new Set();
 
@@ -957,6 +993,7 @@ import {
 		}
 
 		if (chunk.type === 'error') {
+			activeStream.hadError = true;
 			activeStream.parts.push({ type: 'text', text: chunk.errorText, state: 'done' });
 			flushActiveStreamToMessages(activeStream);
 			return;
@@ -1086,18 +1123,15 @@ import {
 			case AgentMessageType.CF_AGENT_STREAM_RESUMING: {
 				if (!data.id) break;
 				if (cancelledRequestIds.has(data.id)) {
-					if (streamResumeProbe?.requestId === data.id) {
-						streamResumeProbe = null;
-					}
-					settledRequestIds = new Set([...settledRequestIds, data.id].slice(-8));
-					try {
-						sendSocketMessage({
-							type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
-							id: data.id
-						});
-					} catch (error) {
-						console.error('Error resending cancelled request:', error);
-					}
+					cancelResumedRequest(data.id);
+					break;
+				}
+				if (cancelledContinuationPending) {
+					cancelledContinuationPending = false;
+					cancelResumedRequest(data.id);
+					break;
+				}
+				if (!expectingContinuation && currentRequestId && data.id !== currentRequestId) {
 					break;
 				}
 				if (settledRequestIds.has(data.id)) break;
@@ -1124,13 +1158,27 @@ import {
 				if (!data.id) break;
 				// SS-9: drop frames for a request the user stopped. Without this a late
 				// frame would recreate activeStream below and resume appending text.
-				if (cancelledRequestIds.has(data.id) || settledRequestIds.has(data.id)) {
+				if (cancelledRequestIds.has(data.id)) {
+					break;
+				}
+				if (cancelledContinuationPending) {
+					cancelledContinuationPending = false;
+					cancelResumedRequest(data.id);
+					break;
+				}
+				if (!expectingContinuation && currentRequestId && data.id !== currentRequestId) {
+					break;
+				}
+				if (settledRequestIds.has(data.id)) {
 					break;
 				}
 
 				if (!activeStream || activeStream.id !== data.id) {
 					const continuation = data.continuation === true || expectingContinuation;
 					activeStream = createStreamState(data.id, continuation);
+				}
+				if (data.error && activeStream) {
+					activeStream.hadError = true;
 				}
 
 				if (data.body?.trim()) {
@@ -1165,11 +1213,11 @@ import {
 					}
 				}
 
-				if (data.done || data.error) {
+				if (data.done) {
 					if (activeStream) {
 						flushActiveStreamToMessages(activeStream);
 					}
-					if (data.error) {
+					if (activeStream?.hadError) {
 						settledRequestIds = new Set([...settledRequestIds, data.id].slice(-8));
 						resetRequestState();
 					} else {
@@ -1226,6 +1274,8 @@ import {
 		previousProjectId = targetProjectId;
 		input = '';
 		attachedFile = null;
+		cancelledContinuationPending = false;
+		cancelTurnDeliveryPending = false;
 		resetRequestState();
 		uiMessages = [];
 		closeSocket();
@@ -1249,24 +1299,39 @@ import {
 	});
 
 	function stopRequest() {
-		if (!currentRequestId) {
+		if (!currentRequestId && !expectingContinuation) {
 			return;
 		}
 		requestPreparationSequence += 1;
 		isPreparingRequest = false;
+		const stoppedRequestId = currentRequestId;
+		const wasAwaitingContinuation = expectingContinuation;
 
 		// SS-9: remember the cancelled id so a late CF_AGENT_USE_CHAT_RESPONSE frame
 		// for it can't recreate activeStream and resume appending after the stop.
-		cancelledRequestIds.add(currentRequestId);
-		settledRequestIds = new Set([...settledRequestIds, currentRequestId].slice(-8));
+		if (stoppedRequestId) {
+			cancelledRequestIds.add(stoppedRequestId);
+			settledRequestIds = new Set([...settledRequestIds, stoppedRequestId].slice(-8));
+		}
+		cancelledContinuationPending = wasAwaitingContinuation;
+		cancelTurnDeliveryPending = true;
 
 		try {
-			sendSocketMessage({
-				type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
-				id: currentRequestId
-			});
+			if (socket) flushPendingTurnCancellation(socket);
 		} catch (error) {
-			console.error('Error stopping request:', error);
+			// A reconnect will send the turn reset before any new request.
+			console.error('Error stopping agent turn:', error);
+		}
+
+		if (stoppedRequestId) {
+			try {
+				sendSocketMessage({
+					type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+					id: stoppedRequestId
+				});
+			} catch (error) {
+				console.error('Error stopping request:', error);
+			}
 		}
 
 		resetRequestState();

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -1082,6 +1082,7 @@ import {
 				if (currentRequestId) {
 					settledRequestIds = new Set([...settledRequestIds, currentRequestId].slice(-8));
 				}
+				cancelledContinuationPending = cancelledContinuationPending || expectingContinuation;
 				resetRequestState();
 				break;
 			case AgentMessageType.SITE_STUDIO_CHAT_COMMITTED: {

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -129,7 +129,7 @@ import {
 	// A reconnect probe belongs to one socket and one pending request. The server
 	// echoes its probe id on STREAM_RESUME_NONE; the acknowledged id suppresses
 	// duplicate proactive and probe-triggered STREAM_RESUMING frames.
-	let streamResumeProbe = $state<{ probeId: string; requestId: string } | null>(null);
+	let streamResumeProbe = $state<{ probeId: string; requestId: string | null } | null>(null);
 	let streamResumeAcknowledgedRequestId = $state<string | null>(null);
 	// SS-11: guard so we refresh the CSRF cookie at most once per reconnect cycle
 	// (a stale-token handshake 403 closes the socket before OPEN; refreshing once
@@ -268,6 +268,7 @@ import {
 		currentRequestId = null;
 		activeStream = null;
 		expectingContinuation = false;
+		streamResumeProbe = null;
 		requestStartedAt = null;
 		toolStartTimes = {};
 		isReconnecting = false;
@@ -802,7 +803,7 @@ import {
 					// any new model request can use this connection.
 					console.error('Error stopping pending agent turn:', error);
 				}
-				if (reconnecting && isLoading && currentRequestId) {
+				if (reconnecting && isLoading && (currentRequestId || expectingContinuation)) {
 					const requestId = currentRequestId;
 					const probeId = generateId();
 					streamResumeProbe = { probeId, requestId };
@@ -1104,6 +1105,22 @@ import {
 				resetRequestState();
 				break;
 			}
+			case AgentMessageType.CF_AGENT_STREAM_PENDING: {
+				const pendingResume = streamResumeProbe;
+				if (!pendingResume) break;
+				// @cloudflare/ai-chat 0.9.3 omits probeId when forwarding the
+				// request. Reject only an explicitly different correlation.
+				if (data.probeId && data.probeId !== pendingResume.probeId) break;
+				// A queued request from another tab can be the SDK's latest pending
+				// id. Keep this tab's known request; adopt the id only when waiting
+				// for a continuation whose successor was not known yet.
+				const requestId = pendingResume.requestId ?? data.id ?? null;
+				if (pendingResume.requestId === null && data.id) currentRequestId = data.id;
+				// Pending is not terminal. The SDK resolves this same handshake with
+				// STREAM_RESUMING or STREAM_RESUME_NONE, so retain its correlation.
+				streamResumeProbe = { ...pendingResume, requestId };
+				break;
+			}
 			case AgentMessageType.CF_AGENT_STREAM_RESUME_NONE: {
 				const pendingResume = streamResumeProbe;
 				if (!pendingResume || currentRequestId !== pendingResume.requestId) {
@@ -1116,7 +1133,9 @@ import {
 				}
 
 				streamResumeProbe = null;
-				settledRequestIds = new Set([...settledRequestIds, pendingResume.requestId].slice(-8));
+				if (pendingResume.requestId) {
+					settledRequestIds = new Set([...settledRequestIds, pendingResume.requestId].slice(-8));
+				}
 				expectingContinuation = false;
 				resetRequestState();
 				onUpdate();
@@ -1137,11 +1156,19 @@ import {
 					cancelResumedRequest(data.id);
 					break;
 				}
-				if (!expectingContinuation && currentRequestId && data.id !== currentRequestId) {
+				// A live resume probe is parked on the SDK's pre-stream queue, not
+				// bound to one request. If this tab's request settles without a stream,
+				// the next accepted request can legitimately resume this connection.
+				if (
+					!streamResumeProbe &&
+					!expectingContinuation &&
+					currentRequestId &&
+					data.id !== currentRequestId
+				) {
 					break;
 				}
 				if (settledRequestIds.has(data.id)) break;
-				if (streamResumeProbe?.requestId === data.id) {
+				if (streamResumeProbe) {
 					streamResumeProbe = null;
 				}
 				if (streamResumeAcknowledgedRequestId === data.id) break;

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -968,6 +968,9 @@ describe('AgentChat', () => {
 				.map((raw) => JSON.parse(raw))
 				.filter((message) => message.type === AgentMessageType.SITE_STUDIO_CANCEL_TURN)
 		).toHaveLength(1);
+		ws.serverMessage({ type: AgentMessageType.SITE_STUDIO_CHAT_CANCELLED });
+		await settle();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
 
 		const successorId = 'continuation-stream';
 		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: successorId });
@@ -1024,6 +1027,22 @@ describe('AgentChat', () => {
 		expect(screen.queryByText('stale after new request')).not.toBeInTheDocument();
 		screen.getByTitle('Stop request').click();
 		await settle();
+	});
+
+	it('clears an active view when the project turn is stopped in another tab', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('work in this tab');
+		await settle();
+		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
+
+		ws.serverMessage({ type: AgentMessageType.SITE_STUDIO_CHAT_CANCELLED });
+		await settle();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
 	});
 
 	// SS-9: after the user hits Stop, a late CF_AGENT_USE_CHAT_RESPONSE frame for the

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -15,6 +15,8 @@ interface AgentChatTestProps {
 interface FakeSocketMessage {
 	type: string;
 	id?: string;
+	requestId?: string;
+	probeId?: string;
 	messages?: UIChatMessage[];
 	body?: string;
 	done?: boolean;
@@ -498,6 +500,65 @@ describe('AgentChat', () => {
 		expect(screen.getByText('Hello, world')).toBeInTheDocument();
 	});
 
+	it('repairs a malformed stream with the matching persisted commit without reload', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('run the project edits');
+		await settle();
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({
+				type: 'tool-input-available',
+				toolCallId: 'tool-1',
+				toolName: 'codemode',
+				input: { code: 'return {}' }
+			})
+		});
+		// This malformed provider/output chunk is dropped and no terminal frame
+		// arrives. The commit below is the repair authority.
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: 'data: not-json\n\n'
+		});
+		await settle();
+
+		const committed: UIChatMessage[] = [
+			{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'run the project edits' }] },
+			{
+				id: 'assistant-1',
+				role: 'assistant',
+				parts: [{
+					type: 'tool-codemode',
+					toolCallId: 'tool-1',
+					toolName: 'codemode',
+					state: 'output-available',
+					input: { code: 'return {}' },
+					output: { ok: true, changedFiles: ['index.html'] }
+				}]
+			}
+		];
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId: request.id,
+			messages: committed
+		});
+		await settle();
+
+		expect(screen.getByText('Finished')).toBeInTheDocument();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+	});
+
 	it('refreshes the editor after a generated image is saved', async () => {
 		const { component, onUpdate } = renderExposed();
 		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
@@ -618,6 +679,7 @@ describe('AgentChat', () => {
 		expect(
 			screen.getByText('Something went wrong while generating this response.')
 		).toBeInTheDocument();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
 		warn.mockRestore();
 	});
 
@@ -894,6 +956,84 @@ describe('AgentChat', () => {
 		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
 	});
 
+	it('resends cancellation when a stopped request resumes after disconnect', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+		let ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('build something');
+		await settle();
+		const oldRequestId: string = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST).id;
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: oldRequestId,
+			body: JSON.stringify({ type: 'text-start', id: 'old-text' })
+		});
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: oldRequestId,
+			body: JSON.stringify({ type: 'text-delta', id: 'old-text', delta: 'Before disconnect' })
+		});
+		await settle();
+		expect(screen.getByText('Before disconnect')).toBeInTheDocument();
+
+		vi.useFakeTimers();
+		try {
+			ws.serverClose();
+			flushSync();
+			screen.getByTitle('Stop request').click();
+			await settle();
+			expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+
+			await vi.advanceTimersByTimeAsync(1000);
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+			ws = FakeWebSocket.last();
+			ws.open();
+			await settle();
+			ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: oldRequestId });
+			await settle();
+
+			const cancelFrames = ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter((message) => message.type === AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL);
+			expect(cancelFrames).toHaveLength(1);
+			expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+			ws.serverMessage({
+				type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+				id: oldRequestId,
+				body: JSON.stringify({ type: 'text-delta', id: 'old-text', delta: ' stale old stream' })
+			});
+			await settle();
+			expect(screen.queryByText(/stale old stream/)).not.toBeInTheDocument();
+		} finally {
+			vi.useRealTimers();
+		}
+
+		await component.sendPrompt('new task');
+		await settle();
+		const newRequestFrames = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.filter((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(newRequestFrames).toHaveLength(1);
+		const newRequestId: string = newRequestFrames[0].id;
+		expect(newRequestId).not.toBe(oldRequestId);
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: oldRequestId,
+			body: JSON.stringify({ type: 'text-delta', id: 'old-text', delta: ' stale after new request' })
+		});
+		await settle();
+		expect(screen.queryByText(/stale after new request/)).not.toBeInTheDocument();
+		screen.getByTitle('Stop request').click();
+		await settle();
+	});
+
 	// SS-11: a stale-CSRF handshake closes the socket before OPEN; the reconnect
 	// must force a fresh /api/csrf round-trip so the next handshake uses a new token,
 	// and must not infinite-loop.
@@ -1112,6 +1252,86 @@ describe('AgentChat', () => {
 
 		// There is no retry budget to exhaust while this project remains active.
 		expect(screen.queryByText(/The response was interrupted/)).not.toBeInTheDocument();
+	});
+
+	it('reconciles a pending turn when reconnect resume reports no active stream', async () => {
+		let historyGets = 0;
+		fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+			const url = requestUrl(input);
+			if (url.endsWith('/api/csrf')) {
+				document.cookie = 'cail_csrf_sitestudio=test-csrf-token';
+				return new Response(null, { status: 204 });
+			}
+			if (url.endsWith('/get-messages')) {
+				historyGets += 1;
+				const history: UIChatMessage[] =
+					historyGets === 1
+						? []
+						: [{ id: 'finished', role: 'assistant', parts: [{ type: 'text', text: 'Finished' }] }];
+				return new Response(JSON.stringify(history), { status: 200 });
+			}
+			return new Response('[]', { status: 200 });
+		});
+
+		const { component, onUpdate } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+		let ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+		const initialHistoryGets = historyGets;
+
+		await component.sendPrompt('do a big task');
+		await settle();
+		const requestFrame = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(requestFrame).toBeTruthy();
+		const requestId: string = requestFrame.id;
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: requestId,
+			body: JSON.stringify({ type: 'tool-input-start', toolCallId: 'tool-1', toolName: 'write_file' })
+		});
+		await settle();
+		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
+
+		vi.useFakeTimers();
+		try {
+			ws.serverClose();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(1000);
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+			expect(FakeWebSocket.instances.length).toBe(2);
+
+			ws = FakeWebSocket.last();
+			ws.open();
+			await settle();
+			const resumeRequests = ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter((message) => message.type === AgentMessageType.CF_AGENT_STREAM_RESUME_REQUEST);
+			expect(resumeRequests).toHaveLength(1);
+			expect(historyGets).toBe(initialHistoryGets);
+			expect(resumeRequests[0].probeId).toEqual(expect.any(String));
+		} finally {
+			vi.useRealTimers();
+		}
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_STREAM_RESUME_NONE,
+			probeId: 'different-probe'
+		});
+		await settle();
+		expect(historyGets).toBe(initialHistoryGets);
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_STREAM_RESUME_NONE
+		});
+		await waitFor(() => expect(screen.getByText('Finished')).toBeInTheDocument());
+		expect(historyGets).toBe(initialHistoryGets + 1);
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+		expect(onUpdate).toHaveBeenCalledTimes(1);
 	});
 
 	it('schedules a reconnect with backoff after an unexpected socket close', async () => {

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -993,6 +993,19 @@ describe('AgentChat', () => {
 		await settle();
 		expect(screen.queryByText('stale continuation')).not.toBeInTheDocument();
 
+		const laterSuccessorId = 'later-continuation-stream';
+		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: laterSuccessorId });
+		await settle();
+		expect(
+			ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter(
+					(message) =>
+						message.type === AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL &&
+						message.id === laterSuccessorId
+				)
+		).toHaveLength(1);
+
 		await component.sendPrompt('new task');
 		await settle();
 		const requestFrames = ws.sent

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -1029,7 +1029,7 @@ describe('AgentChat', () => {
 		await settle();
 	});
 
-	it('clears an active view when the project turn is stopped in another tab', async () => {
+	it('clears and suppresses a pending continuation stopped in another tab', async () => {
 		const { component } = renderExposed();
 		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
 		const ws = FakeWebSocket.last();
@@ -1038,11 +1038,61 @@ describe('AgentChat', () => {
 
 		await component.sendPrompt('work in this tab');
 		await settle();
+		const requestId: string = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST).id;
+		const questionPart = {
+			type: 'tool-ask_user_question' as const,
+			toolCallId: 'other-tab-question',
+			toolName: 'ask_user_question',
+			state: 'input-available' as const,
+			input: { question: 'Continue?', options: ['Yes'] }
+		};
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: requestId,
+			body: JSON.stringify({
+				type: 'tool-input-available',
+				toolCallId: questionPart.toolCallId,
+				toolName: questionPart.toolName,
+				input: questionPart.input
+			})
+		});
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId,
+			messages: [
+				{ id: 'other-tab-user', role: 'user', parts: [{ type: 'text', text: 'work in this tab' }] },
+				{ id: 'other-tab-assistant', role: 'assistant', parts: [questionPart] }
+			]
+		});
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument());
+		screen.getByRole('button', { name: 'Skip' }).click();
+		await waitFor(() =>
+			expect(
+				ws.sent.map((raw) => JSON.parse(raw)).filter(
+					(message) => message.type === AgentMessageType.CF_AGENT_TOOL_RESULT
+				)
+			).toHaveLength(1)
+		);
 		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
 
 		ws.serverMessage({ type: AgentMessageType.SITE_STUDIO_CHAT_CANCELLED });
 		await settle();
 		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+
+		const lateSuccessorId = 'other-tab-late-successor';
+		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: lateSuccessorId });
+		await settle();
+		expect(
+			ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter(
+					(message) =>
+						message.type === AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL &&
+						message.id === lateSuccessorId
+				)
+		).toHaveLength(1);
 	});
 
 	// SS-9: after the user hits Stop, a late CF_AGENT_USE_CHAT_RESPONSE frame for the

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -1486,12 +1486,40 @@ describe('AgentChat', () => {
 			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
 		expect(requestFrame).toBeTruthy();
 		const requestId: string = requestFrame.id;
+		const pendingQuestion = {
+			type: 'tool-ask_user_question' as const,
+			toolCallId: 'reconnect-question',
+			toolName: 'ask_user_question',
+			state: 'input-available' as const,
+			input: { question: 'Continue after reconnect?', options: ['Yes'] }
+		};
 		ws.serverMessage({
 			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
 			id: requestId,
-			body: JSON.stringify({ type: 'tool-input-start', toolCallId: 'tool-1', toolName: 'write_file' })
+			body: JSON.stringify({
+				type: 'tool-input-available',
+				toolCallId: pendingQuestion.toolCallId,
+				toolName: pendingQuestion.toolName,
+				input: pendingQuestion.input
+			})
 		});
-		await settle();
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId,
+			messages: [
+				{ id: 'reconnect-user', role: 'user', parts: [{ type: 'text', text: 'do a big task' }] },
+				{ id: 'reconnect-assistant', role: 'assistant', parts: [pendingQuestion] }
+			]
+		});
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument());
+		screen.getByRole('button', { name: 'Skip' }).click();
+		await waitFor(() =>
+			expect(
+				ws.sent.map((raw) => JSON.parse(raw)).filter(
+					(message) => message.type === AgentMessageType.CF_AGENT_TOOL_RESULT
+				)
+			).toHaveLength(1)
+		);
 		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
 
 		vi.useFakeTimers();
@@ -1513,6 +1541,13 @@ describe('AgentChat', () => {
 			expect(resumeRequests).toHaveLength(1);
 			expect(historyGets).toBe(initialHistoryGets);
 			expect(resumeRequests[0].probeId).toEqual(expect.any(String));
+
+			ws.serverMessage({
+				type: AgentMessageType.CF_AGENT_STREAM_PENDING,
+				id: 'pending-successor'
+			});
+			await settle();
+			expect(screen.getByTitle('Stop request')).toBeInTheDocument();
 		} finally {
 			vi.useRealTimers();
 		}
@@ -1530,7 +1565,100 @@ describe('AgentChat', () => {
 		await waitFor(() => expect(screen.getByText('Finished')).toBeInTheDocument());
 		expect(historyGets).toBe(initialHistoryGets + 1);
 		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
-		expect(onUpdate).toHaveBeenCalledTimes(1);
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+	});
+
+	it('ignores a pending resume frame that arrives after Stop and a fresh request', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+		let ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('first request');
+		await settle();
+		const firstRequest = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(firstRequest).toBeTruthy();
+
+		vi.useFakeTimers();
+		try {
+			ws.serverClose();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(1000);
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+			ws = FakeWebSocket.last();
+			ws.open();
+			await settle();
+			expect(
+				ws.sent
+					.map((raw) => JSON.parse(raw))
+					.filter((message) => message.type === AgentMessageType.CF_AGENT_STREAM_RESUME_REQUEST)
+			).toHaveLength(1);
+		} finally {
+			vi.useRealTimers();
+		}
+
+		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_PENDING, id: 'other-tab-request' });
+		await settle();
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_STREAM_RESUMING,
+			id: 'other-tab-request'
+		});
+		await settle();
+		expect(
+			ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter(
+					(message) =>
+						message.type === AgentMessageType.CF_AGENT_STREAM_RESUME_ACK &&
+						message.id === 'other-tab-request'
+				)
+		).toHaveLength(1);
+
+		vi.useFakeTimers();
+		try {
+			ws.serverClose();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(1000);
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+			ws = FakeWebSocket.last();
+			ws.open();
+			await settle();
+		} finally {
+			vi.useRealTimers();
+		}
+
+		screen.getByTitle('Stop request').click();
+		await settle();
+		expect(
+			ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter(
+					(message) =>
+						message.type === AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL &&
+						message.id === 'other-tab-request'
+				)
+		).toHaveLength(1);
+		await component.sendPrompt('fresh request');
+		await settle();
+		const freshRequest = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.filter((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST)
+			.at(-1);
+
+		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_PENDING, id: 'stale-request' });
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: freshRequest.id,
+			body: JSON.stringify({ type: 'text-delta', id: 'fresh-text', delta: 'fresh response' })
+		});
+		await waitFor(() => expect(screen.getByText('fresh response')).toBeInTheDocument());
 	});
 
 	it('schedules a reconnect with backoff after an unexpected socket close', async () => {

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -853,6 +853,9 @@ describe('AgentChat', () => {
 		await component.sendPrompt('hello');
 		await settle();
 		expect(refreshCount).toBe(1);
+		const initialRequestId: string = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST).id;
 		expect(events.indexOf('refresh-1')).toBeLessThan(events.indexOf(`ws-${AgentMessageType.CF_AGENT_USE_CHAT_REQUEST}`));
 
 		function questionFrame(id: string, toolCallId: string) {
@@ -868,7 +871,7 @@ describe('AgentChat', () => {
 			});
 		}
 
-		questionFrame('stream-1', 'tool-1');
+		questionFrame(initialRequestId, 'tool-1');
 		await waitFor(() => expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument());
 		const skipButton = screen.getByRole('button', { name: 'Skip' });
 		skipButton.click();
@@ -899,6 +902,115 @@ describe('AgentChat', () => {
 		expect(events.indexOf('refresh-2')).toBeLessThan(toolResultEvents[0]);
 		expect(events.indexOf('refresh-3')).toBeLessThan(toolResultEvents[1]);
 		expect(events.indexOf('refresh-3')).toBeGreaterThan(events.indexOf('refresh-2'));
+	});
+
+	it('cancels a successor after stopping before a tool continuation resumes', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('answer a question');
+		await settle();
+		const initialRequest = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(initialRequest).toBeTruthy();
+		const initialRequestId: string = initialRequest.id;
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: initialRequestId,
+			body: JSON.stringify({
+				type: 'tool-input-available',
+				toolCallId: 'question-1',
+				toolName: 'ask_user_question',
+				input: { question: 'Pick a path', options: ['A', 'B'] }
+			})
+		});
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId: initialRequestId,
+			messages: [
+				{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'answer a question' }] },
+				{
+					id: 'assistant-1',
+					role: 'assistant',
+					parts: [
+						{
+							type: 'tool-ask_user_question',
+							toolCallId: 'question-1',
+							toolName: 'ask_user_question',
+							state: 'input-available',
+							input: { question: 'Pick a path', options: ['A', 'B'] }
+						}
+					]
+				}
+			]
+		});
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument());
+		screen.getByRole('button', { name: 'Skip' }).click();
+		await waitFor(() =>
+			expect(
+				ws.sent.map((raw) => JSON.parse(raw)).filter(
+					(message) => message.type === AgentMessageType.CF_AGENT_TOOL_RESULT
+				)
+			).toHaveLength(1)
+		);
+		await settle();
+
+		screen.getByTitle('Stop request').click();
+		await settle();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+		expect(
+			ws.sent
+				.map((raw) => JSON.parse(raw))
+				.filter((message) => message.type === AgentMessageType.SITE_STUDIO_CANCEL_TURN)
+		).toHaveLength(1);
+
+		const successorId = 'continuation-stream';
+		ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: successorId });
+		await settle();
+		const successorMessages = ws.sent.map((raw) => JSON.parse(raw));
+		expect(
+			successorMessages.filter(
+				(message) =>
+					message.type === AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL && message.id === successorId
+			)
+		).toHaveLength(1);
+		expect(
+			successorMessages.filter(
+				(message) => message.type === AgentMessageType.CF_AGENT_STREAM_RESUME_ACK && message.id === successorId
+			)
+		).toHaveLength(0);
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: successorId,
+			body: JSON.stringify({ type: 'text-delta', id: 'stale', delta: 'stale continuation' })
+		});
+		await settle();
+		expect(screen.queryByText('stale continuation')).not.toBeInTheDocument();
+
+		await component.sendPrompt('new task');
+		await settle();
+		const requestFrames = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.filter((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(requestFrames).toHaveLength(2);
+		expect(requestFrames[1].id).not.toBe(successorId);
+		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: successorId,
+			body: JSON.stringify({ type: 'text-delta', id: 'stale', delta: 'stale after new request' })
+		});
+		await settle();
+		expect(screen.queryByText('stale after new request')).not.toBeInTheDocument();
+		screen.getByTitle('Stop request').click();
+		await settle();
 	});
 
 	// SS-9: after the user hits Stop, a late CF_AGENT_USE_CHAT_RESPONSE frame for the
@@ -996,6 +1108,11 @@ describe('AgentChat', () => {
 			ws = FakeWebSocket.last();
 			ws.open();
 			await settle();
+			expect(
+				ws.sent
+					.map((raw) => JSON.parse(raw))
+					.filter((message) => message.type === AgentMessageType.SITE_STUDIO_CANCEL_TURN)
+			).toHaveLength(1);
 			ws.serverMessage({ type: AgentMessageType.CF_AGENT_STREAM_RESUMING, id: oldRequestId });
 			await settle();
 


### PR DESCRIPTION
Repairs the live chat lifecycle at the persistence boundary. The server broadcasts the canonical persisted transcript for a completed turn, while the client keeps request ownership until that commit arrives. Reconnects use the pinned Cloudflare Agents resume protocol and fall back to persisted history when no stream remains. Cancellation remains isolated across disconnects and later requests.\n\nLocal lint, focused chat/reconnect tests, and diff checks pass. Fresh-package CI is authoritative for the full repository gate.