### PR TITLE
Fix Site Studio UI stream lifecycle handling

### DIFF
--- a/packages/frontend/src/lib/agents/chat.test.ts
+++ b/packages/frontend/src/lib/agents/chat.test.ts
@@ -4,6 +4,7 @@ import {
 	mergeUpdatedMessage,
 	cloneParts,
 	isToolPart,
+	parseUIStreamChunk,
 	type UIMessagePart,
 	type UIToolPart,
 	type UITextPart,
@@ -126,17 +127,19 @@ describe('applyChunkToParts — tool input lifecycle', () => {
 		]);
 	});
 
-	it('tool-input-delta updates input on the matching tool part', () => {
+	it('tool-input-delta accumulates official JSON text fragments', () => {
 		const parts: UIMessagePart[] = [
 			{ type: 'tool-codemode', toolCallId: 'c1', toolName: 'codemode', state: 'input-streaming' }
 		];
-		applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'c1', input: { code: 'x' } });
+		applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'c1', inputTextDelta: '{"co' });
+		expect(toolPart(parts, 'c1').input).toBe('{"co');
+		applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'c1', inputTextDelta: 'de":"x"}' });
 		expect(toolPart(parts, 'c1').input).toEqual({ code: 'x' });
 	});
 
 	it('tool-input-delta for an unknown call id is a handled no-op', () => {
 		const parts: UIMessagePart[] = [];
-		const handled = applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'nope', input: {} });
+		const handled = applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'nope', inputTextDelta: '{}' });
 		expect(handled).toBe(true);
 		expect(parts).toEqual([]);
 	});
@@ -157,6 +160,30 @@ describe('applyChunkToParts — tool input lifecycle', () => {
 		expect(tp.input).toEqual({ code: 'run()' });
 		expect(tp.title).toBe('Final');
 		expect(parts).toHaveLength(1);
+	});
+
+	it('tool-input-available does not regress a settled tool part', () => {
+		const parts: UIMessagePart[] = [
+			{
+				type: 'tool-codemode',
+				toolCallId: 'c1',
+				toolName: 'codemode',
+				state: 'output-available',
+				input: { code: 'run()' },
+				output: { ok: true }
+			}
+		];
+		applyChunkToParts(parts, {
+			type: 'tool-input-available',
+			toolCallId: 'c1',
+			toolName: 'codemode',
+			input: { code: 'replayed()' }
+		});
+		expect(toolPart(parts, 'c1')).toMatchObject({
+			state: 'output-available',
+			input: { code: 'run()' },
+			output: { ok: true }
+		});
 	});
 
 	it('tool-input-available creates a new part when the call id is unseen', () => {
@@ -211,6 +238,31 @@ describe('applyChunkToParts — tool input lifecycle', () => {
 		expect(tp.state).toBe('output-error');
 		expect(tp.errorText).toBe('nope');
 	});
+
+	it('tool-input-error does not overwrite a settled output', () => {
+		const parts: UIMessagePart[] = [
+			{
+				type: 'tool-codemode',
+				toolCallId: 'c1',
+				toolName: 'codemode',
+				state: 'output-available',
+				input: { code: 'run()' },
+				output: { ok: true }
+			}
+		];
+		applyChunkToParts(parts, {
+			type: 'tool-input-error',
+			toolCallId: 'c1',
+			toolName: 'codemode',
+			input: { code: 'bad()' },
+			errorText: 'late error'
+		});
+		expect(toolPart(parts, 'c1')).toMatchObject({
+			state: 'output-available',
+			input: { code: 'run()' },
+			output: { ok: true }
+		});
+	});
 });
 
 describe('applyChunkToParts — tool approval + output lifecycle', () => {
@@ -263,6 +315,57 @@ describe('applyChunkToParts — tool approval + output lifecycle', () => {
 		expect(tp.errorText).toBe('failed');
 	});
 
+	it('the first terminal output wins when a replay changes success into an error', () => {
+		const parts = seededToolPart();
+		applyChunkToParts(parts, { type: 'tool-output-available', toolCallId: 'c1', output: { ok: true } });
+		applyChunkToParts(parts, { type: 'tool-output-error', toolCallId: 'c1', errorText: 'late failure' });
+		expect(toolPart(parts, 'c1')).toMatchObject({ state: 'output-available', output: { ok: true } });
+	});
+
+	it('the first terminal output wins when a replay changes an error into success', () => {
+		const parts = seededToolPart();
+		applyChunkToParts(parts, { type: 'tool-output-error', toolCallId: 'c1', errorText: 'first failure' });
+		applyChunkToParts(parts, { type: 'tool-output-available', toolCallId: 'c1', output: { ok: true } });
+		expect(toolPart(parts, 'c1')).toMatchObject({ state: 'output-error', errorText: 'first failure' });
+	});
+
+	it('a preliminary output can be replaced by the final output', () => {
+		const parts = seededToolPart();
+		applyChunkToParts(parts, {
+			type: 'tool-output-available',
+			toolCallId: 'c1',
+			output: { phase: 'working' },
+			preliminary: true
+		});
+		applyChunkToParts(parts, { type: 'tool-output-available', toolCallId: 'c1', output: { ok: true } });
+		expect(toolPart(parts, 'c1')).toMatchObject({ state: 'output-available', output: { ok: true } });
+		expect(toolPart(parts, 'c1').preliminary).toBeUndefined();
+	});
+
+	it('a preliminary output can be replaced by a final error', () => {
+		const parts = seededToolPart();
+		applyChunkToParts(parts, {
+			type: 'tool-output-available',
+			toolCallId: 'c1',
+			output: { phase: 'working' },
+			preliminary: true
+		});
+		applyChunkToParts(parts, { type: 'tool-output-error', toolCallId: 'c1', errorText: 'final failure' });
+		expect(toolPart(parts, 'c1')).toMatchObject({ state: 'output-error', errorText: 'final failure' });
+	});
+
+	it('a preliminary output can be replaced by an explicit denial', () => {
+		const parts = seededToolPart();
+		applyChunkToParts(parts, {
+			type: 'tool-output-available',
+			toolCallId: 'c1',
+			output: { phase: 'working' },
+			preliminary: true
+		});
+		applyChunkToParts(parts, { type: 'tool-output-denied', toolCallId: 'c1' });
+		expect(toolPart(parts, 'c1').state).toBe('output-denied');
+	});
+
 	it('tool-output-denied sets output-denied state', () => {
 		const parts = seededToolPart();
 		applyChunkToParts(parts, { type: 'tool-output-denied', toolCallId: 'c1' });
@@ -279,11 +382,99 @@ describe('applyChunkToParts — tool approval + output lifecycle', () => {
 });
 
 describe('applyChunkToParts — step markers, data parts, unknown chunks', () => {
+	it('parses the AI SDK v6 finish-step and file wire chunks', () => {
+		expect(parseUIStreamChunk('{"type":"finish-step"}')).toEqual({ type: 'finish-step' });
+		expect(parseUIStreamChunk('{"type":"file","mediaType":"text/plain","url":"data:text/plain,ok"}')).toEqual({
+			type: 'file',
+			mediaType: 'text/plain',
+			url: 'data:text/plain,ok'
+		});
+	});
+
 	it('start-step and step-start both push a step-start part', () => {
 		const parts: UIMessagePart[] = [];
 		applyChunkToParts(parts, { type: 'start-step' });
 		applyChunkToParts(parts, { type: 'step-start' });
 		expect(parts).toEqual([{ type: 'step-start' }, { type: 'step-start' }]);
+	});
+
+	it('finish-step and abort are recognized without changing message parts', () => {
+		const parts: UIMessagePart[] = [{ type: 'text', text: 'partial' }];
+		expect(applyChunkToParts(parts, { type: 'finish-step' })).toBe(true);
+		expect(applyChunkToParts(parts, { type: 'abort', reason: 'cancelled' })).toBe(true);
+		expect(parts).toEqual([{ type: 'text', text: 'partial' }]);
+	});
+
+	it('source and file chunks are retained as message parts', () => {
+		const parts: UIMessagePart[] = [];
+		applyChunkToParts(parts, { type: 'source-url', sourceId: 's1', url: 'https://example.test' });
+		applyChunkToParts(parts, { type: 'source-url', sourceId: 's1', url: 'https://example.test' });
+		applyChunkToParts(parts, {
+			type: 'source-document',
+			sourceId: 's2',
+			mediaType: 'text/plain',
+			title: 'Notes',
+			filename: 'notes.txt'
+		});
+		applyChunkToParts(parts, { type: 'file', mediaType: 'text/plain', url: 'data:text/plain,hello' });
+		applyChunkToParts(parts, { type: 'file', mediaType: 'text/plain', url: 'data:text/plain,hello' });
+		expect(parts).toEqual([
+			{ type: 'source-url', sourceId: 's1', url: 'https://example.test' },
+			{ type: 'source-document', sourceId: 's2', mediaType: 'text/plain', title: 'Notes', filename: 'notes.txt' },
+			{ type: 'file', mediaType: 'text/plain', url: 'data:text/plain,hello' }
+		]);
+	});
+
+	it('accepts official metadata values and tool provider fields at the stream boundary', () => {
+		expect(parseUIStreamChunk('{"type":"start","messageMetadata":null}')).toEqual({
+			type: 'start',
+			messageMetadata: null
+		});
+		expect(
+			parseUIStreamChunk(
+				JSON.stringify({
+					type: 'tool-input-start',
+					toolCallId: 'c1',
+					toolName: 'codemode',
+					providerExecuted: true,
+					providerMetadata: { gateway: { trace: 't1' } },
+					toolMetadata: { label: 'Code' },
+					dynamic: true
+				})
+			)
+		).toMatchObject({
+			type: 'tool-input-start',
+			providerExecuted: true,
+			providerMetadata: { gateway: { trace: 't1' } },
+			toolMetadata: { label: 'Code' },
+			dynamic: true
+		});
+	});
+
+	it('transient data chunks do not enter message parts', () => {
+		const parts: UIMessagePart[] = [];
+		expect(applyChunkToParts(parts, { type: 'data-progress', data: { phase: 'working' }, transient: true })).toBe(true);
+		expect(parts).toEqual([]);
+	});
+
+	it('replays an official tool input stream into a settled successful tool part', () => {
+		const parts: UIMessagePart[] = [];
+		applyChunkToParts(parts, { type: 'tool-input-start', toolCallId: 'c1', toolName: 'codemode' });
+		applyChunkToParts(parts, { type: 'tool-input-delta', toolCallId: 'c1', inputTextDelta: '{"code":"return {}"}' });
+		applyChunkToParts(parts, {
+			type: 'tool-input-available',
+			toolCallId: 'c1',
+			toolName: 'codemode',
+			input: { code: 'return {}' }
+		});
+		applyChunkToParts(parts, { type: 'tool-output-available', toolCallId: 'c1', output: { ok: true } });
+		applyChunkToParts(parts, { type: 'finish-step' });
+
+		expect(toolPart(parts, 'c1')).toMatchObject({
+			state: 'output-available',
+			input: { code: 'return {}' },
+			output: { ok: true }
+		});
 	});
 
 	it('data-* chunk without id is appended', () => {

--- a/packages/frontend/src/lib/agents/chat.ts
+++ b/packages/frontend/src/lib/agents/chat.ts
@@ -40,6 +40,31 @@ export interface UIReasoningPart {
 	state?: 'streaming' | 'done';
 }
 
+/** UI message parts emitted by the AI SDK for citations and generated files. */
+export interface UISourceUrlPart {
+	type: 'source-url';
+	sourceId: string;
+	url: string;
+	title?: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
+export interface UISourceDocumentPart {
+	type: 'source-document';
+	sourceId: string;
+	mediaType: string;
+	title: string;
+	filename?: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
+export interface UIFilePart {
+	type: 'file';
+	mediaType: string;
+	url: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
 export interface UIToolPart {
 	type: `tool-${string}`;
 	toolCallId: string;
@@ -67,7 +92,20 @@ export interface UIDataPart {
 	data: JsonValue;
 }
 
-export type UIMessagePart = UITextPart | UIReasoningPart | UIToolPart | UIStepStartPart | UIDataPart;
+/** A streamed data part may be marked transient and must not enter history. */
+export interface UIDataChunk extends UIDataPart {
+	transient?: boolean;
+}
+
+export type UIMessagePart =
+	| UITextPart
+	| UIReasoningPart
+	| UISourceUrlPart
+	| UISourceDocumentPart
+	| UIFilePart
+	| UIToolPart
+	| UIStepStartPart
+	| UIDataPart;
 
 export interface UIChatMessage {
 	id: string;
@@ -88,9 +126,17 @@ const toolStateSchema = z.enum([
 	'output-denied'
 ]);
 const metadataSchema = z.record(z.string(), jsonValueSchema);
+// These metadata values arrive over JSON, so `undefined` (permitted by the
+// SDK's in-memory types) cannot occur on the wire and is intentionally not in
+// the boundary type.
+const providerMetadataSchema = z.record(z.string(), z.record(z.string(), jsonValueSchema));
+const toolMetadataSchema = z.record(z.string(), jsonValueSchema);
 const uiMessagePartSchema = z.union([
 	z.object({ type: z.literal('text'), text: z.string(), state: z.enum(['streaming', 'done']).optional() }).catchall(jsonValueSchema),
 	z.object({ type: z.literal('reasoning'), text: z.string(), state: z.enum(['streaming', 'done']).optional() }).catchall(jsonValueSchema),
+	z.object({ type: z.literal('source-url'), sourceId: z.string(), url: z.string(), title: z.string().optional(), providerMetadata: metadataSchema.optional() }).catchall(jsonValueSchema),
+	z.object({ type: z.literal('source-document'), sourceId: z.string(), mediaType: z.string(), title: z.string(), filename: z.string().optional(), providerMetadata: metadataSchema.optional() }).catchall(jsonValueSchema),
+	z.object({ type: z.literal('file'), mediaType: z.string(), url: z.string(), providerMetadata: metadataSchema.optional() }).catchall(jsonValueSchema),
 	z.object({
 		type: toolPartTypeSchema,
 		toolCallId: z.string(),
@@ -153,6 +199,7 @@ export interface ActiveStreamMessage {
 	messageId: string;
 	continuation: boolean;
 	hadError: boolean;
+	errorText?: string;
 	parts: UIMessagePart[];
 	metadata?: Record<string, JsonValue>;
 }
@@ -161,6 +208,7 @@ export interface ToolApprovalRequestChunk {
 	type: 'tool-approval-request';
 	approvalId: string;
 	toolCallId: string;
+	signature?: string;
 }
 
 export interface ToolInputAvailableChunk {
@@ -168,6 +216,10 @@ export interface ToolInputAvailableChunk {
 	toolCallId: string;
 	toolName: string;
 	input: JsonValue;
+	providerExecuted?: boolean;
+	providerMetadata?: Record<string, JsonValue>;
+	toolMetadata?: Record<string, JsonValue>;
+	dynamic?: boolean;
 	title?: string;
 }
 
@@ -175,6 +227,10 @@ export interface ToolOutputAvailableChunk {
 	type: 'tool-output-available';
 	toolCallId: string;
 	output: JsonValue;
+	providerExecuted?: boolean;
+	providerMetadata?: Record<string, JsonValue>;
+	toolMetadata?: Record<string, JsonValue>;
+	dynamic?: boolean;
 	preliminary?: boolean;
 }
 
@@ -182,6 +238,10 @@ export interface ToolOutputErrorChunk {
 	type: 'tool-output-error';
 	toolCallId: string;
 	errorText: string;
+	providerExecuted?: boolean;
+	providerMetadata?: Record<string, JsonValue>;
+	toolMetadata?: Record<string, JsonValue>;
+	dynamic?: boolean;
 }
 
 export interface ToolOutputDeniedChunk {
@@ -192,28 +252,67 @@ export interface ToolOutputDeniedChunk {
 export interface TextStartChunk {
 	type: 'text-start';
 	id: string;
+	providerMetadata?: Record<string, JsonValue>;
 }
 
 export interface TextDeltaChunk {
 	type: 'text-delta';
 	id: string;
 	delta: string;
+	providerMetadata?: Record<string, JsonValue>;
 }
 
 export interface TextEndChunk {
 	type: 'text-end';
 	id: string;
+	providerMetadata?: Record<string, JsonValue>;
 }
 
 export interface MessageStartChunk {
 	type: 'start';
 	messageId?: string;
-	messageMetadata?: Record<string, JsonValue>;
+	/** AI SDK v6 types this as unknown; the wire format is JSON. */
+	messageMetadata?: JsonValue;
 }
 
 export interface MessageFinishChunk {
 	type: 'finish';
-	messageMetadata?: Record<string, JsonValue>;
+	finishReason?: 'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other';
+	/** AI SDK v6 types this as unknown; the wire format is JSON. */
+	messageMetadata?: JsonValue;
+}
+
+export interface FinishStepChunk {
+	type: 'finish-step';
+}
+
+export interface SourceUrlChunk {
+	type: 'source-url';
+	sourceId: string;
+	url: string;
+	title?: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
+export interface SourceDocumentChunk {
+	type: 'source-document';
+	sourceId: string;
+	mediaType: string;
+	title: string;
+	filename?: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
+export interface FileChunk {
+	type: 'file';
+	mediaType: string;
+	url: string;
+	providerMetadata?: Record<string, JsonValue>;
+}
+
+export interface AbortChunk {
+	type: 'abort';
+	reason?: string;
 }
 
 export type UIStreamChunk =
@@ -227,23 +326,35 @@ export type UIStreamChunk =
 	| ToolOutputDeniedChunk
 	| MessageStartChunk
 	| MessageFinishChunk
+	| FinishStepChunk
+	| SourceUrlChunk
+	| SourceDocumentChunk
+	| FileChunk
+	| AbortChunk
 	| {
 			type: 'tool-input-start';
 			toolCallId: string;
 			toolName: string;
+			providerExecuted?: boolean;
+			providerMetadata?: Record<string, JsonValue>;
+			toolMetadata?: Record<string, JsonValue>;
+			dynamic?: boolean;
 			title?: string;
 	  }
 	| {
 			type: 'tool-input-delta';
 			toolCallId: string;
-			inputTextDelta?: string;
-			input?: JsonValue;
-	  }
+			inputTextDelta: string;
+		}
 	| {
 			type: 'tool-input-error';
 			toolCallId: string;
 			toolName: string;
 			input: JsonValue;
+			providerExecuted?: boolean;
+			providerMetadata?: Record<string, JsonValue>;
+			toolMetadata?: Record<string, JsonValue>;
+			dynamic?: boolean;
 			errorText: string;
 			title?: string;
 	  }
@@ -268,36 +379,93 @@ export type UIStreamChunk =
 	  }
 	| {
 			type: 'message-metadata';
-			messageMetadata: Record<string, JsonValue>;
+			/** AI SDK v6 permits any metadata value; the app persists objects only. */
+			messageMetadata: JsonValue;
 	  }
 	| {
 			type: 'error';
 			errorText: string;
 	  }
-	| UIDataPart;
+	| UIDataChunk;
 
 const uiStreamChunkSchema = z.union([
-	z.object({ type: z.literal('text-start'), id: z.string() }),
-	z.object({ type: z.literal('text-delta'), id: z.string(), delta: z.string() }),
-	z.object({ type: z.literal('text-end'), id: z.string() }),
-	z.object({ type: z.literal('tool-input-start'), toolCallId: z.string(), toolName: z.string(), title: z.string().optional() }),
-	z.object({ type: z.literal('tool-input-delta'), toolCallId: z.string(), inputTextDelta: z.string().optional(), input: jsonValueSchema.optional() }),
-	z.object({ type: z.literal('tool-input-available'), toolCallId: z.string(), toolName: z.string(), input: jsonValueSchema, title: z.string().optional() }),
-	z.object({ type: z.literal('tool-input-error'), toolCallId: z.string(), toolName: z.string(), input: jsonValueSchema, errorText: z.string(), title: z.string().optional() }),
-	z.object({ type: z.literal('tool-approval-request'), approvalId: z.string(), toolCallId: z.string() }),
-	z.object({ type: z.literal('tool-output-available'), toolCallId: z.string(), output: jsonValueSchema, preliminary: z.boolean().optional() }),
-	z.object({ type: z.literal('tool-output-error'), toolCallId: z.string(), errorText: z.string() }),
+	z.object({ type: z.literal('text-start'), id: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('text-delta'), id: z.string(), delta: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('text-end'), id: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({
+		type: z.literal('tool-input-start'),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		toolMetadata: toolMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+		title: z.string().optional()
+	}),
+	z.object({ type: z.literal('tool-input-delta'), toolCallId: z.string(), inputTextDelta: z.string() }),
+	z.object({
+		type: z.literal('tool-input-available'),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		input: jsonValueSchema,
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		toolMetadata: toolMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+		title: z.string().optional()
+	}),
+	z.object({
+		type: z.literal('tool-input-error'),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		input: jsonValueSchema,
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		toolMetadata: toolMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+		errorText: z.string(),
+		title: z.string().optional()
+	}),
+	z.object({ type: z.literal('tool-approval-request'), approvalId: z.string(), toolCallId: z.string(), signature: z.string().optional() }),
+	z.object({
+		type: z.literal('tool-output-available'),
+		toolCallId: z.string(),
+		output: jsonValueSchema,
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		toolMetadata: toolMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+		preliminary: z.boolean().optional()
+	}),
+	z.object({
+		type: z.literal('tool-output-error'),
+		toolCallId: z.string(),
+		errorText: z.string(),
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		toolMetadata: toolMetadataSchema.optional(),
+		dynamic: z.boolean().optional()
+	}),
 	z.object({ type: z.literal('tool-output-denied'), toolCallId: z.string() }),
-	z.object({ type: z.literal('reasoning-start'), id: z.string() }),
-	z.object({ type: z.literal('reasoning-delta'), id: z.string(), delta: z.string() }),
-	z.object({ type: z.literal('reasoning-end'), id: z.string() }),
-	z.object({ type: z.literal('start'), messageId: z.string().optional(), messageMetadata: metadataSchema.optional() }),
-	z.object({ type: z.literal('finish'), messageMetadata: metadataSchema.optional() }),
+	z.object({ type: z.literal('reasoning-start'), id: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('reasoning-delta'), id: z.string(), delta: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('reasoning-end'), id: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('source-url'), sourceId: z.string(), url: z.string(), title: z.string().optional(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('source-document'), sourceId: z.string(), mediaType: z.string(), title: z.string(), filename: z.string().optional(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('file'), mediaType: z.string(), url: z.string(), providerMetadata: providerMetadataSchema.optional() }),
+	z.object({ type: z.literal('start'), messageId: z.string().optional(), messageMetadata: jsonValueSchema.optional() }),
+	z.object({
+		type: z.literal('finish'),
+		finishReason: z.enum(['stop', 'length', 'content-filter', 'tool-calls', 'error', 'other']).optional(),
+		messageMetadata: jsonValueSchema.optional()
+	}),
 	z.object({ type: z.literal('start-step') }),
 	z.object({ type: z.literal('step-start') }),
-	z.object({ type: z.literal('message-metadata'), messageMetadata: metadataSchema }),
+	z.object({ type: z.literal('finish-step') }),
+	z.object({ type: z.literal('abort'), reason: z.string().optional() }),
+	z.object({ type: z.literal('message-metadata'), messageMetadata: jsonValueSchema }),
 	z.object({ type: z.literal('error'), errorText: z.string() }),
-	z.object({ type: dataPartTypeSchema, id: z.string().optional(), data: jsonValueSchema })
+	z.object({ type: dataPartTypeSchema, id: z.string().optional(), data: jsonValueSchema, transient: z.boolean().optional() })
 ]);
 
 /** Parse and validate persisted chat history before it enters component state. */
@@ -384,6 +552,25 @@ export function cloneParts(parts: UIMessagePart[]): UIMessagePart[] {
 	});
 }
 
+/** Tool inputs must remain JSON objects so the tool cards can inspect them. */
+function normalizeToolInput(input: JsonValue): JsonValue {
+	const objectInput = z.record(z.string(), jsonValueSchema).safeParse(input);
+	if (objectInput.success) return objectInput.data;
+
+	const encodedInput = z.string().safeParse(input);
+	if (encodedInput.success && encodedInput.data.trim().startsWith('{')) {
+		try {
+			const parsed: unknown = JSON.parse(encodedInput.data);
+			const parsedObject = z.record(z.string(), jsonValueSchema).safeParse(parsed);
+			if (parsedObject.success) return parsedObject.data;
+		} catch {
+			// Invalid partial JSON is expected while a tool call is streaming.
+		}
+	}
+
+	return {};
+}
+
 export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk): boolean {
 	switch (chunk.type) {
 		case 'text-start':
@@ -424,7 +611,51 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 			}
 			return true;
 		}
+		case 'file':
+			if (
+				parts.some(
+					(part): part is UIFilePart =>
+						part.type === 'file' && part.mediaType === chunk.mediaType && part.url === chunk.url
+				)
+			) {
+				return true;
+			}
+			parts.push({
+				type: 'file',
+				mediaType: chunk.mediaType,
+				url: chunk.url,
+				providerMetadata: chunk.providerMetadata
+			});
+			return true;
+		case 'source-url':
+			if (parts.some((part): part is UISourceUrlPart => part.type === 'source-url' && part.sourceId === chunk.sourceId)) {
+				return true;
+			}
+			parts.push({
+				type: 'source-url',
+				sourceId: chunk.sourceId,
+				url: chunk.url,
+				title: chunk.title,
+				providerMetadata: chunk.providerMetadata
+			});
+			return true;
+		case 'source-document':
+			if (
+				parts.some((part): part is UISourceDocumentPart => part.type === 'source-document' && part.sourceId === chunk.sourceId)
+			) {
+				return true;
+			}
+			parts.push({
+				type: 'source-document',
+				sourceId: chunk.sourceId,
+				mediaType: chunk.mediaType,
+				title: chunk.title,
+				filename: chunk.filename,
+				providerMetadata: chunk.providerMetadata
+			});
+			return true;
 		case 'tool-input-start':
+			if (findToolPartByCallId(parts, chunk.toolCallId)) return true;
 			parts.push({
 				type: `tool-${chunk.toolName}`,
 				toolCallId: chunk.toolCallId,
@@ -435,24 +666,35 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 			return true;
 		case 'tool-input-delta': {
 			const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
-			if (toolPart) {
-				toolPart.input = chunk.input;
+			if (toolPart?.state !== 'input-streaming') return true;
+
+			const previousText = z.string().safeParse(toolPart.input);
+			const inputText = `${previousText.success ? previousText.data : ''}${chunk.inputTextDelta}`;
+			try {
+				const parsed: unknown = JSON.parse(inputText);
+				const parsedValue = jsonValueSchema.safeParse(parsed);
+				toolPart.input = parsedValue.success ? normalizeToolInput(parsedValue.data) : inputText;
+			} catch {
+				// Keep the raw fragment until the SDK emits a complete JSON value.
+				toolPart.input = inputText;
 			}
 			return true;
 		}
 		case 'tool-input-available': {
 			const existing = findToolPartByCallId(parts, chunk.toolCallId);
 			if (existing) {
-				existing.state = 'input-available';
-				existing.input = chunk.input;
-				existing.title = chunk.title;
+				if (existing.state === 'input-streaming') {
+					existing.state = 'input-available';
+					existing.input = normalizeToolInput(chunk.input);
+					if (chunk.title !== undefined) existing.title = chunk.title;
+				}
 			} else {
 				parts.push({
 					type: `tool-${chunk.toolName}`,
 					toolCallId: chunk.toolCallId,
 					toolName: chunk.toolName,
 					state: 'input-available',
-					input: chunk.input,
+					input: normalizeToolInput(chunk.input),
 					title: chunk.title
 				});
 			}
@@ -461,17 +703,20 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 		case 'tool-input-error': {
 			const existing = findToolPartByCallId(parts, chunk.toolCallId);
 			if (existing) {
+				if (existing.state === 'output-available' || existing.state === 'output-error' || existing.state === 'output-denied') {
+					return true;
+				}
 				existing.state = 'output-error';
-				existing.input = chunk.input;
+				existing.input = normalizeToolInput(chunk.input);
 				existing.errorText = chunk.errorText;
-				existing.title = chunk.title;
+				if (chunk.title !== undefined) existing.title = chunk.title;
 			} else {
 				parts.push({
 					type: `tool-${chunk.toolName}`,
 					toolCallId: chunk.toolCallId,
 					toolName: chunk.toolName,
 					state: 'output-error',
-					input: chunk.input,
+					input: normalizeToolInput(chunk.input),
 					errorText: chunk.errorText,
 					title: chunk.title
 				});
@@ -481,6 +726,14 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 		case 'tool-approval-request': {
 			const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
 			if (toolPart) {
+				if (
+					toolPart.state === 'approval-responded' ||
+					toolPart.state === 'output-available' ||
+					toolPart.state === 'output-error' ||
+					toolPart.state === 'output-denied'
+				) {
+					return true;
+				}
 				toolPart.state = 'approval-requested';
 				toolPart.approval = { id: chunk.approvalId };
 			}
@@ -489,6 +742,14 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 		case 'tool-output-available': {
 			const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
 			if (toolPart) {
+				if (
+					toolPart.state === 'output-error' ||
+					toolPart.state === 'output-denied' ||
+					(toolPart.state === 'output-available' &&
+						!(toolPart.preliminary === true && chunk.preliminary !== true))
+				) {
+					return true;
+				}
 				toolPart.state = 'output-available';
 				toolPart.output = chunk.output;
 				toolPart.preliminary = chunk.preliminary;
@@ -498,15 +759,32 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 		case 'tool-output-error': {
 			const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
 			if (toolPart) {
+				if (
+					toolPart.state === 'output-error' ||
+					toolPart.state === 'output-denied' ||
+					(toolPart.state === 'output-available' && toolPart.preliminary !== true)
+				) {
+					return true;
+				}
 				toolPart.state = 'output-error';
 				toolPart.errorText = chunk.errorText;
+				toolPart.preliminary = undefined;
 			}
 			return true;
 		}
 		case 'tool-output-denied': {
 			const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
 			if (toolPart) {
+				if (
+					toolPart.state === 'approval-responded' ||
+					toolPart.state === 'output-error' ||
+					toolPart.state === 'output-denied' ||
+					(toolPart.state === 'output-available' && toolPart.preliminary !== true)
+				) {
+					return true;
+				}
 				toolPart.state = 'output-denied';
+				toolPart.preliminary = undefined;
 			}
 			return true;
 		}
@@ -514,9 +792,13 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 		case 'step-start':
 			parts.push({ type: 'step-start' });
 			return true;
+		case 'finish-step':
+		case 'abort':
+			return true;
 		default:
 			if (isDataChunk(chunk)) {
 				const dataChunk = chunk;
+				if (dataChunk.transient) return true;
 
 				if ('id' in chunk && chunk.id) {
 					const existing = findDataPartByTypeAndId(parts, dataChunk.type, chunk.id);
@@ -536,7 +818,7 @@ export function applyChunkToParts(parts: UIMessagePart[], chunk: UIStreamChunk):
 	}
 }
 
-function isDataChunk(chunk: UIStreamChunk): chunk is UIDataPart {
+function isDataChunk(chunk: UIStreamChunk): chunk is UIDataChunk {
 	return chunk.type.startsWith('data-');
 }
 

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -537,6 +537,12 @@ import {
 		scrollToBottom();
 	}
 
+	function appendStreamError(stream: ActiveStreamMessage, text: string) {
+		if (!text || stream.errorText === text) return;
+		stream.errorText = text;
+		stream.parts.push({ type: 'text', text, state: 'done' });
+	}
+
 	function getCurrentMessagesForRequest(nextUserMessage?: UIChatMessage): UIChatMessage[] {
 		return nextUserMessage ? [...uiMessages, nextUserMessage] : [...uiMessages];
 	}
@@ -995,8 +1001,25 @@ import {
 
 		if (chunk.type === 'error') {
 			activeStream.hadError = true;
-			activeStream.parts.push({ type: 'text', text: chunk.errorText, state: 'done' });
+			appendStreamError(activeStream, chunk.errorText);
 			flushActiveStreamToMessages(activeStream);
+			return;
+		}
+
+		if (chunk.type === 'abort') {
+			const requestId = activeStream.id;
+			activeStream.hadError = true;
+			activeStream.parts.push({
+				type: 'text',
+				text: 'The response stopped partway. Send your message again.',
+				state: 'done'
+			});
+			flushActiveStreamToMessages(activeStream);
+			// An abort is terminal even when the transport never sends the usual
+			// done frame. Mark the request settled before clearing state so a late
+			// replay cannot recreate the Working indicator.
+			settledRequestIds = new Set([...settledRequestIds, requestId].slice(-8));
+			resetRequestState();
 			return;
 		}
 
@@ -1007,13 +1030,16 @@ import {
 				activeStream.messageId = chunk.messageId;
 			}
 
-			if (
-				(chunk.type === 'start' || chunk.type === 'finish' || chunk.type === 'message-metadata') &&
-				chunk.messageMetadata
-			) {
-				activeStream.metadata = activeStream.metadata
-					? { ...activeStream.metadata, ...chunk.messageMetadata }
-					: { ...chunk.messageMetadata };
+			if (chunk.type === 'start' || chunk.type === 'finish' || chunk.type === 'message-metadata') {
+				// AI SDK v6 declares messageMetadata as unknown and permits scalar or
+				// null values. Site Studio's persisted message contract is an object;
+				// retain only object metadata at that application boundary.
+				const metadata = z.record(z.string(), jsonValueSchema).safeParse(chunk.messageMetadata);
+				if (metadata.success) {
+					activeStream.metadata = activeStream.metadata
+						? { ...activeStream.metadata, ...metadata.data }
+						: { ...metadata.data };
+				}
 			}
 		}
 
@@ -1232,16 +1258,17 @@ import {
 							!bodyText.startsWith('data:') &&
 							!bodyText.startsWith('{') &&
 							!bodyText.startsWith('[');
-						if (!(data.error && looksLikeProse)) {
-							console.warn('Failed to parse stream chunk', error);
-							if (data.error && activeStream) {
-								activeStream.parts.push({
-									type: 'text',
-									text: 'Something went wrong while generating this response.',
-									state: 'done'
-								});
+							if (data.error && activeStream && looksLikeProse) {
+								// Error frames may carry the provider's human-readable message as
+								// plain text rather than a UI chunk. Render it here; a later
+								// structured copy is deduplicated by appendStreamError.
+								appendStreamError(activeStream, bodyText);
+							} else {
+								console.warn('Failed to parse stream chunk', error);
+								if (data.error && activeStream) {
+									appendStreamError(activeStream, 'Something went wrong while generating this response.');
+								}
 							}
-						}
 					}
 				}
 

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { flushSync, tick } from 'svelte';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import AgentChat from './AgentChat.svelte';
-import { AgentMessageType, type UIChatMessage } from '$lib/agents/chat';
+import { AgentMessageType, type UIChatMessage, type UIStreamChunk } from '$lib/agents/chat';
 import { invalidateCsrfToken } from '$lib/api/csrf';
 import type { JsonValue } from '$lib/contracts';
 
@@ -615,6 +615,116 @@ describe('AgentChat', () => {
 		expect(screen.getByText('Usage limit reached.')).toBeInTheDocument();
 	});
 
+	it('ends an aborted stream instead of leaving the request stuck in Working', async () => {
+		mount();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: 'aborted-stream',
+			body: JSON.stringify({ type: 'abort', reason: 'upstream_closed' }),
+			done: false
+		});
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: 'aborted-stream',
+			body: '',
+			done: true
+		});
+		await settle();
+
+		expect(screen.getByText('The response stopped partway. Send your message again.')).toBeInTheDocument();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+	});
+
+	it('settles an abort immediately when no done frame follows', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+		await component.sendPrompt('trigger an upstream abort');
+		await settle();
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({ type: 'abort', reason: 'connection_closed' }),
+			done: false
+		});
+		await settle();
+
+		expect(screen.getByText('The response stopped partway. Send your message again.')).toBeInTheDocument();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
+	});
+
+	it('renders the official tool stream as Finished instead of Needs attention', async () => {
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+		await component.sendPrompt('run the official tool stream');
+		await settle();
+
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+		const requestId = request.id;
+		const sendChunk = (chunk: UIStreamChunk) => {
+			ws.serverMessage({
+				type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+				id: requestId,
+				body: JSON.stringify(chunk),
+				done: false
+			});
+		};
+		sendChunk({ type: 'tool-input-start', toolCallId: 'tool-1', toolName: 'codemode' });
+		sendChunk({ type: 'tool-input-delta', toolCallId: 'tool-1', inputTextDelta: '{"co' });
+		sendChunk({ type: 'tool-input-delta', toolCallId: 'tool-1', inputTextDelta: 'de":"return {}"}' });
+		sendChunk({
+			type: 'tool-input-available',
+			toolCallId: 'tool-1',
+			toolName: 'codemode',
+			input: { code: 'return {}' }
+		});
+		sendChunk({ type: 'tool-output-available', toolCallId: 'tool-1', output: { ok: true } });
+		sendChunk({ type: 'finish-step' });
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: requestId,
+			body: '',
+			done: true
+		});
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId,
+			messages: [{
+				id: 'assistant-1',
+				role: 'assistant',
+				parts: [{
+					type: 'tool-codemode',
+					toolCallId: 'tool-1',
+					toolName: 'codemode',
+					state: 'output-available',
+					input: { code: 'return {}' },
+					output: { ok: true }
+				}]
+			}]
+		});
+		await settle();
+
+		expect(screen.getByText('Finished')).toBeInTheDocument();
+		expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+	});
+
 	it('handles a plain-text error frame body (CAIL quota) without noise or duplication', async () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		mount();
@@ -649,12 +759,42 @@ describe('AgentChat', () => {
 		});
 		await settle();
 
-		// Rendered exactly once (from the persisted message), no generic fallback,
+		// Rendered exactly once, no generic fallback,
 		// and no "Failed to parse stream chunk" console noise for this known shape.
 		expect(screen.getAllByText(quotaText)).toHaveLength(1);
 		expect(
 			screen.queryByText('Something went wrong while generating this response.')
 		).not.toBeInTheDocument();
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it('renders a sole plain-text error frame instead of clearing the request silently', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+		await component.sendPrompt('trigger a provider error');
+		await settle();
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+
+		const errorText = 'The provider returned a temporary error.';
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: errorText,
+			done: true,
+			error: true
+		});
+		await settle();
+
+		expect(screen.getByText(errorText)).toBeInTheDocument();
+		expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument();
 		expect(warn).not.toHaveBeenCalled();
 		warn.mockRestore();
 	});


### PR DESCRIPTION
## Summary
- accept the AI SDK v6 UI stream envelope (including metadata, files, sources, finish-step, abort, and provider fields)
- keep tool state monotonic across replay while allowing preliminary results to reach final success/error/denial
- terminate aborts and render plain transport errors without duplicate/no-op failures
- deduplicate resumed source/file chunks and cover real request correlation in component tests

## Verification
- `bun run --cwd packages/frontend check` (svelte-check 0 errors/warnings; 15 test files, 204 tests)
- focused chat 49/49 and AgentChat 43/43
- oxlint, Biome, and `git diff --check`
