### PR TITLE
Fix Site Studio asset URL semantics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "5.20260722.1",
         "@types/node": "26.1.1",
+        "htmlrewriter": "0.0.13",
         "typescript": "5.9.3",
         "vitest": "4.1.10",
         "wrangler": "4.121.0",
@@ -781,6 +782,8 @@
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+
+    "htmlrewriter": ["htmlrewriter@0.0.13", "", {}, "sha512-HPxT+y/i9RzNeKrJ6MBFXwB+FeTfHPfcBzoKHVnk3oiKn2s6x13tLoxjggI+0/yOSBG1n8SV//PGDBJYT/4XQw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260722.1",
+    "htmlrewriter": "0.0.13",
     "@types/node": "26.1.1",
     "typescript": "5.9.3",
     "vitest": "4.1.10",

--- a/packages/app/src/lib/htmlrewriter-test-setup.ts
+++ b/packages/app/src/lib/htmlrewriter-test-setup.ts
@@ -1,0 +1,7 @@
+import { HTMLRewriter as NodeHTMLRewriter } from "htmlrewriter";
+
+Object.defineProperty(globalThis, "HTMLRewriter", {
+  configurable: true,
+  value: NodeHTMLRewriter,
+  writable: true,
+});

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -271,6 +271,31 @@ describe("addCacheBusterToHtml", () => {
     ]);
   });
 
+  it("keeps relative paths that collide with the ingress mount in project storage", async () => {
+    const html = [
+      '<base href="site-studio/preview/proj/">',
+      '<link rel="stylesheet" href="styles.css">',
+      '<script src="app.js"></script>'
+    ].join("");
+    const rewritten = await addCacheBusterToHtml(
+      html,
+      "123",
+      { pt: "token" },
+      "/site-studio/preview/proj/",
+      "index.html"
+    );
+
+    expect(rewritten).toContain(
+      '<base href="/site-studio/preview/proj/site-studio/preview/proj/">'
+    );
+    expect(rewritten).toContain('href="styles.css?v=123&pt=token"');
+    expect(rewritten).toContain('src="app.js?v=123&pt=token"');
+    expect(await collectPreviewResourcePaths(html, "index.html", "/site-studio/preview/proj/")).toEqual([
+      "site-studio/preview/proj/app.js",
+      "site-studio/preview/proj/styles.css"
+    ]);
+  });
+
   it("uses a nested document path when rewriting a published local base", async () => {
     const html = '<base href="assets/"><script src="app.js"></script>';
     const rewritten = await rewriteRootRelativeHtmlUrls(

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -8,6 +8,7 @@ import {
   addCacheBusterToHtml,
   collectPreviewCssResourcePaths,
   rewriteRootRelativeCssUrls,
+  rewriteRootRelativeHtmlUrls,
   buildFileTree,
   collectPreviewResourcePaths
 } from "./path";
@@ -216,6 +217,76 @@ describe("addCacheBusterToHtml", () => {
     expect(await collectPreviewResourcePaths(html, "docs/index.html")).toEqual(["docs/assets/app.js"]);
   });
 
+  it.each(["", "#section"])("keeps a %j base on the current local document", async (baseHref) => {
+    const html = `<base href="${baseHref}"><script src="app.js"></script><img src="/images/hero.png">`;
+    const rewritten = await addCacheBusterToHtml(
+      html,
+      "123",
+      { pt: "token" },
+      "/site-studio/preview/proj/",
+      "docs/index.html"
+    );
+
+    expect(rewritten).toContain(`<base href="${baseHref}">`);
+    expect(rewritten).toContain('src="app.js?v=123&pt=token"');
+    expect(rewritten).toContain('src="/site-studio/preview/proj/images/hero.png?v=123&pt=token"');
+    const documentUrl = new URL(
+      "/site-studio/preview/proj/docs/index.html",
+      "https://preview.example"
+    );
+    const effectiveBase = new URL(baseHref, documentUrl);
+    expect(effectiveBase.pathname).toBe("/site-studio/preview/proj/docs/index.html");
+    expect(new URL("app.js", effectiveBase).pathname).toBe(
+      "/site-studio/preview/proj/docs/app.js"
+    );
+    expect(await collectPreviewResourcePaths(html, "docs/index.html", "/site-studio/preview/proj/")).toEqual([
+      "docs/app.js",
+      "images/hero.png"
+    ]);
+  });
+
+  it("does not double-mount an authored preview base or its child URLs", async () => {
+    const html = [
+      '<base href="/site-studio/preview/proj/docs/">',
+      '<script src="app.js"></script>',
+      '<img src="/site-studio/preview/proj/images/hero.png">'
+    ].join("");
+    const rewritten = await addCacheBusterToHtml(
+      html,
+      "123",
+      { pt: "token" },
+      "/site-studio/preview/proj/",
+      "index.html"
+    );
+
+    expect(rewritten).toContain('<base href="/site-studio/preview/proj/docs/">');
+    expect(rewritten).not.toContain("/site-studio/preview/proj/site-studio/preview/proj/");
+    expect(rewritten).toContain('src="app.js?v=123&pt=token"');
+    expect(rewritten).toContain(
+      'src="/site-studio/preview/proj/images/hero.png?v=123&pt=token"'
+    );
+    expect(await collectPreviewResourcePaths(html, "index.html", "/site-studio/preview/proj/")).toEqual([
+      "docs/app.js",
+      "images/hero.png"
+    ]);
+  });
+
+  it("uses a nested document path when rewriting a published local base", async () => {
+    const html = '<base href="assets/"><script src="app.js"></script>';
+    const rewritten = await rewriteRootRelativeHtmlUrls(
+      html,
+      "/u/janedoe/site/",
+      "docs/index.html"
+    );
+    expect(rewritten).toContain('<base href="/u/janedoe/site/docs/assets/">');
+    expect(rewritten).toContain('<script src="app.js"></script>');
+    const documentUrl = new URL("/u/janedoe/site/docs/index.html", "https://published.example");
+    const effectiveBase = new URL("/u/janedoe/site/docs/assets/", documentUrl);
+    expect(new URL("app.js", effectiveBase).pathname).toBe(
+      "/u/janedoe/site/docs/assets/app.js"
+    );
+  });
+
   it("rewrites and scopes local CSS URLs while preserving external and data URLs", () => {
     const css = [
       '@import "/theme.css";',
@@ -243,6 +314,11 @@ describe("addCacheBusterToHtml", () => {
       "images/hero.png",
       "theme.css"
     ]);
+    expect(collectPreviewCssResourcePaths(
+      ".hero { background: url(/site-studio/preview/proj/images/hero.png); }",
+      "docs/styles.css",
+      "/site-studio/preview/proj/"
+    )).toEqual(["images/hero.png"]);
   });
 
 });

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -4,7 +4,11 @@ import {
   sanitizeFilePath,
   getContentType,
   isTextContentType,
+  addCacheBusterToCss,
   addCacheBusterToHtml,
+  collectPreviewCssResourcePaths,
+  rewriteRootRelativeHtmlUrls,
+  rewriteRootRelativeCssUrls,
   buildFileTree,
   collectPreviewResourcePaths
 } from "./path";
@@ -242,15 +246,193 @@ describe("addCacheBusterToHtml", () => {
     expect(addCacheBusterToHtml(html, "123", { pt: "secret" })).toBe(html);
   });
 
+  it("rewrites root-relative destinations to the supplied site mount", () => {
+    const html = [
+      '<link href="/styles.css">',
+      '<script src="/app.js?cache=1#ready"></script>',
+      '<img src="//attacker.example/pixel.png">'
+    ].join("");
+
+    expect(addCacheBusterToHtml(html, "123", { pt: "secret" }, "/preview/proj/")).toBe([
+      '<link href="/preview/proj/styles.css?v=123&pt=secret">',
+      '<script src="/preview/proj/app.js?cache=1&v=123&pt=secret#ready"></script>',
+      '<img src="//attacker.example/pixel.png">'
+    ].join(""));
+    expect(rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toContain(
+      '<link href="/u/janedoe/site/styles.css">'
+    );
+  });
+
+  it("rewrites parsed URL-bearing attributes and inline CSS without touching code or comments", () => {
+    const html = [
+      '<a href="/">Home</a>',
+      '<video poster="/poster.jpg"><source srcset="/wide.jpg 1x, /small.jpg 2x"></video>',
+      '<form action="/submit"><object data="/document.pdf"></object></form>',
+      '<svg><use xlink:href="/icons.svg#check"></use></svg><button formaction="/save">Save</button>',
+      '<img data-src="/lazy.jpg" data-href="/lazy.html">',
+      '<div style="background-image: url(\'/inline-bg.png\')"></div>',
+      '<style>.hero { background: url(/style-bg.png); }</style>',
+      '<!-- <img src="/comment.png"> -->',
+      '<script>const markup = \'<img src="/script-string.png">\';</script>'
+    ].join("");
+
+    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+    expect(result).toContain('poster="/preview/proj/poster.jpg?v=123&pt=token"');
+    expect(result).toContain('srcset="/preview/proj/wide.jpg?v=123&pt=token 1x, /preview/proj/small.jpg?v=123&pt=token 2x"');
+    expect(result).toContain('action="/preview/proj/submit?v=123&pt=token"');
+    expect(result).toContain('data="/preview/proj/document.pdf?v=123&pt=token"');
+    expect(result).toContain('xlink:href="/preview/proj/icons.svg?v=123&pt=token#check"');
+    expect(result).toContain('formaction="/preview/proj/save?v=123&pt=token"');
+    expect(result).toContain('data-src="/preview/proj/lazy.jpg?v=123&pt=token"');
+    expect(result).toContain('data-href="/preview/proj/lazy.html?v=123&pt=token"');
+    expect(result).toContain('background-image: url(\'/preview/proj/inline-bg.png?v=123&pt=token\')');
+    expect(result).toContain('background: url(/preview/proj/style-bg.png?v=123&pt=token)');
+    expect(result).toContain('<img src="/comment.png">');
+    expect(result).toContain('<img src="/script-string.png">');
+
+    expect(collectPreviewResourcePaths(html, "index.html")).toEqual([
+      "document.pdf",
+      "icons.svg",
+      "index.html",
+      "inline-bg.png",
+      "lazy.html",
+      "lazy.jpg",
+      "poster.jpg",
+      "save",
+      "small.jpg",
+      "style-bg.png",
+      "submit",
+      "wide.jpg"
+    ]);
+  });
+
+  it("maps root navigation to index and rejects parent escapes", () => {
+    const html = '<a href="/">Home</a><script src="../outside.js"></script><img src="/../secret.png">';
+    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+
+    expect(result).toContain('href="/preview/proj/?v=123&pt=token"');
+    expect(result).toContain('src="../outside.js"');
+    expect(result).toContain('src="/../secret.png"');
+    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["index.html"]);
+  });
+
+  it("preserves root-relative trailing slashes for directory routes", () => {
+    const html = '<a href="/docs/">Docs</a>';
+    const rewritten = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+
+    expect(rewritten).toContain('href="/preview/proj/docs/?v=123&pt=token"');
+    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["docs/"]);
+  });
+
+  it("rewrites and scopes local CSS URLs while preserving external and data URLs", () => {
+    const css = [
+      '@import "/theme.css";',
+      ".hero { background: url('/images/hero.png'); }",
+      ".font { src: url(../fonts/body.woff2) format('woff2'); }",
+      ".external { background: url(https://cdn.example.com/bg.png); }",
+      ".data { background: url(data:image/png;base64,abc); }",
+      "/* background: url(/comment.png); */",
+      ".string { content: \"url(/string.png)\"; }"
+    ].join("\n");
+    const rewritten = addCacheBusterToCss(css, "123", { pt: "token" }, "/preview/proj/", "styles/main.css");
+
+    expect(rewritten).toContain("url('/preview/proj/images/hero.png?v=123&pt=token')");
+    expect(rewritten).toContain("url(../fonts/body.woff2?v=123&pt=token)");
+    expect(rewritten).toContain("url(https://cdn.example.com/bg.png)");
+    expect(rewritten).toContain("url(data:image/png;base64,abc)");
+    expect(rewritten).toContain('@import "/preview/proj/theme.css?v=123&pt=token";');
+    expect(rewritten).toContain("url(/comment.png)");
+    expect(rewritten).toContain('content: "url(/string.png)"');
+    expect(rewriteRootRelativeCssUrls(css, "/u/janedoe/site/")).toContain(
+      "url('/u/janedoe/site/images/hero.png')"
+    );
+    expect(collectPreviewCssResourcePaths(css, "styles/main.css")).toEqual([
+      "fonts/body.woff2",
+      "images/hero.png",
+      "theme.css"
+    ]);
+  });
+
+  it("rewrites local srcset candidates alongside data URLs", () => {
+    const srcset = "data:image/svg+xml,%3Csvg%3E 1x, /images/a.png 2x, /images/b.png 3x";
+    const html = `<img srcset="${srcset}">`;
+    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+
+    expect(result).toContain(
+      'srcset="data:image/svg+xml,%3Csvg%3E 1x, /preview/proj/images/a.png?v=123&pt=token 2x, /preview/proj/images/b.png?v=123&pt=token 3x"'
+    );
+    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["images/a.png", "images/b.png"]);
+
+    const mixedWithoutDataDescriptor = 'data:image/png;base64,abc, /images/c.png 2x';
+    const withoutDescriptor = addCacheBusterToHtml(
+      `<img srcset="${mixedWithoutDataDescriptor}">`,
+      "123",
+      { pt: "token" },
+      "/preview/proj/",
+      "index.html"
+    );
+    expect(withoutDescriptor).toContain(
+      'srcset="data:image/png;base64,abc, /preview/proj/images/c.png?v=123&pt=token 2x"'
+    );
+
+    const encodedDelimiterSrcset = '<img srcset="/%2Cencoded.png 1x, /images/d.png 2x">';
+    const encodedDelimiterResult = addCacheBusterToHtml(
+      encodedDelimiterSrcset,
+      "123",
+      { pt: "token" },
+      "/preview/proj/",
+      "index.html"
+    );
+    expect(encodedDelimiterResult).toContain(
+      'srcset="/%2Cencoded.png 1x, /preview/proj/images/d.png?v=123&pt=token 2x"'
+    );
+    expect(collectPreviewResourcePaths(encodedDelimiterSrcset, "index.html")).toEqual(["images/d.png"]);
+  });
+
+  it("leaves escaped CSS URL tokens and unsafe encoded path segments unchanged", () => {
+    // Preview/publish currently address R2 with the raw URL pathname. Preserve
+    // encoded candidates and fail closed rather than decoding them into a
+    // different storage key or a CSS/HTML delimiter.
+    const css = String.raw`.escaped { background: url(/images/escaped\).png); }
+.safe { background: url(/images/safe.png); }
+.query { background: url(/%3Fsecret.png); }
+.fragment { background: url(/%23secret.png); }
+.space { background: url(/space%20name.png); }
+.double { background: url("/%22double.png"); }
+.single { background: url('/%27single.png'); }
+.markup { background: url(/%3Ctag%3E.png); }
+.ampersand { background: url(/%26name.png); }
+.parentheses { background: url(/%28name%29.png); }`;
+    const rewritten = addCacheBusterToCss(css, "123", { pt: "token" }, "/preview/proj/", "styles/main.css");
+
+    expect(rewritten).toContain(String.raw`url(/images/escaped\).png)`);
+    expect(rewritten).toContain("url(/preview/proj/images/safe.png?v=123&pt=token)");
+    expect(rewritten).toContain("url(/%3Fsecret.png)");
+    expect(rewritten).toContain("url(/%23secret.png)");
+    expect(rewritten).toContain("url(/space%20name.png)");
+    expect(rewritten).toContain('url("/%22double.png")');
+    expect(rewritten).toContain("url('/%27single.png')");
+    expect(rewritten).toContain("url(/%3Ctag%3E.png)");
+    expect(rewritten).toContain("url(/%26name.png)");
+    expect(rewritten).toContain("url(/%28name%29.png)");
+    expect(collectPreviewCssResourcePaths(css, "styles/main.css")).toEqual(["images/safe.png"]);
+
+    const html = '<img src="/%3Fsecret.png"><img src=\'/%23secret.png\'><img src="/%252Fsecret.png"><img src="/space%20name.png"><img src="/%22double.png"><img src=\'/%27single.png\'><img src="/%3Ctag%3E.png"><img src="/%26name.png"><img src=/%60tick.png><img src=/%3Dequals.png>';
+    expect(rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toBe(html);
+    expect(collectPreviewResourcePaths(html, "index.html")).toEqual([]);
+  });
+
   it("collects only relative project paths for a scoped preview grant", () => {
     const html = [
       '<script src="app.js?x=1"></script>',
       '<a href="../about.html#team">About</a>',
+      '<link href="/styles.css">',
       '<img src="//attacker.example/pixel.png">'
     ].join("");
     expect(collectPreviewResourcePaths(html, "docs/index.html")).toEqual([
       "about.html",
-      "docs/app.js"
+      "docs/app.js",
+      "styles.css"
     ]);
   });
 

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -7,7 +7,6 @@ import {
   addCacheBusterToCss,
   addCacheBusterToHtml,
   collectPreviewCssResourcePaths,
-  rewriteRootRelativeHtmlUrls,
   rewriteRootRelativeCssUrls,
   buildFileTree,
   collectPreviewResourcePaths
@@ -175,116 +174,26 @@ describe("isTextContentType", () => {
 });
 
 describe("addCacheBusterToHtml", () => {
-  it("adds version to link hrefs", async () => {
-    const html = '<link rel="stylesheet" href="styles.css">';
-    const result = await addCacheBusterToHtml(html, "123");
-    expect(result).toBe('<link rel="stylesheet" href="styles.css?v=123">');
-  });
-
-  it("adds version to script srcs", async () => {
-    const html = '<script src="app.js"></script>';
-    const result = await addCacheBusterToHtml(html, "123");
-    expect(result).toBe('<script src="app.js?v=123"></script>');
-  });
-
-  it("adds version to img srcs", async () => {
-    const html = '<img src="photo.png">';
-    const result = await addCacheBusterToHtml(html, "123");
-    expect(result).toBe('<img src="photo.png?v=123">');
-  });
-
-  it("does not modify external URLs", async () => {
-    const html = '<link href="https://cdn.example.com/style.css">';
-    const result = await addCacheBusterToHtml(html, "123");
-    expect(result).toBe(html);
-  });
-
-  it("adds cache and preview-token params to relative asset and navigation URLs", async () => {
+  it("adds params to project links while preserving query and fragment", async () => {
     const html = [
-      '<link href="styles.css">',
+      '<link href="styles.css?existing=1#ready">',
       '<script src="app.js"></script>',
-      '<img src="photo.png">',
-      '<a href="about.html">About</a>'
+      '<img src="photo.png">'
     ].join("");
     const result = await addCacheBusterToHtml(html, "123", { pt: "preview-token" });
 
-    expect(result).toContain('href="styles.css?v=123&pt=preview-token"');
+    expect(result).toContain('href="styles.css?existing=1&v=123&pt=preview-token#ready"');
     expect(result).toContain('src="app.js?v=123&pt=preview-token"');
     expect(result).toContain('src="photo.png?v=123&pt=preview-token"');
-    expect(result).toContain('href="about.html?v=123&pt=preview-token"');
   });
 
-  it("leaves external and non-navigation URLs unchanged", async () => {
-    const values = [
-      "https://example.com/page",
-      "http://example.com/page",
-      "//example.com/page",
-      "#section",
-      "mailto:user@example.com",
-      "tel:+12125550123",
-      "javascript:void(0)",
-      "data:text/plain,hello"
-    ];
-    const html = values.map((href) => `<a href="${href}">x</a>`).join("");
-
-    expect(await addCacheBusterToHtml(html, "123", { pt: "token" })).toBe(html);
-  });
-
-  it("preserves existing queries and puts preview params before fragments", async () => {
-    expect(await addCacheBusterToHtml(
-      '<a href="about.html?existing=1#section">About</a>',
-      "123",
-      { pt: "token" }
-    )).toBe('<a href="about.html?existing=1&v=123&pt=token#section">About</a>');
-  });
-
-  it("never appends a preview bearer to protocol-relative or root-relative destinations", async () => {
-    const html = [
-      '<img src="//attacker.example/pixel.png">',
-      '<script src="/shared/app.js"></script>'
-    ].join("");
-    expect(await addCacheBusterToHtml(html, "123", { pt: "secret" })).toBe(html);
-  });
-
-  it("rewrites root-relative destinations to the supplied site mount", async () => {
-    const html = [
-      '<link href="/styles.css">',
-      '<script src="/app.js?cache=1#ready"></script>',
-      '<img src="//attacker.example/pixel.png">'
-    ].join("");
-
-    expect(await addCacheBusterToHtml(html, "123", { pt: "secret" }, "/preview/proj/")).toBe([
-      '<link href="/preview/proj/styles.css?v=123&pt=secret">',
-      '<script src="/preview/proj/app.js?cache=1&v=123&pt=secret#ready"></script>',
-      '<img src="//attacker.example/pixel.png">'
-    ].join(""));
-    expect(await rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toContain(
-      '<link href="/u/janedoe/site/styles.css">'
-    );
-  });
-
-  it("maps root navigation to index and rejects parent escapes", async () => {
+  it("maps root navigation and rejects parent escapes", async () => {
     const html = '<a href="/">Home</a><script src="../outside.js"></script><img src="/../secret.png">';
     const result = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
 
     expect(result).toContain('href="/preview/proj/?v=123&pt=token"');
     expect(result).toContain('src="../outside.js"');
     expect(result).toContain('src="/../secret.png"');
-    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["index.html"]);
-  });
-
-  it("preserves root-relative trailing slashes for directory routes", async () => {
-    const html = '<a href="/docs/">Docs</a>';
-    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
-
-    expect(rewritten).toContain('href="/preview/proj/docs/?v=123&pt=token"');
-    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["docs/"]);
-    expect(await addCacheBusterToHtml('<a href="/foo/../">Root</a>', "123", { pt: "token" }, "/preview/proj/")
-      ).toContain('href="/preview/proj/?v=123&pt=token"');
-    const repeated = '<a href="/foo//">Repeated</a>';
-    expect(await addCacheBusterToHtml(repeated, "123", { pt: "token" }, "/preview/proj/", "index.html"))
-      .toBe(repeated);
-    expect(await collectPreviewResourcePaths(repeated, "index.html")).toEqual([]);
   });
 
   it("uses browser URL semantics for query-only and dot-directory references", async () => {
@@ -297,14 +206,6 @@ describe("addCacheBusterToHtml", () => {
     expect(await collectPreviewResourcePaths('<a href=".">Directory</a>', "docs/index.html")).toEqual([
       "docs/"
     ]);
-  });
-
-  it("does not leak preview parameters through an external base", async () => {
-    const html = '<base href="https://outside.example/"><script src="app.js"></script><img src="/logo.png">';
-    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
-    expect(rewritten).toContain('<script src="app.js"></script>');
-    expect(rewritten).toContain('/preview/proj/logo.png?v=123&pt=token');
-    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["logo.png"]);
   });
 
   it("resolves later relative references from the first local base", async () => {
@@ -344,40 +245,6 @@ describe("addCacheBusterToHtml", () => {
     ]);
   });
 
-  it("leaves data and external srcset candidates untouched", async () => {
-    const html = '<img srcset="data:image/png;base64,abc, /images/hero.png 2x, https://cdn.example/hero.png 3x">';
-    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
-    expect(rewritten).toContain("data:image/png;base64,abc,");
-    expect(rewritten).toContain("https://cdn.example/hero.png 3x");
-    expect(rewritten).toContain("/preview/proj/images/hero.png?v=123&pt=token 2x");
-  });
-
-  it("fails closed for encoded root paths", async () => {
-    const html = '<img src="/%3Fsecret.png"><img src="/images/safe.png">';
-    expect(await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html"))
-      .toContain('src="/%3Fsecret.png"');
-    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["images/safe.png"]);
-  });
-
-  it("collects only relative project paths for a scoped preview grant", async () => {
-    const html = [
-      '<script src="app.js?x=1"></script>',
-      '<a href="../about.html#team">About</a>',
-      '<link href="/styles.css">',
-      '<img src="//attacker.example/pixel.png">'
-    ].join("");
-    expect(await collectPreviewResourcePaths(html, "docs/index.html")).toEqual([
-      "about.html",
-      "docs/app.js",
-      "styles.css"
-    ]);
-  });
-
-  it("generates timestamp when no version provided", async () => {
-    const html = '<link href="styles.css">';
-    const result = await addCacheBusterToHtml(html);
-    expect(result).toMatch(/styles\.css\?v=\d+/);
-  });
 });
 
 describe("buildFileTree", () => {

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -175,38 +175,38 @@ describe("isTextContentType", () => {
 });
 
 describe("addCacheBusterToHtml", () => {
-  it("adds version to link hrefs", () => {
+  it("adds version to link hrefs", async () => {
     const html = '<link rel="stylesheet" href="styles.css">';
-    const result = addCacheBusterToHtml(html, "123");
+    const result = await addCacheBusterToHtml(html, "123");
     expect(result).toBe('<link rel="stylesheet" href="styles.css?v=123">');
   });
 
-  it("adds version to script srcs", () => {
+  it("adds version to script srcs", async () => {
     const html = '<script src="app.js"></script>';
-    const result = addCacheBusterToHtml(html, "123");
+    const result = await addCacheBusterToHtml(html, "123");
     expect(result).toBe('<script src="app.js?v=123"></script>');
   });
 
-  it("adds version to img srcs", () => {
+  it("adds version to img srcs", async () => {
     const html = '<img src="photo.png">';
-    const result = addCacheBusterToHtml(html, "123");
+    const result = await addCacheBusterToHtml(html, "123");
     expect(result).toBe('<img src="photo.png?v=123">');
   });
 
-  it("does not modify external URLs", () => {
+  it("does not modify external URLs", async () => {
     const html = '<link href="https://cdn.example.com/style.css">';
-    const result = addCacheBusterToHtml(html, "123");
+    const result = await addCacheBusterToHtml(html, "123");
     expect(result).toBe(html);
   });
 
-  it("adds cache and preview-token params to relative asset and navigation URLs", () => {
+  it("adds cache and preview-token params to relative asset and navigation URLs", async () => {
     const html = [
       '<link href="styles.css">',
       '<script src="app.js"></script>',
       '<img src="photo.png">',
       '<a href="about.html">About</a>'
     ].join("");
-    const result = addCacheBusterToHtml(html, "123", { pt: "preview-token" });
+    const result = await addCacheBusterToHtml(html, "123", { pt: "preview-token" });
 
     expect(result).toContain('href="styles.css?v=123&pt=preview-token"');
     expect(result).toContain('src="app.js?v=123&pt=preview-token"');
@@ -214,7 +214,7 @@ describe("addCacheBusterToHtml", () => {
     expect(result).toContain('href="about.html?v=123&pt=preview-token"');
   });
 
-  it("leaves external and non-navigation URLs unchanged", () => {
+  it("leaves external and non-navigation URLs unchanged", async () => {
     const values = [
       "https://example.com/page",
       "http://example.com/page",
@@ -227,101 +227,92 @@ describe("addCacheBusterToHtml", () => {
     ];
     const html = values.map((href) => `<a href="${href}">x</a>`).join("");
 
-    expect(addCacheBusterToHtml(html, "123", { pt: "token" })).toBe(html);
+    expect(await addCacheBusterToHtml(html, "123", { pt: "token" })).toBe(html);
   });
 
-  it("preserves existing queries and puts preview params before fragments", () => {
-    expect(addCacheBusterToHtml(
+  it("preserves existing queries and puts preview params before fragments", async () => {
+    expect(await addCacheBusterToHtml(
       '<a href="about.html?existing=1#section">About</a>',
       "123",
       { pt: "token" }
     )).toBe('<a href="about.html?existing=1&v=123&pt=token#section">About</a>');
   });
 
-  it("never appends a preview bearer to protocol-relative or root-relative destinations", () => {
+  it("never appends a preview bearer to protocol-relative or root-relative destinations", async () => {
     const html = [
       '<img src="//attacker.example/pixel.png">',
       '<script src="/shared/app.js"></script>'
     ].join("");
-    expect(addCacheBusterToHtml(html, "123", { pt: "secret" })).toBe(html);
+    expect(await addCacheBusterToHtml(html, "123", { pt: "secret" })).toBe(html);
   });
 
-  it("rewrites root-relative destinations to the supplied site mount", () => {
+  it("rewrites root-relative destinations to the supplied site mount", async () => {
     const html = [
       '<link href="/styles.css">',
       '<script src="/app.js?cache=1#ready"></script>',
       '<img src="//attacker.example/pixel.png">'
     ].join("");
 
-    expect(addCacheBusterToHtml(html, "123", { pt: "secret" }, "/preview/proj/")).toBe([
+    expect(await addCacheBusterToHtml(html, "123", { pt: "secret" }, "/preview/proj/")).toBe([
       '<link href="/preview/proj/styles.css?v=123&pt=secret">',
       '<script src="/preview/proj/app.js?cache=1&v=123&pt=secret#ready"></script>',
       '<img src="//attacker.example/pixel.png">'
     ].join(""));
-    expect(rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toContain(
+    expect(await rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toContain(
       '<link href="/u/janedoe/site/styles.css">'
     );
   });
 
-  it("rewrites parsed URL-bearing attributes and inline CSS without touching code or comments", () => {
-    const html = [
-      '<a href="/">Home</a>',
-      '<video poster="/poster.jpg"><source srcset="/wide.jpg 1x, /small.jpg 2x"></video>',
-      '<form action="/submit"><object data="/document.pdf"></object></form>',
-      '<svg><use xlink:href="/icons.svg#check"></use></svg><button formaction="/save">Save</button>',
-      '<img data-src="/lazy.jpg" data-href="/lazy.html">',
-      '<div style="background-image: url(\'/inline-bg.png\')"></div>',
-      '<style>.hero { background: url(/style-bg.png); }</style>',
-      '<!-- <img src="/comment.png"> -->',
-      '<script>const markup = \'<img src="/script-string.png">\';</script>'
-    ].join("");
-
-    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
-    expect(result).toContain('poster="/preview/proj/poster.jpg?v=123&pt=token"');
-    expect(result).toContain('srcset="/preview/proj/wide.jpg?v=123&pt=token 1x, /preview/proj/small.jpg?v=123&pt=token 2x"');
-    expect(result).toContain('action="/preview/proj/submit?v=123&pt=token"');
-    expect(result).toContain('data="/preview/proj/document.pdf?v=123&pt=token"');
-    expect(result).toContain('xlink:href="/preview/proj/icons.svg?v=123&pt=token#check"');
-    expect(result).toContain('formaction="/preview/proj/save?v=123&pt=token"');
-    expect(result).toContain('data-src="/preview/proj/lazy.jpg?v=123&pt=token"');
-    expect(result).toContain('data-href="/preview/proj/lazy.html?v=123&pt=token"');
-    expect(result).toContain('background-image: url(\'/preview/proj/inline-bg.png?v=123&pt=token\')');
-    expect(result).toContain('background: url(/preview/proj/style-bg.png?v=123&pt=token)');
-    expect(result).toContain('<img src="/comment.png">');
-    expect(result).toContain('<img src="/script-string.png">');
-
-    expect(collectPreviewResourcePaths(html, "index.html")).toEqual([
-      "document.pdf",
-      "icons.svg",
-      "index.html",
-      "inline-bg.png",
-      "lazy.html",
-      "lazy.jpg",
-      "poster.jpg",
-      "save",
-      "small.jpg",
-      "style-bg.png",
-      "submit",
-      "wide.jpg"
-    ]);
-  });
-
-  it("maps root navigation to index and rejects parent escapes", () => {
+  it("maps root navigation to index and rejects parent escapes", async () => {
     const html = '<a href="/">Home</a><script src="../outside.js"></script><img src="/../secret.png">';
-    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+    const result = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
 
     expect(result).toContain('href="/preview/proj/?v=123&pt=token"');
     expect(result).toContain('src="../outside.js"');
     expect(result).toContain('src="/../secret.png"');
-    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["index.html"]);
+    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["index.html"]);
   });
 
-  it("preserves root-relative trailing slashes for directory routes", () => {
+  it("preserves root-relative trailing slashes for directory routes", async () => {
     const html = '<a href="/docs/">Docs</a>';
-    const rewritten = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
 
     expect(rewritten).toContain('href="/preview/proj/docs/?v=123&pt=token"');
-    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["docs/"]);
+    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["docs/"]);
+    expect(await addCacheBusterToHtml('<a href="/foo/../">Root</a>', "123", { pt: "token" }, "/preview/proj/")
+      ).toContain('href="/preview/proj/?v=123&pt=token"');
+    const repeated = '<a href="/foo//">Repeated</a>';
+    expect(await addCacheBusterToHtml(repeated, "123", { pt: "token" }, "/preview/proj/", "index.html"))
+      .toBe(repeated);
+    expect(await collectPreviewResourcePaths(repeated, "index.html")).toEqual([]);
+  });
+
+  it("uses browser URL semantics for query-only and dot-directory references", async () => {
+    expect(await collectPreviewResourcePaths('<a href="?x">Current</a>', "docs/index.html")).toEqual([
+      "docs/index.html"
+    ]);
+    expect(await collectPreviewResourcePaths('<a href="./?x">Directory</a>', "docs/index.html")).toEqual([
+      "docs/"
+    ]);
+    expect(await collectPreviewResourcePaths('<a href=".">Directory</a>', "docs/index.html")).toEqual([
+      "docs/"
+    ]);
+  });
+
+  it("does not leak preview parameters through an external base", async () => {
+    const html = '<base href="https://outside.example/"><script src="app.js"></script><img src="/logo.png">';
+    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+    expect(rewritten).toContain('<script src="app.js"></script>');
+    expect(rewritten).toContain('/preview/proj/logo.png?v=123&pt=token');
+    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["logo.png"]);
+  });
+
+  it("resolves later relative references from the first local base", async () => {
+    const html = '<base href="assets/"><script src="app.js"></script>';
+    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "docs/index.html");
+    expect(rewritten).toContain('<base href="/preview/proj/docs/assets/">');
+    expect(rewritten).toContain('<script src="app.js?v=123&pt=token"></script>');
+    expect(await collectPreviewResourcePaths(html, "docs/index.html")).toEqual(["docs/assets/app.js"]);
   });
 
   it("rewrites and scopes local CSS URLs while preserving external and data URLs", () => {
@@ -353,92 +344,38 @@ describe("addCacheBusterToHtml", () => {
     ]);
   });
 
-  it("rewrites local srcset candidates alongside data URLs", () => {
-    const srcset = "data:image/svg+xml,%3Csvg%3E 1x, /images/a.png 2x, /images/b.png 3x";
-    const html = `<img srcset="${srcset}">`;
-    const result = addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
-
-    expect(result).toContain(
-      'srcset="data:image/svg+xml,%3Csvg%3E 1x, /preview/proj/images/a.png?v=123&pt=token 2x, /preview/proj/images/b.png?v=123&pt=token 3x"'
-    );
-    expect(collectPreviewResourcePaths(html, "index.html")).toEqual(["images/a.png", "images/b.png"]);
-
-    const mixedWithoutDataDescriptor = 'data:image/png;base64,abc, /images/c.png 2x';
-    const withoutDescriptor = addCacheBusterToHtml(
-      `<img srcset="${mixedWithoutDataDescriptor}">`,
-      "123",
-      { pt: "token" },
-      "/preview/proj/",
-      "index.html"
-    );
-    expect(withoutDescriptor).toContain(
-      'srcset="data:image/png;base64,abc, /preview/proj/images/c.png?v=123&pt=token 2x"'
-    );
-
-    const encodedDelimiterSrcset = '<img srcset="/%2Cencoded.png 1x, /images/d.png 2x">';
-    const encodedDelimiterResult = addCacheBusterToHtml(
-      encodedDelimiterSrcset,
-      "123",
-      { pt: "token" },
-      "/preview/proj/",
-      "index.html"
-    );
-    expect(encodedDelimiterResult).toContain(
-      'srcset="/%2Cencoded.png 1x, /preview/proj/images/d.png?v=123&pt=token 2x"'
-    );
-    expect(collectPreviewResourcePaths(encodedDelimiterSrcset, "index.html")).toEqual(["images/d.png"]);
+  it("leaves data and external srcset candidates untouched", async () => {
+    const html = '<img srcset="data:image/png;base64,abc, /images/hero.png 2x, https://cdn.example/hero.png 3x">';
+    const rewritten = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
+    expect(rewritten).toContain("data:image/png;base64,abc,");
+    expect(rewritten).toContain("https://cdn.example/hero.png 3x");
+    expect(rewritten).toContain("/preview/proj/images/hero.png?v=123&pt=token 2x");
   });
 
-  it("leaves escaped CSS URL tokens and unsafe encoded path segments unchanged", () => {
-    // Preview/publish currently address R2 with the raw URL pathname. Preserve
-    // encoded candidates and fail closed rather than decoding them into a
-    // different storage key or a CSS/HTML delimiter.
-    const css = String.raw`.escaped { background: url(/images/escaped\).png); }
-.safe { background: url(/images/safe.png); }
-.query { background: url(/%3Fsecret.png); }
-.fragment { background: url(/%23secret.png); }
-.space { background: url(/space%20name.png); }
-.double { background: url("/%22double.png"); }
-.single { background: url('/%27single.png'); }
-.markup { background: url(/%3Ctag%3E.png); }
-.ampersand { background: url(/%26name.png); }
-.parentheses { background: url(/%28name%29.png); }`;
-    const rewritten = addCacheBusterToCss(css, "123", { pt: "token" }, "/preview/proj/", "styles/main.css");
-
-    expect(rewritten).toContain(String.raw`url(/images/escaped\).png)`);
-    expect(rewritten).toContain("url(/preview/proj/images/safe.png?v=123&pt=token)");
-    expect(rewritten).toContain("url(/%3Fsecret.png)");
-    expect(rewritten).toContain("url(/%23secret.png)");
-    expect(rewritten).toContain("url(/space%20name.png)");
-    expect(rewritten).toContain('url("/%22double.png")');
-    expect(rewritten).toContain("url('/%27single.png')");
-    expect(rewritten).toContain("url(/%3Ctag%3E.png)");
-    expect(rewritten).toContain("url(/%26name.png)");
-    expect(rewritten).toContain("url(/%28name%29.png)");
-    expect(collectPreviewCssResourcePaths(css, "styles/main.css")).toEqual(["images/safe.png"]);
-
-    const html = '<img src="/%3Fsecret.png"><img src=\'/%23secret.png\'><img src="/%252Fsecret.png"><img src="/space%20name.png"><img src="/%22double.png"><img src=\'/%27single.png\'><img src="/%3Ctag%3E.png"><img src="/%26name.png"><img src=/%60tick.png><img src=/%3Dequals.png>';
-    expect(rewriteRootRelativeHtmlUrls(html, "/u/janedoe/site/")).toBe(html);
-    expect(collectPreviewResourcePaths(html, "index.html")).toEqual([]);
+  it("fails closed for encoded root paths", async () => {
+    const html = '<img src="/%3Fsecret.png"><img src="/images/safe.png">';
+    expect(await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html"))
+      .toContain('src="/%3Fsecret.png"');
+    expect(await collectPreviewResourcePaths(html, "index.html")).toEqual(["images/safe.png"]);
   });
 
-  it("collects only relative project paths for a scoped preview grant", () => {
+  it("collects only relative project paths for a scoped preview grant", async () => {
     const html = [
       '<script src="app.js?x=1"></script>',
       '<a href="../about.html#team">About</a>',
       '<link href="/styles.css">',
       '<img src="//attacker.example/pixel.png">'
     ].join("");
-    expect(collectPreviewResourcePaths(html, "docs/index.html")).toEqual([
+    expect(await collectPreviewResourcePaths(html, "docs/index.html")).toEqual([
       "about.html",
       "docs/app.js",
       "styles.css"
     ]);
   });
 
-  it("generates timestamp when no version provided", () => {
+  it("generates timestamp when no version provided", async () => {
     const html = '<link href="styles.css">';
-    const result = addCacheBusterToHtml(html);
+    const result = await addCacheBusterToHtml(html);
     expect(result).toMatch(/styles\.css\?v=\d+/);
   });
 });

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -1,6 +1,9 @@
 import { CONTENT_TYPES } from "./constants";
 import type { ProjectTreeNode, StorageFile } from "../types";
 
+const URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const PREVIEW_ORIGIN = "https://preview.invalid";
+
 export function sanitizeProjectId(name: string): string {
   const projectId = name
     .trim()
@@ -50,253 +53,256 @@ export function isTextContentType(contentType: string): boolean {
   );
 }
 
-export function addCacheBusterToHtml(
+type MarkupState = {
+  basePath: string;
+  baseExternal: boolean;
+  baseSeen: boolean;
+  paths?: Set<string>;
+};
+
+type MarkupOptions = {
+  documentPath: string;
+  includeRootRelative: boolean;
+  rootPath?: string;
+};
+
+type UrlRewrite = (url: string, state: MarkupState) => string;
+type BaseResolution = { path: string | null; external: boolean };
+
+export async function addCacheBusterToHtml(
   html: string,
   version?: string,
   extraParams: Record<string, string> = {},
   rootPath?: string,
-  documentPath?: string
-): string {
-  const value = version || Date.now().toString();
-  const params = { v: value, ...extraParams };
-
-  return rewriteLocalHtmlUrls(
+  documentPath = "index.html"
+): Promise<string> {
+  const params = { v: version || Date.now().toString(), ...extraParams };
+  return rewriteMarkup(
     html,
     (url) => addQueryParams(rewriteRootRelativeUrl(url, rootPath), params),
-    { includeRootRelative: Boolean(rootPath), documentPath }
+    { documentPath, includeRootRelative: Boolean(rootPath), rootPath }
   );
 }
 
-const URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
-const RAW_HTML_TAGS = new Set(["script", "style", "textarea", "title"]);
+async function rewriteMarkup(
+  markup: string,
+  rewrite: UrlRewrite,
+  options: MarkupOptions,
+  paths?: Set<string>
+): Promise<string> {
+  const state: MarkupState = {
+    basePath: options.documentPath,
+    baseExternal: false,
+    baseSeen: false,
+    paths
+  };
+  let styleText = "";
 
-type HtmlRewriteOptions = {
-  includeRootRelative?: boolean;
-  documentPath?: string;
-};
+  const rewriter = new HTMLRewriter()
+    .on("*", {
+      element(element) {
+        const tagName = element.tagName.toLowerCase();
+        const attributes = Array.from(element.attributes, (attribute) => {
+          if (Array.isArray(attribute)) {
+            return { name: attribute[0], value: attribute[1] };
+          }
+          return { name: attribute.name, value: attribute.value };
+        });
+        for (const attribute of attributes) {
+          const { name, value } = attribute;
+          const lowerName = name.toLowerCase();
+          if (tagName === "base" && lowerName === "href" && !state.baseSeen) {
+            state.baseSeen = true;
+            const base = resolveBaseHref(value, state.basePath);
+            if (base.external) {
+              state.baseExternal = true;
+            } else if (base.path !== null) {
+              state.basePath = base.path;
+              if (options.rootPath) {
+                element.setAttribute(name, mountPath(options.rootPath, base.path));
+              }
+            }
+            continue;
+          }
+          if (tagName === "base" && lowerName === "href") continue;
 
-type UrlRewrite = (url: string) => string;
+          const rewritten = rewriteMarkupAttribute(
+            name,
+            value,
+            state,
+            options,
+            rewrite
+          );
+          if (rewritten !== value) element.setAttribute(name, rewritten);
+        }
+      }
+    })
+    .on("style", {
+      text(text) {
+        styleText += text.text;
+        if (!text.lastInTextNode) {
+          text.remove();
+          return;
+        }
+        const rewritten = rewriteCssUrls(
+          styleText,
+          (url) => rewriteMarkupUrl(url, state, options, rewrite)
+        );
+        text.replace(rewritten, { html: true });
+        styleText = "";
+      }
+    });
+
+  return rewriter.transform(new Response(markup)).text();
+}
+
+function rewriteMarkupAttribute(
+  name: string,
+  value: string,
+  state: MarkupState,
+  options: MarkupOptions,
+  rewrite: UrlRewrite
+): string {
+  const lower = name.toLowerCase();
+  if (lower === "style") {
+    return rewriteCssUrls(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
+  }
+  if (isSrcsetAttribute(lower)) {
+    return rewriteSrcset(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
+  }
+  if (!isUrlAttribute(lower)) return value;
+  return rewriteMarkupUrl(value, state, options, rewrite);
+}
+
+function rewriteMarkupUrl(
+  value: string,
+  state: MarkupState,
+  options: MarkupOptions,
+  rewrite: UrlRewrite
+): string {
+  const { leading, core, trailing } = splitTrimmed(value);
+  if (!isLocalUrl(core, options.includeRootRelative)) return value;
+  if (state.baseExternal && !core.startsWith("/")) return value;
+  const path = resolvePreviewResourcePath(core, state.basePath);
+  if (!path) return value;
+  state.paths?.add(path);
+  return `${leading}${rewrite(core, state)}${trailing}`;
+}
 
 function isUrlAttribute(name: string): boolean {
-  const lower = name.toLowerCase();
-  if (["href", "src", "xlink:href", "poster", "action", "formaction", "data"].includes(lower)) return true;
-  if (lower.startsWith("data-")) {
-    const suffix = lower.slice("data-".length);
-    return suffix === "background"
-      || suffix === "background-image"
-      || suffix === "image"
-      || /(?:^|[-_:])(?:href|poster|src|url)(?:$|[-_:])/.test(suffix);
+  if (["href", "src", "xlink:href", "poster", "action", "formaction", "data"].includes(name)) return true;
+  if (!name.startsWith("data-")) return false;
+  const suffix = name.slice(5);
+  return suffix === "background"
+    || suffix === "background-image"
+    || suffix === "image"
+    || /(?:^|[-_:])(?:href|poster|src|url)(?:$|[-_:])/.test(suffix);
+}
+
+function isSrcsetAttribute(name: string): boolean {
+  return name === "srcset" || name === "data-srcset" || name.endsWith("-srcset");
+}
+
+function isLocalUrl(value: string, includeRootRelative: boolean): boolean {
+  const trimmed = value.trim();
+  const rootRelative = trimmed.startsWith("/") && !trimmed.startsWith("//");
+  return trimmed.length > 0
+    && !trimmed.startsWith("#")
+    && !trimmed.startsWith("//")
+    && (!rootRelative || includeRootRelative)
+    && !URI_SCHEME_RE.test(trimmed);
+}
+
+function resolveBaseHref(value: string, documentPath: string): BaseResolution {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("//") || URI_SCHEME_RE.test(trimmed)) {
+    return { path: null, external: true };
+  }
+  if (!isLocalUrl(trimmed, true)) return { path: documentPath, external: false };
+  const pathPart = stripUrlPath(trimmed);
+  if (hasPathEscape(pathPart, documentPath)) return { path: null, external: false };
+  try {
+    const pathname = new URL(trimmed, `${PREVIEW_ORIGIN}/${documentPath}`).pathname;
+    if (pathname.includes("%")) return { path: null, external: false };
+    return { path: pathname === "/" ? "" : pathname.slice(1), external: false };
+  } catch {
+    return { path: null, external: false };
+  }
+}
+
+function resolvePreviewResourcePath(value: string, documentPath: string): string | null {
+  const trimmed = value.trim();
+  if (!isLocalUrl(trimmed, true)) return null;
+  const pathPart = stripUrlPath(trimmed);
+  if (hasPathEscape(pathPart, documentPath)) return null;
+  try {
+    const pathname = new URL(trimmed, `${PREVIEW_ORIGIN}/${documentPath}`).pathname;
+    if (pathname.includes("%")) return null;
+    return pathname === "/" ? "index.html" : pathname.slice(1);
+  } catch {
+    return null;
+  }
+}
+
+function stripUrlPath(value: string): string {
+  const hash = value.indexOf("#");
+  const beforeFragment = hash >= 0 ? value.slice(0, hash) : value;
+  const query = beforeFragment.indexOf("?");
+  return query >= 0 ? beforeFragment.slice(0, query) : beforeFragment;
+}
+
+function hasPathEscape(pathPart: string, documentPath?: string): boolean {
+  const pathWithoutRoot = pathPart.startsWith("/") ? pathPart.slice(1) : pathPart;
+  if (pathWithoutRoot.includes("//") || pathPart.includes("%")) return true;
+  let depth = pathPart.startsWith("/")
+    ? 0
+    : (documentPath?.split("/").slice(0, -1).filter(Boolean).length || 0);
+  for (const segment of pathPart.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      depth -= 1;
+      if (depth < 0) return true;
+      continue;
+    }
+    if (segment.includes("\\") || segment.includes("\0") || /[?#"'<> &]/.test(segment)) return true;
+    depth += 1;
   }
   return false;
 }
 
-function isSrcsetAttribute(name: string): boolean {
-  const lower = name.toLowerCase();
-  return lower === "srcset" || lower === "data-srcset" || lower.endsWith("-srcset");
-}
-
-function isLocalPreviewUrl(value: string, includeRootRelative = false): boolean {
+function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
+  if (!rootPath) return value;
   const trimmed = value.trim();
-  const isProtocolRelative = trimmed.startsWith("//");
-  const isRootRelative = trimmed.startsWith("/") && !isProtocolRelative;
-  return (
-    trimmed.length > 0 &&
-    !trimmed.startsWith("#") &&
-    !isProtocolRelative &&
-    (!isRootRelative || includeRootRelative) &&
-    !URI_SCHEME_RE.test(trimmed)
-  );
-}
-
-function rewriteLocalHtmlUrls(
-  html: string,
-  rewrite: UrlRewrite,
-  options: HtmlRewriteOptions = {}
-): string {
-  let output = "";
-  let cursor = 0;
-
-  while (cursor < html.length) {
-    const tagStart = html.indexOf("<", cursor);
-    if (tagStart < 0) {
-      output += html.slice(cursor);
-      break;
-    }
-    output += html.slice(cursor, tagStart);
-
-    if (html.startsWith("<!--", tagStart)) {
-      const commentEnd = html.indexOf("-->", tagStart + 4);
-      if (commentEnd < 0) {
-        output += html.slice(tagStart);
-        break;
-      }
-      const end = commentEnd + 3;
-      output += html.slice(tagStart, end);
-      cursor = end;
-      continue;
-    }
-
-    const tagEnd = findHtmlTagEnd(html, tagStart + 1);
-    if (tagEnd < 0) {
-      output += html.slice(tagStart);
-      break;
-    }
-
-    const tag = html.slice(tagStart, tagEnd + 1);
-    const parsedTag = parseHtmlTag(tag);
-    output += parsedTag
-      ? rewriteHtmlTag(tag, rewrite, options)
-      : tag;
-    cursor = tagEnd + 1;
-
-    if (!parsedTag || parsedTag.closing || parsedTag.selfClosing || !RAW_HTML_TAGS.has(parsedTag.name)) {
-      continue;
-    }
-
-    const rawClose = findRawHtmlClosingTag(html, cursor, parsedTag.name);
-    if (rawClose < 0) {
-      const body = html.slice(cursor);
-      output += parsedTag.name === "style"
-        ? rewriteCssUrls(body, rewrite, options)
-        : body;
-      break;
-    }
-    const body = html.slice(cursor, rawClose);
-    output += parsedTag.name === "style"
-      ? rewriteCssUrls(body, rewrite, options)
-      : body;
-    cursor = rawClose;
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return value;
+  const leadingLength = value.length - value.trimStart().length;
+  const trailingLength = value.length - value.trimEnd().length;
+  const leading = value.slice(0, leadingLength);
+  const trailing = trailingLength > 0 ? value.slice(value.length - trailingLength) : "";
+  const core = trailingLength > 0
+    ? value.slice(leadingLength, value.length - trailingLength)
+    : value.slice(leadingLength);
+  const path = stripUrlPath(core);
+  if (hasPathEscape(path)) return value;
+  const hash = core.indexOf("#");
+  const fragment = hash >= 0 ? core.slice(hash) : "";
+  const beforeFragment = hash >= 0 ? core.slice(0, hash) : core;
+  const query = beforeFragment.indexOf("?");
+  const suffix = query >= 0
+    ? `${beforeFragment.slice(query)}${fragment}`
+    : fragment;
+  try {
+    const normalized = new URL(path, `${PREVIEW_ORIGIN}/`).pathname;
+    if (normalized.includes("%")) return value;
+    return `${leading}${mountPath(rootPath, normalized.slice(1))}${suffix}${trailing}`;
+  } catch {
+    return value;
   }
-
-  return output;
 }
 
-function findHtmlTagEnd(html: string, start: number): number {
-  let quote: string | null = null;
-  for (let index = start; index < html.length; index += 1) {
-    const character = html[index];
-    if (quote) {
-      if (character === quote) quote = null;
-      continue;
-    }
-    if (character === "\"" || character === "'") {
-      quote = character;
-    } else if (character === ">") {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function findRawHtmlClosingTag(html: string, start: number, tagName: string): number {
-  const closing = new RegExp(`<\\/\\s*${tagName}\\b`, "ig");
-  closing.lastIndex = start;
-  const match = closing.exec(html);
-  return match?.index ?? -1;
-}
-
-function parseHtmlTag(tag: string): { name: string; closing: boolean; selfClosing: boolean } | null {
-  const match = /^<\s*(\/?|\?)\s*([A-Za-z][A-Za-z0-9:_-]*)/.exec(tag);
-  if (!match) return null;
-  return {
-    name: match[2].toLowerCase(),
-    closing: match[1] === "/",
-    selfClosing: match[1] === "?" || /\/\s*>$/.test(tag)
-  };
-}
-
-function rewriteHtmlTag(
-  tag: string,
-  rewrite: UrlRewrite,
-  options: HtmlRewriteOptions
-): string {
-  const tagMatch = /^<\s*(?:\/?|\?)\s*[A-Za-z][A-Za-z0-9:_-]*/.exec(tag);
-  if (!tagMatch) return tag;
-
-  let output = tag.slice(0, tagMatch[0].length);
-  let cursor = tagMatch[0].length;
-  while (cursor < tag.length) {
-    if (tag[cursor] === ">") {
-      output += tag.slice(cursor);
-      break;
-    }
-
-    const attributeStart = cursor;
-    while (cursor < tag.length && /\s/.test(tag[cursor])) cursor += 1;
-    if (cursor >= tag.length) {
-      output += tag.slice(attributeStart);
-      break;
-    }
-    if (tag[cursor] === "/") {
-      output += tag.slice(attributeStart);
-      break;
-    }
-
-    const nameStart = cursor;
-    while (cursor < tag.length && !/[\s=/>]/.test(tag[cursor])) cursor += 1;
-    if (cursor === nameStart) {
-      output += tag.slice(attributeStart, cursor + 1);
-      cursor += 1;
-      continue;
-    }
-
-    const attributeName = tag.slice(nameStart, cursor);
-    let equals = cursor;
-    while (equals < tag.length && /\s/.test(tag[equals])) equals += 1;
-    if (tag[equals] !== "=") {
-      output += tag.slice(attributeStart, equals);
-      cursor = equals;
-      continue;
-    }
-
-    let valueStart = equals + 1;
-    while (valueStart < tag.length && /\s/.test(tag[valueStart])) valueStart += 1;
-    if (valueStart >= tag.length) {
-      output += tag.slice(attributeStart);
-      break;
-    }
-
-    const quote = tag[valueStart] === "\"" || tag[valueStart] === "'" ? tag[valueStart] : null;
-    const contentStart = quote ? valueStart + 1 : valueStart;
-    let valueEnd = contentStart;
-    if (quote) {
-      while (valueEnd < tag.length && tag[valueEnd] !== quote) valueEnd += 1;
-    } else {
-      while (valueEnd < tag.length && !/[\s>]/.test(tag[valueEnd])) valueEnd += 1;
-    }
-
-    const rawValue = tag.slice(contentStart, valueEnd);
-    const rewritten = rewriteHtmlAttribute(attributeName, rawValue, rewrite, options);
-    output += tag.slice(attributeStart, contentStart);
-    output += rewritten;
-    if (quote && valueEnd < tag.length) output += quote;
-    cursor = quote && valueEnd < tag.length ? valueEnd + 1 : valueEnd;
-  }
-
-  return output;
-}
-
-function rewriteHtmlAttribute(
-  name: string,
-  value: string,
-  rewrite: UrlRewrite,
-  options: HtmlRewriteOptions
-): string {
-  if (isSrcsetAttribute(name)) {
-    return rewriteSrcset(value, rewrite, options);
-  }
-  if (name.toLowerCase() === "style") {
-    return rewriteCssUrls(value, rewrite, options);
-  }
-  if (!isUrlAttribute(name)) return value;
-  return rewriteLocalUrlValue(value, rewrite, options);
-}
-
-function rewriteLocalUrlValue(value: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
-  const { leading, core, trailing } = splitTrimmed(value);
-  if (!isLocalPreviewUrl(core, options.includeRootRelative)) return value;
-  if (options.documentPath && !resolvePreviewResourcePath(core, options.documentPath)) return value;
-  return `${leading}${rewrite(core)}${trailing}`;
+function mountPath(rootPath: string, filePath: string): string {
+  const root = rootPath.trim().replace(/\/+$/, "") || "/";
+  const suffix = filePath.replace(/^\/+/, "");
+  return root === "/" ? `/${suffix}` : `${root}/${suffix}`;
 }
 
 function splitTrimmed(value: string) {
@@ -311,63 +317,42 @@ function splitTrimmed(value: string) {
   };
 }
 
-function rewriteSrcset(value: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
-  const candidates = splitSrcsetCandidates(value);
-  return candidates.map((candidate) => {
+function rewriteSrcset(value: string, rewrite: (url: string) => string): string {
+  return splitSrcsetCandidates(value).map((candidate) => {
     const { leading, core, trailing } = splitTrimmed(candidate);
     if (!core) return candidate;
     const match = /^(?:"([^"]*)"|'([^']*)'|(\S+))([\s\S]*)$/.exec(core);
     if (!match) return candidate;
     const url = match[1] ?? match[2] ?? match[3];
     const quote = match[1] !== undefined ? '"' : match[2] !== undefined ? "'" : "";
-    const rewritten = rewriteLocalUrlValue(url, rewrite, options);
-    return `${leading}${quote}${rewritten}${quote}${match[4]}${trailing}`;
+    const next = rewrite(url);
+    return `${leading}${quote}${next}${quote}${match[4]}${trailing}`;
   }).join(",");
 }
 
 function splitSrcsetCandidates(value: string): string[] {
   const candidates: string[] = [];
   let start = 0;
-  let index = 0;
   let quote: string | null = null;
   let parentheses = 0;
-  let dataUrlStart = findDataUrlStart(value, start);
-  let dataUrl = dataUrlStart >= 0;
-  let dataUrlHasWhitespace = false;
-  while (index < value.length) {
+  let dataStart = findDataUrlStart(value, start);
+  let dataWhitespace = false;
+  for (let index = 0; index < value.length; index += 1) {
     const character = value[index];
     if (quote) {
       if (character === quote && !isEscapedAt(value, index)) quote = null;
-      index += 1;
       continue;
     }
-    if (character === "\"" || character === "'") {
-      quote = character;
-    } else if (character === "(") {
-      parentheses += 1;
-    } else if (character === ")") {
-      parentheses = Math.max(0, parentheses - 1);
-    } else if (dataUrl && index >= dataUrlStart && /\s/.test(character)) {
-      dataUrlHasWhitespace = true;
-    } else if (
-      character === ","
-      && parentheses === 0
-      && (!dataUrl || dataUrlHasWhitespace || /\s/.test(value[index + 1] ?? ""))
-    ) {
-      // A data URL owns its payload commas. A comma followed by whitespace
-      // still unambiguously starts the next candidate when the data URL has
-      // no descriptor.
+    if (character === "\"" || character === "'") quote = character;
+    else if (character === "(") parentheses += 1;
+    else if (character === ")") parentheses = Math.max(0, parentheses - 1);
+    else if (dataStart >= 0 && index >= dataStart && /\s/.test(character)) dataWhitespace = true;
+    else if (character === "," && parentheses === 0 && (dataStart < 0 || dataWhitespace || /\s/.test(value[index + 1] ?? ""))) {
       candidates.push(value.slice(start, index));
       start = index + 1;
-      index = start;
-      quote = null;
-      parentheses = 0;
-      dataUrlStart = findDataUrlStart(value, start);
-      dataUrl = dataUrlStart >= 0;
-      dataUrlHasWhitespace = false;
-      continue;
+      dataStart = findDataUrlStart(value, start);
+      dataWhitespace = false;
     }
-    index += 1;
   }
   candidates.push(value.slice(start));
   return candidates;
@@ -379,19 +364,16 @@ function findDataUrlStart(value: string, start: number): number {
   return value.slice(index, index + 5).toLowerCase() === "data:" ? index : -1;
 }
 
-function rewriteCssUrls(css: string, rewrite: UrlRewrite, options: HtmlRewriteOptions = {}): string {
+function rewriteCssUrls(css: string, rewrite: (url: string) => string): string {
   let output = "";
   let cursor = 0;
   while (cursor < css.length) {
     if (css.startsWith("/*", cursor)) {
       const end = css.indexOf("*/", cursor + 2);
-      if (end < 0) {
-        output += css.slice(cursor);
-        break;
-      }
-      const commentEnd = end + 2;
-      output += css.slice(cursor, commentEnd);
-      cursor = commentEnd;
+      if (end < 0) return output + css.slice(cursor);
+      const next = end + 2;
+      output += css.slice(cursor, next);
+      cursor = next;
       continue;
     }
     if (css[cursor] === "\"" || css[cursor] === "'") {
@@ -400,14 +382,12 @@ function rewriteCssUrls(css: string, rewrite: UrlRewrite, options: HtmlRewriteOp
       cursor = end;
       continue;
     }
-
-    const rewrittenImport = rewriteCssImportString(css, cursor, rewrite, options);
-    if (rewrittenImport) {
-      output += rewrittenImport.text;
-      cursor = rewrittenImport.end;
+    const imported = rewriteCssImportString(css, cursor, rewrite);
+    if (imported) {
+      output += imported.text;
+      cursor = imported.end;
       continue;
     }
-
     const open = findCssUrlOpen(css, cursor);
     if (open < 0) {
       output += css[cursor];
@@ -416,40 +396,29 @@ function rewriteCssUrls(css: string, rewrite: UrlRewrite, options: HtmlRewriteOp
     }
     output += css.slice(cursor, open + 1);
     const close = findCssFunctionEnd(css, open + 1);
-    if (close < 0) {
-      output += css.slice(open + 1);
-      break;
-    }
+    if (close < 0) return output + css.slice(open + 1);
     const inner = css.slice(open + 1, close);
-    output += rewriteCssUrlArgument(inner, rewrite, options);
+    output += rewriteCssUrlArgument(inner, rewrite);
     output += ")";
     cursor = close + 1;
   }
   return output;
 }
 
-function rewriteCssImportString(
-  css: string,
-  start: number,
-  rewrite: UrlRewrite,
-  options: HtmlRewriteOptions
-) {
+function rewriteCssImportString(css: string, start: number, rewrite: (url: string) => string) {
   if (css.slice(start, start + 7).toLowerCase() !== "@import") return null;
   const afterName = css[start + 7];
   if (afterName && /[A-Za-z0-9_-]/.test(afterName)) return null;
-
   let quoteStart = start + 7;
   while (quoteStart < css.length && /\s/.test(css[quoteStart])) quoteStart += 1;
   const quote = css[quoteStart];
   if (quote !== "\"" && quote !== "'") return null;
-
   const end = findCssStringEnd(css, quoteStart);
   if (end <= quoteStart || css[end - 1] !== quote) return null;
-  const rawUrl = css.slice(quoteStart + 1, end - 1);
-  const rewritten = rewriteLocalUrlValue(rawUrl, rewrite, options);
+  const url = css.slice(quoteStart + 1, end - 1);
   return {
     end,
-    text: `${css.slice(start, quoteStart + 1)}${rewritten}${quote}`
+    text: `${css.slice(start, quoteStart + 1)}${rewrite(url)}${quote}`
   };
 }
 
@@ -468,11 +437,8 @@ function findCssFunctionEnd(css: string, start: number): number {
     const character = css[index];
     if (quote) {
       if (character === quote && !isEscapedAt(css, index)) quote = null;
-    } else if (character === "\"" || character === "'") {
-      quote = character;
-    } else if (character === ")" && !isEscapedAt(css, index)) {
-      return index;
-    }
+    } else if (character === "\"" || character === "'") quote = character;
+    else if (character === ")" && !isEscapedAt(css, index)) return index;
   }
   return -1;
 }
@@ -486,24 +452,18 @@ function findCssStringEnd(css: string, start: number): number {
 }
 
 function isEscapedAt(value: string, index: number): boolean {
-  let slashCount = 0;
-  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
-    slashCount += 1;
-  }
-  return slashCount % 2 === 1;
+  let slashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) slashes += 1;
+  return slashes % 2 === 1;
 }
 
-function rewriteCssUrlArgument(inner: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
+function rewriteCssUrlArgument(inner: string, rewrite: (url: string) => string): string {
   const { leading, core, trailing } = splitTrimmed(inner);
-  if (!core) return inner;
-  // CSS escapes can change token boundaries (for example `\)` inside an
-  // unquoted URL). Leave those authored tokens byte-for-byte intact until a
-  // CSS tokenizer is available instead of guessing at their decoded path.
-  if (core.includes("\\") || hasUnsafeCssTokenCharacter(core)) return inner;
+  if (!core || core.includes("\\") || /[\p{Cc}\p{Zs}]/u.test(core)) return inner;
   const quote = core[0] === "\"" || core[0] === "'" ? core[0] : null;
   const url = quote && core.endsWith(quote) ? core.slice(1, -1) : core;
-  const rewritten = rewriteLocalUrlValue(url, rewrite, options);
-  const wrapped = quote && core.endsWith(quote) ? `${quote}${rewritten}${quote}` : rewritten;
+  const next = rewrite(url);
+  const wrapped = quote && core.endsWith(quote) ? `${quote}${next}${quote}` : next;
   return `${leading}${wrapped}${trailing}`;
 }
 
@@ -512,109 +472,26 @@ export function addCacheBusterToCss(
   version?: string,
   extraParams: Record<string, string> = {},
   rootPath?: string,
-  documentPath?: string
+  documentPath = "index.css"
 ): string {
-  const value = version || Date.now().toString();
-  const params = { v: value, ...extraParams };
-  return rewriteCssUrls(
-    css,
-    (url) => addQueryParams(rewriteRootRelativeUrl(url, rootPath), params),
-    { includeRootRelative: Boolean(rootPath), documentPath }
-  );
+  const params = { v: version || Date.now().toString(), ...extraParams };
+  return rewriteCssUrls(css, (url) => {
+    const path = resolvePreviewResourcePath(url, documentPath);
+    if (!path) return url;
+    return addQueryParams(rewriteRootRelativeUrl(url, rootPath), params);
+  });
 }
 
-function normalizeRootPath(rootPath: string): string {
-  const trimmed = rootPath.trim();
-  if (!trimmed) return "/";
-  const rooted = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return `${rooted.replace(/\/+$/, "")}/`;
-}
-
-function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
-  if (!rootPath) return value;
-
-  const trimmed = value.trim();
-  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return value;
-
-  const leadingLength = value.length - value.trimStart().length;
-  const trailingLength = value.length - value.trimEnd().length;
-  const leading = value.slice(0, leadingLength);
-  const trailing = trailingLength > 0 ? value.slice(value.length - trailingLength) : "";
-  const core = trailingLength > 0
-    ? value.slice(leadingLength, value.length - trailingLength)
-    : value.slice(leadingLength);
-
-  const hashIndex = core.indexOf("#");
-  const fragment = hashIndex >= 0 ? core.slice(hashIndex) : "";
-  const beforeFragment = hashIndex >= 0 ? core.slice(0, hashIndex) : core;
-  const queryIndex = beforeFragment.indexOf("?");
-  const path = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
-  const suffix = queryIndex >= 0
-    ? `${beforeFragment.slice(queryIndex)}${fragment}`
-    : fragment;
-  const normalizedPath = normalizeRootRelativePath(path);
-  if (normalizedPath === null) return value;
-  const trailingSlash = path.length > 1 && path.endsWith("/") ? "/" : "";
-  const root = normalizeRootPath(rootPath);
-  return `${leading}${root}${normalizedPath}${trailingSlash}${suffix}${trailing}`;
-}
-
-function normalizeRootRelativePath(path: string): string | null {
-  const segments: string[] = [];
-  for (const rawSegment of path.slice(1).split("/")) {
-    if (rawSegment.includes("%")) return null;
-    let segment: string;
-    try {
-      segment = decodeURIComponent(rawSegment);
-    } catch {
-      return null;
-    }
-    if (!segment || segment === ".") continue;
-    if (segment === "..") {
-      if (segments.length === 0) return null;
-      segments.pop();
-      continue;
-    }
-    if (isUnsafeDecodedPathSegment(segment)) return null;
-    segments.push(segment);
-  }
-  return segments.join("/");
-}
-
-function isUnsafeDecodedPathSegment(segment: string): boolean {
-  for (const character of segment) {
-    if ("\\/?#%\"'<> &".includes(character)) return true;
-    const code = character.charCodeAt(0);
-    if (code <= 0x20 || code === 0x7f) return true;
-  }
-  return false;
-}
-
-function hasUnsafeCssTokenCharacter(value: string): boolean {
-  for (const character of value) {
-    const code = character.charCodeAt(0);
-    if (code <= 0x20 || code === 0x7f) return true;
-  }
-  return false;
-}
-
-/**
- * Rewrite root-relative authored URLs to the canonical site mount. A static
- * document's `/styles.css` means "from this site's root", not from the app
- * origin; without this boundary rewrite it falls through to the SPA shell.
- */
-export function rewriteRootRelativeHtmlUrls(html: string, rootPath: string): string {
-  return rewriteLocalHtmlUrls(
+export async function rewriteRootRelativeHtmlUrls(html: string, rootPath: string): Promise<string> {
+  return rewriteMarkup(
     html,
     (url) => rewriteRootRelativeUrl(url, rootPath),
-    { includeRootRelative: true }
+    { documentPath: "index.html", includeRootRelative: true, rootPath }
   );
 }
 
 export function rewriteRootRelativeCssUrls(css: string, rootPath: string): string {
-  return rewriteCssUrls(css, (url) => rewriteRootRelativeUrl(url, rootPath), {
-    includeRootRelative: true
-  });
+  return rewriteCssUrls(css, (url) => rewriteRootRelativeUrl(url, rootPath));
 }
 
 function addQueryParams(value: string, params: Record<string, string>): string {
@@ -624,82 +501,33 @@ function addQueryParams(value: string, params: Record<string, string>): string {
   const queryIndex = beforeFragment.indexOf("?");
   const pathname = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
   const search = new URLSearchParams(queryIndex >= 0 ? beforeFragment.slice(queryIndex + 1) : "");
-  for (const [key, paramValue] of Object.entries(params)) {
-    search.set(key, paramValue);
-  }
+  for (const [key, paramValue] of Object.entries(params)) search.set(key, paramValue);
   return `${pathname}?${search.toString()}${fragment}`;
 }
 
-/**
- * Resolve the authored relative URLs that a preview document may request.
- * Preview bearer grants are scoped to this set so a token visible to authored
- * JavaScript cannot read arbitrary, unlinked project files.
- */
-export function collectPreviewResourcePaths(html: string, documentPath: string): string[] {
+export async function collectPreviewResourcePaths(html: string, documentPath: string): Promise<string[]> {
   const paths = new Set<string>();
-  rewriteLocalHtmlUrls(html, (value) => {
-    const path = resolvePreviewResourcePath(value, documentPath);
-    if (path) paths.add(path);
-    return value;
-  }, { includeRootRelative: true, documentPath });
+  await rewriteMarkup(html, (url) => url, { documentPath, includeRootRelative: true }, paths);
   return [...paths].sort();
 }
 
 export function collectPreviewCssResourcePaths(css: string, documentPath: string): string[] {
   const paths = new Set<string>();
-  rewriteCssUrls(css, (value) => {
-    const path = resolvePreviewResourcePath(value, documentPath);
+  rewriteCssUrls(css, (url) => {
+    const path = resolvePreviewResourcePath(url, documentPath);
     if (path) paths.add(path);
-    return value;
-  }, { includeRootRelative: true, documentPath });
+    return url;
+  });
   return [...paths].sort();
 }
 
-function resolvePreviewResourcePath(value: string, documentPath: string): string | null {
-  const trimmed = value.trim();
-  if (!isLocalPreviewUrl(trimmed, true)) return null;
-  const hashIndex = trimmed.indexOf("#");
-  const beforeFragment = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
-  const queryIndex = beforeFragment.indexOf("?");
-  const pathPart = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
-  const rooted = pathPart.startsWith("/");
-  const baseSegments = rooted
-    ? []
-    : documentPath.replace(/\\/g, "/").split("/").slice(0, -1).filter(Boolean);
-  const segments = [...baseSegments];
-  for (const rawSegment of pathPart.split("/")) {
-    if (rawSegment.includes("%")) return null;
-    let segment: string;
-    try {
-      segment = decodeURIComponent(rawSegment);
-    } catch {
-      return null;
-    }
-    if (!segment || segment === ".") continue;
-    if (segment === "..") {
-      if (segments.length === 0) return null;
-      segments.pop();
-      continue;
-    }
-    if (isUnsafeDecodedPathSegment(segment)) return null;
-    segments.push(segment);
-  }
-  if (segments.length === 0) return "index.html";
-  const resolved = segments.join("/");
-  return pathPart.length > 1 && pathPart.endsWith("/") ? `${resolved}/` : resolved;
-}
-
-export function buildFileTree(files: StorageFile[]): ProjectTreeNode[] {
-  type TreeNode = {
-    dirs: Record<string, TreeNode>;
-    files: ProjectTreeNode[];
-  };
+function buildFileTree(files: StorageFile[]): ProjectTreeNode[] {
+  type TreeNode = { dirs: Record<string, TreeNode>; files: ProjectTreeNode[] };
   const tree: TreeNode = { dirs: {}, files: [] };
 
   for (const file of files) {
     const parts = file.path.split("/");
     let current = tree;
-
     parts.forEach((part, index) => {
       if (index === parts.length - 1) {
         current.files.push({
@@ -711,7 +539,6 @@ export function buildFileTree(files: StorageFile[]): ProjectTreeNode[] {
         });
         return;
       }
-
       current.dirs[part] ||= { dirs: {}, files: [] };
       current = current.dirs[part];
     });
@@ -719,21 +546,15 @@ export function buildFileTree(files: StorageFile[]): ProjectTreeNode[] {
 
   function toArray(node: TreeNode, parentPath = ""): ProjectTreeNode[] {
     const entries: ProjectTreeNode[] = [];
-
     for (const key of Object.keys(node.dirs)) {
       const dirPath = parentPath ? `${parentPath}/${key}` : key;
-      entries.push({
-        name: key,
-        path: dirPath,
-        type: "directory",
-        children: toArray(node.dirs[key], dirPath),
-      });
+      entries.push({ name: key, path: dirPath, type: "directory", children: toArray(node.dirs[key], dirPath) });
     }
-
     entries.push(...node.files);
-
     return entries;
   }
 
   return toArray(tree);
 }
+
+export { buildFileTree };

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -53,33 +53,567 @@ export function isTextContentType(contentType: string): boolean {
 export function addCacheBusterToHtml(
   html: string,
   version?: string,
-  extraParams: Record<string, string> = {}
+  extraParams: Record<string, string> = {},
+  rootPath?: string,
+  documentPath?: string
 ): string {
   const value = version || Date.now().toString();
   const params = { v: value, ...extraParams };
 
-  return rewriteLocalHtmlUrls(html, (url) => addQueryParams(url, params));
+  return rewriteLocalHtmlUrls(
+    html,
+    (url) => addQueryParams(rewriteRootRelativeUrl(url, rootPath), params),
+    { includeRootRelative: Boolean(rootPath), documentPath }
+  );
 }
 
-const LOCAL_HTML_URL_RE =
-  /(<(?:link|a)\b[^>]*\bhref=["']|<(?:script|img)\b[^>]*\bsrc=["'])([^"']+)(["'][^>]*>)/gi;
 const URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const RAW_HTML_TAGS = new Set(["script", "style", "textarea", "title"]);
 
-function isLocalPreviewUrl(value: string): boolean {
+type HtmlRewriteOptions = {
+  includeRootRelative?: boolean;
+  documentPath?: string;
+};
+
+type UrlRewrite = (url: string) => string;
+
+function isUrlAttribute(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (["href", "src", "xlink:href", "poster", "action", "formaction", "data"].includes(lower)) return true;
+  if (lower.startsWith("data-")) {
+    const suffix = lower.slice("data-".length);
+    return suffix === "background"
+      || suffix === "background-image"
+      || suffix === "image"
+      || /(?:^|[-_:])(?:href|poster|src|url)(?:$|[-_:])/.test(suffix);
+  }
+  return false;
+}
+
+function isSrcsetAttribute(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === "srcset" || lower === "data-srcset" || lower.endsWith("-srcset");
+}
+
+function isLocalPreviewUrl(value: string, includeRootRelative = false): boolean {
   const trimmed = value.trim();
+  const isProtocolRelative = trimmed.startsWith("//");
+  const isRootRelative = trimmed.startsWith("/") && !isProtocolRelative;
   return (
     trimmed.length > 0 &&
     !trimmed.startsWith("#") &&
-    !trimmed.startsWith("/") &&
-    !trimmed.startsWith("//") &&
+    !isProtocolRelative &&
+    (!isRootRelative || includeRootRelative) &&
     !URI_SCHEME_RE.test(trimmed)
   );
 }
 
-function rewriteLocalHtmlUrls(html: string, rewrite: (url: string) => string): string {
-  return html.replace(LOCAL_HTML_URL_RE, (match, prefix: string, value: string, suffix: string) => {
-    if (!isLocalPreviewUrl(value)) return match;
-    return `${prefix}${rewrite(value)}${suffix}`;
+function rewriteLocalHtmlUrls(
+  html: string,
+  rewrite: UrlRewrite,
+  options: HtmlRewriteOptions = {}
+): string {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const tagStart = html.indexOf("<", cursor);
+    if (tagStart < 0) {
+      output += html.slice(cursor);
+      break;
+    }
+    output += html.slice(cursor, tagStart);
+
+    if (html.startsWith("<!--", tagStart)) {
+      const commentEnd = html.indexOf("-->", tagStart + 4);
+      if (commentEnd < 0) {
+        output += html.slice(tagStart);
+        break;
+      }
+      const end = commentEnd + 3;
+      output += html.slice(tagStart, end);
+      cursor = end;
+      continue;
+    }
+
+    const tagEnd = findHtmlTagEnd(html, tagStart + 1);
+    if (tagEnd < 0) {
+      output += html.slice(tagStart);
+      break;
+    }
+
+    const tag = html.slice(tagStart, tagEnd + 1);
+    const parsedTag = parseHtmlTag(tag);
+    output += parsedTag
+      ? rewriteHtmlTag(tag, rewrite, options)
+      : tag;
+    cursor = tagEnd + 1;
+
+    if (!parsedTag || parsedTag.closing || parsedTag.selfClosing || !RAW_HTML_TAGS.has(parsedTag.name)) {
+      continue;
+    }
+
+    const rawClose = findRawHtmlClosingTag(html, cursor, parsedTag.name);
+    if (rawClose < 0) {
+      const body = html.slice(cursor);
+      output += parsedTag.name === "style"
+        ? rewriteCssUrls(body, rewrite, options)
+        : body;
+      break;
+    }
+    const body = html.slice(cursor, rawClose);
+    output += parsedTag.name === "style"
+      ? rewriteCssUrls(body, rewrite, options)
+      : body;
+    cursor = rawClose;
+  }
+
+  return output;
+}
+
+function findHtmlTagEnd(html: string, start: number): number {
+  let quote: string | null = null;
+  for (let index = start; index < html.length; index += 1) {
+    const character = html[index];
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === "\"" || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function findRawHtmlClosingTag(html: string, start: number, tagName: string): number {
+  const closing = new RegExp(`<\\/\\s*${tagName}\\b`, "ig");
+  closing.lastIndex = start;
+  const match = closing.exec(html);
+  return match?.index ?? -1;
+}
+
+function parseHtmlTag(tag: string): { name: string; closing: boolean; selfClosing: boolean } | null {
+  const match = /^<\s*(\/?|\?)\s*([A-Za-z][A-Za-z0-9:_-]*)/.exec(tag);
+  if (!match) return null;
+  return {
+    name: match[2].toLowerCase(),
+    closing: match[1] === "/",
+    selfClosing: match[1] === "?" || /\/\s*>$/.test(tag)
+  };
+}
+
+function rewriteHtmlTag(
+  tag: string,
+  rewrite: UrlRewrite,
+  options: HtmlRewriteOptions
+): string {
+  const tagMatch = /^<\s*(?:\/?|\?)\s*[A-Za-z][A-Za-z0-9:_-]*/.exec(tag);
+  if (!tagMatch) return tag;
+
+  let output = tag.slice(0, tagMatch[0].length);
+  let cursor = tagMatch[0].length;
+  while (cursor < tag.length) {
+    if (tag[cursor] === ">") {
+      output += tag.slice(cursor);
+      break;
+    }
+
+    const attributeStart = cursor;
+    while (cursor < tag.length && /\s/.test(tag[cursor])) cursor += 1;
+    if (cursor >= tag.length) {
+      output += tag.slice(attributeStart);
+      break;
+    }
+    if (tag[cursor] === "/") {
+      output += tag.slice(attributeStart);
+      break;
+    }
+
+    const nameStart = cursor;
+    while (cursor < tag.length && !/[\s=/>]/.test(tag[cursor])) cursor += 1;
+    if (cursor === nameStart) {
+      output += tag.slice(attributeStart, cursor + 1);
+      cursor += 1;
+      continue;
+    }
+
+    const attributeName = tag.slice(nameStart, cursor);
+    let equals = cursor;
+    while (equals < tag.length && /\s/.test(tag[equals])) equals += 1;
+    if (tag[equals] !== "=") {
+      output += tag.slice(attributeStart, equals);
+      cursor = equals;
+      continue;
+    }
+
+    let valueStart = equals + 1;
+    while (valueStart < tag.length && /\s/.test(tag[valueStart])) valueStart += 1;
+    if (valueStart >= tag.length) {
+      output += tag.slice(attributeStart);
+      break;
+    }
+
+    const quote = tag[valueStart] === "\"" || tag[valueStart] === "'" ? tag[valueStart] : null;
+    const contentStart = quote ? valueStart + 1 : valueStart;
+    let valueEnd = contentStart;
+    if (quote) {
+      while (valueEnd < tag.length && tag[valueEnd] !== quote) valueEnd += 1;
+    } else {
+      while (valueEnd < tag.length && !/[\s>]/.test(tag[valueEnd])) valueEnd += 1;
+    }
+
+    const rawValue = tag.slice(contentStart, valueEnd);
+    const rewritten = rewriteHtmlAttribute(attributeName, rawValue, rewrite, options);
+    output += tag.slice(attributeStart, contentStart);
+    output += rewritten;
+    if (quote && valueEnd < tag.length) output += quote;
+    cursor = quote && valueEnd < tag.length ? valueEnd + 1 : valueEnd;
+  }
+
+  return output;
+}
+
+function rewriteHtmlAttribute(
+  name: string,
+  value: string,
+  rewrite: UrlRewrite,
+  options: HtmlRewriteOptions
+): string {
+  if (isSrcsetAttribute(name)) {
+    return rewriteSrcset(value, rewrite, options);
+  }
+  if (name.toLowerCase() === "style") {
+    return rewriteCssUrls(value, rewrite, options);
+  }
+  if (!isUrlAttribute(name)) return value;
+  return rewriteLocalUrlValue(value, rewrite, options);
+}
+
+function rewriteLocalUrlValue(value: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
+  const { leading, core, trailing } = splitTrimmed(value);
+  if (!isLocalPreviewUrl(core, options.includeRootRelative)) return value;
+  if (options.documentPath && !resolvePreviewResourcePath(core, options.documentPath)) return value;
+  return `${leading}${rewrite(core)}${trailing}`;
+}
+
+function splitTrimmed(value: string) {
+  const leadingLength = value.length - value.trimStart().length;
+  const trailingLength = value.length - value.trimEnd().length;
+  return {
+    leading: value.slice(0, leadingLength),
+    core: trailingLength > 0
+      ? value.slice(leadingLength, value.length - trailingLength)
+      : value.slice(leadingLength),
+    trailing: trailingLength > 0 ? value.slice(value.length - trailingLength) : ""
+  };
+}
+
+function rewriteSrcset(value: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
+  const candidates = splitSrcsetCandidates(value);
+  return candidates.map((candidate) => {
+    const { leading, core, trailing } = splitTrimmed(candidate);
+    if (!core) return candidate;
+    const match = /^(?:"([^"]*)"|'([^']*)'|(\S+))([\s\S]*)$/.exec(core);
+    if (!match) return candidate;
+    const url = match[1] ?? match[2] ?? match[3];
+    const quote = match[1] !== undefined ? '"' : match[2] !== undefined ? "'" : "";
+    const rewritten = rewriteLocalUrlValue(url, rewrite, options);
+    return `${leading}${quote}${rewritten}${quote}${match[4]}${trailing}`;
+  }).join(",");
+}
+
+function splitSrcsetCandidates(value: string): string[] {
+  const candidates: string[] = [];
+  let start = 0;
+  let index = 0;
+  let quote: string | null = null;
+  let parentheses = 0;
+  let dataUrlStart = findDataUrlStart(value, start);
+  let dataUrl = dataUrlStart >= 0;
+  let dataUrlHasWhitespace = false;
+  while (index < value.length) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote && !isEscapedAt(value, index)) quote = null;
+      index += 1;
+      continue;
+    }
+    if (character === "\"" || character === "'") {
+      quote = character;
+    } else if (character === "(") {
+      parentheses += 1;
+    } else if (character === ")") {
+      parentheses = Math.max(0, parentheses - 1);
+    } else if (dataUrl && index >= dataUrlStart && /\s/.test(character)) {
+      dataUrlHasWhitespace = true;
+    } else if (
+      character === ","
+      && parentheses === 0
+      && (!dataUrl || dataUrlHasWhitespace || /\s/.test(value[index + 1] ?? ""))
+    ) {
+      // A data URL owns its payload commas. A comma followed by whitespace
+      // still unambiguously starts the next candidate when the data URL has
+      // no descriptor.
+      candidates.push(value.slice(start, index));
+      start = index + 1;
+      index = start;
+      quote = null;
+      parentheses = 0;
+      dataUrlStart = findDataUrlStart(value, start);
+      dataUrl = dataUrlStart >= 0;
+      dataUrlHasWhitespace = false;
+      continue;
+    }
+    index += 1;
+  }
+  candidates.push(value.slice(start));
+  return candidates;
+}
+
+function findDataUrlStart(value: string, start: number): number {
+  let index = start;
+  while (index < value.length && /\s/.test(value[index])) index += 1;
+  return value.slice(index, index + 5).toLowerCase() === "data:" ? index : -1;
+}
+
+function rewriteCssUrls(css: string, rewrite: UrlRewrite, options: HtmlRewriteOptions = {}): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < css.length) {
+    if (css.startsWith("/*", cursor)) {
+      const end = css.indexOf("*/", cursor + 2);
+      if (end < 0) {
+        output += css.slice(cursor);
+        break;
+      }
+      const commentEnd = end + 2;
+      output += css.slice(cursor, commentEnd);
+      cursor = commentEnd;
+      continue;
+    }
+    if (css[cursor] === "\"" || css[cursor] === "'") {
+      const end = findCssStringEnd(css, cursor);
+      output += css.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+
+    const rewrittenImport = rewriteCssImportString(css, cursor, rewrite, options);
+    if (rewrittenImport) {
+      output += rewrittenImport.text;
+      cursor = rewrittenImport.end;
+      continue;
+    }
+
+    const open = findCssUrlOpen(css, cursor);
+    if (open < 0) {
+      output += css[cursor];
+      cursor += 1;
+      continue;
+    }
+    output += css.slice(cursor, open + 1);
+    const close = findCssFunctionEnd(css, open + 1);
+    if (close < 0) {
+      output += css.slice(open + 1);
+      break;
+    }
+    const inner = css.slice(open + 1, close);
+    output += rewriteCssUrlArgument(inner, rewrite, options);
+    output += ")";
+    cursor = close + 1;
+  }
+  return output;
+}
+
+function rewriteCssImportString(
+  css: string,
+  start: number,
+  rewrite: UrlRewrite,
+  options: HtmlRewriteOptions
+) {
+  if (css.slice(start, start + 7).toLowerCase() !== "@import") return null;
+  const afterName = css[start + 7];
+  if (afterName && /[A-Za-z0-9_-]/.test(afterName)) return null;
+
+  let quoteStart = start + 7;
+  while (quoteStart < css.length && /\s/.test(css[quoteStart])) quoteStart += 1;
+  const quote = css[quoteStart];
+  if (quote !== "\"" && quote !== "'") return null;
+
+  const end = findCssStringEnd(css, quoteStart);
+  if (end <= quoteStart || css[end - 1] !== quote) return null;
+  const rawUrl = css.slice(quoteStart + 1, end - 1);
+  const rewritten = rewriteLocalUrlValue(rawUrl, rewrite, options);
+  return {
+    end,
+    text: `${css.slice(start, quoteStart + 1)}${rewritten}${quote}`
+  };
+}
+
+function findCssUrlOpen(css: string, start: number): number {
+  if (css.slice(start, start + 3).toLowerCase() !== "url") return -1;
+  const previous = css[start - 1];
+  if (previous && /[A-Za-z0-9_-]/.test(previous)) return -1;
+  let open = start + 3;
+  while (open < css.length && /\s/.test(css[open])) open += 1;
+  return css[open] === "(" ? open : -1;
+}
+
+function findCssFunctionEnd(css: string, start: number): number {
+  let quote: string | null = null;
+  for (let index = start; index < css.length; index += 1) {
+    const character = css[index];
+    if (quote) {
+      if (character === quote && !isEscapedAt(css, index)) quote = null;
+    } else if (character === "\"" || character === "'") {
+      quote = character;
+    } else if (character === ")" && !isEscapedAt(css, index)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function findCssStringEnd(css: string, start: number): number {
+  const quote = css[start];
+  for (let index = start + 1; index < css.length; index += 1) {
+    if (css[index] === quote && !isEscapedAt(css, index)) return index + 1;
+  }
+  return css.length;
+}
+
+function isEscapedAt(value: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function rewriteCssUrlArgument(inner: string, rewrite: UrlRewrite, options: HtmlRewriteOptions): string {
+  const { leading, core, trailing } = splitTrimmed(inner);
+  if (!core) return inner;
+  // CSS escapes can change token boundaries (for example `\)` inside an
+  // unquoted URL). Leave those authored tokens byte-for-byte intact until a
+  // CSS tokenizer is available instead of guessing at their decoded path.
+  if (core.includes("\\") || hasUnsafeCssTokenCharacter(core)) return inner;
+  const quote = core[0] === "\"" || core[0] === "'" ? core[0] : null;
+  const url = quote && core.endsWith(quote) ? core.slice(1, -1) : core;
+  const rewritten = rewriteLocalUrlValue(url, rewrite, options);
+  const wrapped = quote && core.endsWith(quote) ? `${quote}${rewritten}${quote}` : rewritten;
+  return `${leading}${wrapped}${trailing}`;
+}
+
+export function addCacheBusterToCss(
+  css: string,
+  version?: string,
+  extraParams: Record<string, string> = {},
+  rootPath?: string,
+  documentPath?: string
+): string {
+  const value = version || Date.now().toString();
+  const params = { v: value, ...extraParams };
+  return rewriteCssUrls(
+    css,
+    (url) => addQueryParams(rewriteRootRelativeUrl(url, rootPath), params),
+    { includeRootRelative: Boolean(rootPath), documentPath }
+  );
+}
+
+function normalizeRootPath(rootPath: string): string {
+  const trimmed = rootPath.trim();
+  if (!trimmed) return "/";
+  const rooted = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return `${rooted.replace(/\/+$/, "")}/`;
+}
+
+function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
+  if (!rootPath) return value;
+
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return value;
+
+  const leadingLength = value.length - value.trimStart().length;
+  const trailingLength = value.length - value.trimEnd().length;
+  const leading = value.slice(0, leadingLength);
+  const trailing = trailingLength > 0 ? value.slice(value.length - trailingLength) : "";
+  const core = trailingLength > 0
+    ? value.slice(leadingLength, value.length - trailingLength)
+    : value.slice(leadingLength);
+
+  const hashIndex = core.indexOf("#");
+  const fragment = hashIndex >= 0 ? core.slice(hashIndex) : "";
+  const beforeFragment = hashIndex >= 0 ? core.slice(0, hashIndex) : core;
+  const queryIndex = beforeFragment.indexOf("?");
+  const path = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
+  const suffix = queryIndex >= 0
+    ? `${beforeFragment.slice(queryIndex)}${fragment}`
+    : fragment;
+  const normalizedPath = normalizeRootRelativePath(path);
+  if (normalizedPath === null) return value;
+  const trailingSlash = path.length > 1 && path.endsWith("/") ? "/" : "";
+  const root = normalizeRootPath(rootPath);
+  return `${leading}${root}${normalizedPath}${trailingSlash}${suffix}${trailing}`;
+}
+
+function normalizeRootRelativePath(path: string): string | null {
+  const segments: string[] = [];
+  for (const rawSegment of path.slice(1).split("/")) {
+    if (rawSegment.includes("%")) return null;
+    let segment: string;
+    try {
+      segment = decodeURIComponent(rawSegment);
+    } catch {
+      return null;
+    }
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    if (isUnsafeDecodedPathSegment(segment)) return null;
+    segments.push(segment);
+  }
+  return segments.join("/");
+}
+
+function isUnsafeDecodedPathSegment(segment: string): boolean {
+  for (const character of segment) {
+    if ("\\/?#%\"'<> &".includes(character)) return true;
+    const code = character.charCodeAt(0);
+    if (code <= 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function hasUnsafeCssTokenCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * Rewrite root-relative authored URLs to the canonical site mount. A static
+ * document's `/styles.css` means "from this site's root", not from the app
+ * origin; without this boundary rewrite it falls through to the SPA shell.
+ */
+export function rewriteRootRelativeHtmlUrls(html: string, rootPath: string): string {
+  return rewriteLocalHtmlUrls(
+    html,
+    (url) => rewriteRootRelativeUrl(url, rootPath),
+    { includeRootRelative: true }
+  );
+}
+
+export function rewriteRootRelativeCssUrls(css: string, rootPath: string): string {
+  return rewriteCssUrls(css, (url) => rewriteRootRelativeUrl(url, rootPath), {
+    includeRootRelative: true
   });
 }
 
@@ -104,17 +638,55 @@ function addQueryParams(value: string, params: Record<string, string>): string {
 export function collectPreviewResourcePaths(html: string, documentPath: string): string[] {
   const paths = new Set<string>();
   rewriteLocalHtmlUrls(html, (value) => {
-    try {
-      const resolved = new URL(value, `https://preview.invalid/${documentPath}`);
-      const path = resolved.pathname.replace(/^\/+/, "");
-      if (path) paths.add(path);
-    } catch {
-      // Preserve malformed authored markup. It will fail as a browser request,
-      // but it must not turn the containing preview document into a 500.
-    }
+    const path = resolvePreviewResourcePath(value, documentPath);
+    if (path) paths.add(path);
     return value;
-  });
+  }, { includeRootRelative: true, documentPath });
   return [...paths].sort();
+}
+
+export function collectPreviewCssResourcePaths(css: string, documentPath: string): string[] {
+  const paths = new Set<string>();
+  rewriteCssUrls(css, (value) => {
+    const path = resolvePreviewResourcePath(value, documentPath);
+    if (path) paths.add(path);
+    return value;
+  }, { includeRootRelative: true, documentPath });
+  return [...paths].sort();
+}
+
+function resolvePreviewResourcePath(value: string, documentPath: string): string | null {
+  const trimmed = value.trim();
+  if (!isLocalPreviewUrl(trimmed, true)) return null;
+  const hashIndex = trimmed.indexOf("#");
+  const beforeFragment = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
+  const queryIndex = beforeFragment.indexOf("?");
+  const pathPart = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
+  const rooted = pathPart.startsWith("/");
+  const baseSegments = rooted
+    ? []
+    : documentPath.replace(/\\/g, "/").split("/").slice(0, -1).filter(Boolean);
+  const segments = [...baseSegments];
+  for (const rawSegment of pathPart.split("/")) {
+    if (rawSegment.includes("%")) return null;
+    let segment: string;
+    try {
+      segment = decodeURIComponent(rawSegment);
+    } catch {
+      return null;
+    }
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    if (isUnsafeDecodedPathSegment(segment)) return null;
+    segments.push(segment);
+  }
+  if (segments.length === 0) return "index.html";
+  const resolved = segments.join("/");
+  return pathPart.length > 1 && pathPart.endsWith("/") ? `${resolved}/` : resolved;
 }
 
 export function buildFileTree(files: StorageFile[]): ProjectTreeNode[] {

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -24,37 +24,29 @@ export function sanitizeFilePath(filePath: string): string {
     .trim()
     .replace(/\\/g, "/")
     .replace(/^\/+/, "")
-    .replace(/\/+/g, "/");
+    .replace(/\/{2,}/g, "/");
 
-  if (!normalized) {
-    throw new Error("File path is required");
-  }
-
-  if (normalized.includes("\0") || normalized.includes("..")) {
-    throw new Error("Invalid file path");
-  }
-
+  if (!normalized) throw new Error("File path is required");
+  if (normalized.includes("\0") || normalized.includes("..")) throw new Error("Invalid file path");
   return normalized;
 }
 
 export function getContentType(filePath: string): string {
   const match = filePath.toLowerCase().match(/\.[^.]+$/);
   if (!match) return "application/octet-stream";
-  const entry = Object.entries(CONTENT_TYPES).find(([extension]) => extension === match[0]);
-  return entry?.[1] || "application/octet-stream";
+  return Object.entries(CONTENT_TYPES).find(([extension]) => extension === match[0])?.[1]
+    || "application/octet-stream";
 }
 
 export function isTextContentType(contentType: string): boolean {
-  return (
-    contentType.startsWith("text/") ||
-    contentType.includes("javascript") ||
-    contentType.includes("json") ||
-    contentType.includes("xml")
-  );
+  return contentType.startsWith("text/")
+    || contentType.includes("javascript")
+    || contentType.includes("json")
+    || contentType.includes("xml");
 }
 
 type MarkupState = {
-  basePath: string;
+  documentPath: string;
   baseExternal: boolean;
   baseSeen: boolean;
   paths?: Set<string>;
@@ -66,8 +58,8 @@ type MarkupOptions = {
   rootPath?: string;
 };
 
-type UrlRewrite = (url: string, state: MarkupState) => string;
-type BaseResolution = { path: string | null; external: boolean };
+type ResolvedUrl = { path: string; url: URL };
+type UrlRewrite = (url: string, resolved: ResolvedUrl) => string;
 
 export async function addCacheBusterToHtml(
   html: string,
@@ -91,7 +83,7 @@ async function rewriteMarkup(
   paths?: Set<string>
 ): Promise<string> {
   const state: MarkupState = {
-    basePath: options.documentPath,
+    documentPath: options.documentPath,
     baseExternal: false,
     baseSeen: false,
     paths
@@ -101,39 +93,34 @@ async function rewriteMarkup(
   const rewriter = new HTMLRewriter()
     .on("*", {
       element(element) {
-        const tagName = element.tagName.toLowerCase();
         const attributes = Array.from(element.attributes, (attribute) => {
-          if (Array.isArray(attribute)) {
-            return { name: attribute[0], value: attribute[1] };
-          }
+          if (Array.isArray(attribute)) return { name: attribute[0], value: attribute[1] };
           return { name: attribute.name, value: attribute.value };
         });
-        for (const attribute of attributes) {
-          const { name, value } = attribute;
+
+        for (const { name, value } of attributes) {
           const lowerName = name.toLowerCase();
-          if (tagName === "base" && lowerName === "href" && !state.baseSeen) {
+          if (element.tagName.toLowerCase() === "base" && lowerName === "href") {
+            if (state.baseSeen) continue;
             state.baseSeen = true;
-            const base = resolveBaseHref(value, state.basePath);
-            if (base.external) {
+            const base = resolveBase(value, state.documentPath);
+            if (base === "external" || base === null) {
+              // Preserve an authored external base exactly. Browser URL
+              // resolution makes both relative and root-relative references
+              // external once this base wins, so neither may receive a local
+              // preview mount or bearer token. Invalid or escaping base URLs
+              // fail closed by the same rule.
               state.baseExternal = true;
-            } else if (base.path !== null) {
-              state.basePath = base.path;
-              if (options.rootPath) {
-                element.setAttribute(name, mountPath(options.rootPath, base.path));
-              }
+            } else if (base !== null) {
+              state.baseExternal = false;
+              state.documentPath = base.path;
+              if (options.rootPath) element.setAttribute(name, mountPath(options.rootPath, base.url.pathname));
             }
             continue;
           }
-          if (tagName === "base" && lowerName === "href") continue;
 
-          const rewritten = rewriteMarkupAttribute(
-            name,
-            value,
-            state,
-            options,
-            rewrite
-          );
-          if (rewritten !== value) element.setAttribute(name, rewritten);
+          const next = rewriteMarkupAttribute(name, value, state, options, rewrite);
+          if (next !== value) element.setAttribute(name, next);
         }
       }
     })
@@ -163,14 +150,11 @@ function rewriteMarkupAttribute(
   options: MarkupOptions,
   rewrite: UrlRewrite
 ): string {
-  const lower = name.toLowerCase();
-  if (lower === "style") {
+  const lowerName = name.toLowerCase();
+  if (lowerName === "style") {
     return rewriteCssUrls(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
   }
-  if (isSrcsetAttribute(lower)) {
-    return rewriteSrcset(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
-  }
-  if (!isUrlAttribute(lower)) return value;
+  if (lowerName !== "href" && lowerName !== "src" && lowerName !== "xlink:href") return value;
   return rewriteMarkupUrl(value, state, options, rewrite);
 }
 
@@ -181,127 +165,117 @@ function rewriteMarkupUrl(
   rewrite: UrlRewrite
 ): string {
   const { leading, core, trailing } = splitTrimmed(value);
-  if (!isLocalUrl(core, options.includeRootRelative)) return value;
-  if (state.baseExternal && !core.startsWith("/")) return value;
-  const path = resolvePreviewResourcePath(core, state.basePath);
-  if (!path) return value;
-  state.paths?.add(path);
-  return `${leading}${rewrite(core, state)}${trailing}`;
+  if (state.baseExternal) return value;
+  const resolved = resolveLocalUrl(core, state.documentPath, options.includeRootRelative);
+  if (!resolved) return value;
+  state.paths?.add(resolved.path);
+  return `${leading}${rewrite(core, resolved)}${trailing}`;
 }
 
-function isUrlAttribute(name: string): boolean {
-  if (["href", "src", "xlink:href", "poster", "action", "formaction", "data"].includes(name)) return true;
-  if (!name.startsWith("data-")) return false;
-  const suffix = name.slice(5);
-  return suffix === "background"
-    || suffix === "background-image"
-    || suffix === "image"
-    || /(?:^|[-_:])(?:href|poster|src|url)(?:$|[-_:])/.test(suffix);
+function resolveBase(value: string, documentPath: string): ResolvedUrl | "external" | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("#")) {
+    const path = resolveLocalUrl("", documentPath, true);
+    return path;
+  }
+  if (trimmed.startsWith("//") || URI_SCHEME_RE.test(trimmed)) {
+    return "external";
+  }
+  return resolveLocalUrl(trimmed, documentPath, true);
 }
 
-function isSrcsetAttribute(name: string): boolean {
-  return name === "srcset" || name === "data-srcset" || name.endsWith("-srcset");
-}
-
-function isLocalUrl(value: string, includeRootRelative: boolean): boolean {
+function resolveLocalUrl(value: string, documentPath: string, includeRootRelative: boolean): ResolvedUrl | null {
   const trimmed = value.trim();
   const rootRelative = trimmed.startsWith("/") && !trimmed.startsWith("//");
-  return trimmed.length > 0
-    && !trimmed.startsWith("#")
-    && !trimmed.startsWith("//")
-    && (!rootRelative || includeRootRelative)
-    && !URI_SCHEME_RE.test(trimmed);
-}
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//") || URI_SCHEME_RE.test(trimmed)) return null;
+  if (rootRelative && !includeRootRelative) return null;
 
-function resolveBaseHref(value: string, documentPath: string): BaseResolution {
-  const trimmed = value.trim();
-  if (trimmed.startsWith("//") || URI_SCHEME_RE.test(trimmed)) {
-    return { path: null, external: true };
+  const authoredPath = decodePath(stripUrlPath(trimmed));
+  const authoredDocumentPath = decodePath(documentPath);
+  if (authoredPath === null || authoredDocumentPath === null || hasTraversal(authoredPath, authoredDocumentPath)) {
+    return null;
   }
-  if (!isLocalUrl(trimmed, true)) return { path: documentPath, external: false };
-  const pathPart = stripUrlPath(trimmed);
-  if (hasPathEscape(pathPart, documentPath)) return { path: null, external: false };
+
   try {
-    const pathname = new URL(trimmed, `${PREVIEW_ORIGIN}/${documentPath}`).pathname;
-    if (pathname.includes("%")) return { path: null, external: false };
-    return { path: pathname === "/" ? "" : pathname.slice(1), external: false };
+    const url = new URL(trimmed, documentUrl(documentPath));
+    if (url.origin !== PREVIEW_ORIGIN) return null;
+    const pathname = decodePath(url.pathname);
+    if (pathname === null || hasTraversal(pathname)) return null;
+    return {
+      url,
+      path: pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "")
+    };
   } catch {
-    return { path: null, external: false };
+    return null;
   }
 }
 
-function resolvePreviewResourcePath(value: string, documentPath: string): string | null {
-  const trimmed = value.trim();
-  if (!isLocalUrl(trimmed, true)) return null;
-  const pathPart = stripUrlPath(trimmed);
-  if (hasPathEscape(pathPart, documentPath)) return null;
+function documentUrl(documentPath: string): string {
+  const normalized = documentPath.trim().replace(/^\/+/, "").replace(/\/{2,}/g, "/");
+  return `${PREVIEW_ORIGIN}/${normalized}`;
+}
+
+function decodePath(path: string): string | null {
   try {
-    const pathname = new URL(trimmed, `${PREVIEW_ORIGIN}/${documentPath}`).pathname;
-    if (pathname.includes("%")) return null;
-    return pathname === "/" ? "index.html" : pathname.slice(1);
+    return decodeURIComponent(path);
   } catch {
     return null;
   }
 }
 
 function stripUrlPath(value: string): string {
-  const hash = value.indexOf("#");
-  const beforeFragment = hash >= 0 ? value.slice(0, hash) : value;
-  const query = beforeFragment.indexOf("?");
-  return query >= 0 ? beforeFragment.slice(0, query) : beforeFragment;
+  const hashIndex = value.indexOf("#");
+  const beforeHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+  const queryIndex = beforeHash.indexOf("?");
+  return queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash;
 }
 
-function hasPathEscape(pathPart: string, documentPath?: string): boolean {
-  const pathWithoutRoot = pathPart.startsWith("/") ? pathPart.slice(1) : pathPart;
-  if (pathWithoutRoot.includes("//") || pathPart.includes("%")) return true;
-  let depth = pathPart.startsWith("/")
+export function decodeServedPath(path: string): string | null {
+  const decoded = decodePath(path);
+  if (
+    decoded === null
+    || decoded.startsWith("/")
+    || decoded.includes("//")
+    || decoded.split("/").some((segment) =>
+      segment === "."
+      || segment === ".."
+      || segment.includes("\\")
+      || /[\p{Cc}]/u.test(segment)
+    )
+  ) return null;
+  return decoded || "index.html";
+}
+
+function hasTraversal(path: string, documentPath?: string): boolean {
+  const relative = path.startsWith("/") ? path.slice(1) : path;
+  if (relative.includes("//") || path.includes("\\") || /[\p{Cc}]/u.test(path)) return true;
+  let depth = path.startsWith("/")
     ? 0
     : (documentPath?.split("/").slice(0, -1).filter(Boolean).length || 0);
-  for (const segment of pathPart.split("/")) {
+  for (const segment of path.split("/")) {
     if (!segment || segment === ".") continue;
     if (segment === "..") {
       depth -= 1;
       if (depth < 0) return true;
-      continue;
+    } else {
+      depth += 1;
     }
-    if (segment.includes("\\") || segment.includes("\0") || /[?#"'<> &]/.test(segment)) return true;
-    depth += 1;
   }
   return false;
 }
 
 function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
   if (!rootPath) return value;
-  const trimmed = value.trim();
-  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return value;
-  const leadingLength = value.length - value.trimStart().length;
-  const trailingLength = value.length - value.trimEnd().length;
-  const leading = value.slice(0, leadingLength);
-  const trailing = trailingLength > 0 ? value.slice(value.length - trailingLength) : "";
-  const core = trailingLength > 0
-    ? value.slice(leadingLength, value.length - trailingLength)
-    : value.slice(leadingLength);
-  const path = stripUrlPath(core);
-  if (hasPathEscape(path)) return value;
-  const hash = core.indexOf("#");
-  const fragment = hash >= 0 ? core.slice(hash) : "";
-  const beforeFragment = hash >= 0 ? core.slice(0, hash) : core;
-  const query = beforeFragment.indexOf("?");
-  const suffix = query >= 0
-    ? `${beforeFragment.slice(query)}${fragment}`
-    : fragment;
-  try {
-    const normalized = new URL(path, `${PREVIEW_ORIGIN}/`).pathname;
-    if (normalized.includes("%")) return value;
-    return `${leading}${mountPath(rootPath, normalized.slice(1))}${suffix}${trailing}`;
-  } catch {
-    return value;
-  }
+  const { leading, core, trailing } = splitTrimmed(value);
+  if (!core.startsWith("/") || core.startsWith("//")) return value;
+  const resolved = resolveLocalUrl(core, "index.html", true);
+  if (!resolved) return value;
+  return `${leading}${mountPath(rootPath, resolved.url.pathname)}${resolved.url.search}${resolved.url.hash}${trailing}`;
 }
 
-function mountPath(rootPath: string, filePath: string): string {
+function mountPath(rootPath: string, pathname: string): string {
   const root = rootPath.trim().replace(/\/+$/, "") || "/";
-  const suffix = filePath.replace(/^\/+/, "");
+  const suffix = pathname.replace(/^\/+/, "");
   return root === "/" ? `/${suffix}` : `${root}/${suffix}`;
 }
 
@@ -310,161 +284,111 @@ function splitTrimmed(value: string) {
   const trailingLength = value.length - value.trimEnd().length;
   return {
     leading: value.slice(0, leadingLength),
-    core: trailingLength > 0
+    core: trailingLength
       ? value.slice(leadingLength, value.length - trailingLength)
       : value.slice(leadingLength),
-    trailing: trailingLength > 0 ? value.slice(value.length - trailingLength) : ""
+    trailing: trailingLength ? value.slice(value.length - trailingLength) : ""
   };
 }
 
-function rewriteSrcset(value: string, rewrite: (url: string) => string): string {
-  return splitSrcsetCandidates(value).map((candidate) => {
-    const { leading, core, trailing } = splitTrimmed(candidate);
-    if (!core) return candidate;
-    const match = /^(?:"([^"]*)"|'([^']*)'|(\S+))([\s\S]*)$/.exec(core);
-    if (!match) return candidate;
-    const url = match[1] ?? match[2] ?? match[3];
-    const quote = match[1] !== undefined ? '"' : match[2] !== undefined ? "'" : "";
-    const next = rewrite(url);
-    return `${leading}${quote}${next}${quote}${match[4]}${trailing}`;
-  }).join(",");
-}
-
-function splitSrcsetCandidates(value: string): string[] {
-  const candidates: string[] = [];
-  let start = 0;
-  let quote: string | null = null;
-  let parentheses = 0;
-  let dataStart = findDataUrlStart(value, start);
-  let dataWhitespace = false;
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value[index];
-    if (quote) {
-      if (character === quote && !isEscapedAt(value, index)) quote = null;
-      continue;
-    }
-    if (character === "\"" || character === "'") quote = character;
-    else if (character === "(") parentheses += 1;
-    else if (character === ")") parentheses = Math.max(0, parentheses - 1);
-    else if (dataStart >= 0 && index >= dataStart && /\s/.test(character)) dataWhitespace = true;
-    else if (character === "," && parentheses === 0 && (dataStart < 0 || dataWhitespace || /\s/.test(value[index + 1] ?? ""))) {
-      candidates.push(value.slice(start, index));
-      start = index + 1;
-      dataStart = findDataUrlStart(value, start);
-      dataWhitespace = false;
-    }
-  }
-  candidates.push(value.slice(start));
-  return candidates;
-}
-
-function findDataUrlStart(value: string, start: number): number {
-  let index = start;
-  while (index < value.length && /\s/.test(value[index])) index += 1;
-  return value.slice(index, index + 5).toLowerCase() === "data:" ? index : -1;
-}
-
+// This deliberately handles only CSS url(...) and quoted @import references;
+// comments, quoted text, external/data URLs, and the rest of CSS stay opaque.
 function rewriteCssUrls(css: string, rewrite: (url: string) => string): string {
   let output = "";
   let cursor = 0;
   while (cursor < css.length) {
     if (css.startsWith("/*", cursor)) {
       const end = css.indexOf("*/", cursor + 2);
-      if (end < 0) return output + css.slice(cursor);
-      const next = end + 2;
-      output += css.slice(cursor, next);
-      cursor = next;
+      if (end < 0) return css;
+      output += css.slice(cursor, end + 2);
+      cursor = end + 2;
       continue;
     }
     if (css[cursor] === "\"" || css[cursor] === "'") {
-      const end = findCssStringEnd(css, cursor);
+      const end = findQuotedEnd(css, cursor);
       output += css.slice(cursor, end);
       cursor = end;
       continue;
     }
-    const imported = rewriteCssImportString(css, cursor, rewrite);
+    const imported = rewriteImport(css, cursor, rewrite);
     if (imported) {
       output += imported.text;
       cursor = imported.end;
       continue;
     }
-    const open = findCssUrlOpen(css, cursor);
+    const open = findUrlOpen(css, cursor);
     if (open < 0) {
       output += css[cursor];
       cursor += 1;
       continue;
     }
+    const close = findFunctionEnd(css, open + 1);
+    if (close < 0) return css;
     output += css.slice(cursor, open + 1);
-    const close = findCssFunctionEnd(css, open + 1);
-    if (close < 0) return output + css.slice(open + 1);
-    const inner = css.slice(open + 1, close);
-    output += rewriteCssUrlArgument(inner, rewrite);
+    output += rewriteCssArgument(css.slice(open + 1, close), rewrite);
     output += ")";
     cursor = close + 1;
   }
   return output;
 }
 
-function rewriteCssImportString(css: string, start: number, rewrite: (url: string) => string) {
+function rewriteImport(css: string, start: number, rewrite: (url: string) => string) {
   if (css.slice(start, start + 7).toLowerCase() !== "@import") return null;
-  const afterName = css[start + 7];
-  if (afterName && /[A-Za-z0-9_-]/.test(afterName)) return null;
+  const next = css[start + 7];
+  if (next && /[\w-]/.test(next)) return null;
   let quoteStart = start + 7;
-  while (quoteStart < css.length && /\s/.test(css[quoteStart])) quoteStart += 1;
+  while (/\s/.test(css[quoteStart] ?? "")) quoteStart += 1;
   const quote = css[quoteStart];
   if (quote !== "\"" && quote !== "'") return null;
-  const end = findCssStringEnd(css, quoteStart);
+  const end = findQuotedEnd(css, quoteStart);
   if (end <= quoteStart || css[end - 1] !== quote) return null;
-  const url = css.slice(quoteStart + 1, end - 1);
   return {
     end,
-    text: `${css.slice(start, quoteStart + 1)}${rewrite(url)}${quote}`
+    text: `${css.slice(start, quoteStart + 1)}${rewrite(css.slice(quoteStart + 1, end - 1))}${quote}`
   };
 }
 
-function findCssUrlOpen(css: string, start: number): number {
+function findUrlOpen(css: string, start: number): number {
   if (css.slice(start, start + 3).toLowerCase() !== "url") return -1;
-  const previous = css[start - 1];
-  if (previous && /[A-Za-z0-9_-]/.test(previous)) return -1;
+  if (/[\w-]/.test(css[start - 1] ?? "")) return -1;
   let open = start + 3;
-  while (open < css.length && /\s/.test(css[open])) open += 1;
+  while (/\s/.test(css[open] ?? "")) open += 1;
   return css[open] === "(" ? open : -1;
 }
 
-function findCssFunctionEnd(css: string, start: number): number {
-  let quote: string | null = null;
+function findFunctionEnd(css: string, start: number): number {
+  let depth = 1;
+  let quote = "";
   for (let index = start; index < css.length; index += 1) {
     const character = css[index];
     if (quote) {
-      if (character === quote && !isEscapedAt(css, index)) quote = null;
-    } else if (character === "\"" || character === "'") quote = character;
-    else if (character === ")" && !isEscapedAt(css, index)) return index;
+      if (character === quote && css[index - 1] !== "\\") quote = "";
+    } else if (character === "\"" || character === "'") {
+      quote = character;
+    } else if (character === "(") {
+      depth += 1;
+    } else if (character === ")" && --depth === 0) {
+      return index;
+    }
   }
   return -1;
 }
 
-function findCssStringEnd(css: string, start: number): number {
-  const quote = css[start];
-  for (let index = start + 1; index < css.length; index += 1) {
-    if (css[index] === quote && !isEscapedAt(css, index)) return index + 1;
+function findQuotedEnd(value: string, start: number): number {
+  const quote = value[start];
+  for (let index = start + 1; index < value.length; index += 1) {
+    if (value[index] === quote && value[index - 1] !== "\\") return index + 1;
   }
-  return css.length;
+  return value.length;
 }
 
-function isEscapedAt(value: string, index: number): boolean {
-  let slashes = 0;
-  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) slashes += 1;
-  return slashes % 2 === 1;
-}
-
-function rewriteCssUrlArgument(inner: string, rewrite: (url: string) => string): string {
+function rewriteCssArgument(inner: string, rewrite: (url: string) => string): string {
   const { leading, core, trailing } = splitTrimmed(inner);
-  if (!core || core.includes("\\") || /[\p{Cc}\p{Zs}]/u.test(core)) return inner;
-  const quote = core[0] === "\"" || core[0] === "'" ? core[0] : null;
+  if (!core) return inner;
+  const quote = core[0] === "\"" || core[0] === "'" ? core[0] : "";
   const url = quote && core.endsWith(quote) ? core.slice(1, -1) : core;
   const next = rewrite(url);
-  const wrapped = quote && core.endsWith(quote) ? `${quote}${next}${quote}` : next;
-  return `${leading}${wrapped}${trailing}`;
+  return `${leading}${quote}${next}${quote}${trailing}`;
 }
 
 export function addCacheBusterToCss(
@@ -476,9 +400,8 @@ export function addCacheBusterToCss(
 ): string {
   const params = { v: version || Date.now().toString(), ...extraParams };
   return rewriteCssUrls(css, (url) => {
-    const path = resolvePreviewResourcePath(url, documentPath);
-    if (!path) return url;
-    return addQueryParams(rewriteRootRelativeUrl(url, rootPath), params);
+    const resolved = resolveLocalUrl(url, documentPath, true);
+    return resolved ? addQueryParams(rewriteRootRelativeUrl(url, rootPath), params) : url;
   });
 }
 
@@ -505,17 +428,21 @@ function addQueryParams(value: string, params: Record<string, string>): string {
   return `${pathname}?${search.toString()}${fragment}`;
 }
 
-export async function collectPreviewResourcePaths(html: string, documentPath: string): Promise<string[]> {
+export async function collectPreviewResourcePaths(
+  html: string,
+  documentPath: string,
+  rootPath?: string
+): Promise<string[]> {
   const paths = new Set<string>();
-  await rewriteMarkup(html, (url) => url, { documentPath, includeRootRelative: true }, paths);
+  await rewriteMarkup(html, (url) => url, { documentPath, includeRootRelative: true, rootPath }, paths);
   return [...paths].sort();
 }
 
 export function collectPreviewCssResourcePaths(css: string, documentPath: string): string[] {
   const paths = new Set<string>();
   rewriteCssUrls(css, (url) => {
-    const path = resolvePreviewResourcePath(url, documentPath);
-    if (path) paths.add(path);
+    const resolved = resolveLocalUrl(url, documentPath, true);
+    if (resolved) paths.add(resolved.path);
     return url;
   });
   return [...paths].sort();

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -59,6 +59,7 @@ type MarkupOptions = {
 };
 
 type ResolvedUrl = { path: string; url: URL };
+type BaseResolution = ResolvedUrl & { alreadyMounted: boolean };
 type UrlRewrite = (url: string, resolved: ResolvedUrl) => string;
 
 export async function addCacheBusterToHtml(
@@ -103,7 +104,7 @@ async function rewriteMarkup(
           if (element.tagName.toLowerCase() === "base" && lowerName === "href") {
             if (state.baseSeen) continue;
             state.baseSeen = true;
-            const base = resolveBase(value, state.documentPath);
+            const base = resolveBase(value, state.documentPath, options.rootPath);
             if (base === "external" || base === null) {
               // Preserve an authored external base exactly. Browser URL
               // resolution makes both relative and root-relative references
@@ -111,10 +112,18 @@ async function rewriteMarkup(
               // preview mount or bearer token. Invalid or escaping base URLs
               // fail closed by the same rule.
               state.baseExternal = true;
+            } else if (base === "current") {
+              // Empty and fragment-only base URLs resolve to the current
+              // document URL. Preserve the authored value so the browser can
+              // keep applying its fragment/query semantics while local
+              // preview/publish rewriting continues from documentPath.
+              state.baseExternal = false;
             } else if (base !== null) {
               state.baseExternal = false;
               state.documentPath = base.path;
-              if (options.rootPath) element.setAttribute(name, mountPath(options.rootPath, base.url.pathname));
+              if (options.rootPath && !base.alreadyMounted) {
+                element.setAttribute(name, mountPath(options.rootPath, base.url.pathname));
+              }
             }
             continue;
           }
@@ -168,20 +177,30 @@ function rewriteMarkupUrl(
   if (state.baseExternal) return value;
   const resolved = resolveLocalUrl(core, state.documentPath, options.includeRootRelative);
   if (!resolved) return value;
-  state.paths?.add(resolved.path);
+  state.paths?.add(unmountRootPath(resolved.url.pathname, options.rootPath) ?? resolved.path);
   return `${leading}${rewrite(core, resolved)}${trailing}`;
 }
 
-function resolveBase(value: string, documentPath: string): ResolvedUrl | "external" | null {
+function resolveBase(
+  value: string,
+  documentPath: string,
+  rootPath?: string
+): BaseResolution | "current" | "external" | null {
   const trimmed = value.trim();
   if (!trimmed || trimmed.startsWith("#")) {
-    const path = resolveLocalUrl("", documentPath, true);
-    return path;
+    return "current";
   }
   if (trimmed.startsWith("//") || URI_SCHEME_RE.test(trimmed)) {
     return "external";
   }
-  return resolveLocalUrl(trimmed, documentPath, true);
+  const resolved = resolveLocalUrl(trimmed, documentPath, true);
+  if (!resolved) return null;
+  const unmountedPath = unmountRootPath(resolved.url.pathname, rootPath);
+  return {
+    ...resolved,
+    path: unmountedPath ?? resolved.path,
+    alreadyMounted: unmountedPath !== null
+  };
 }
 
 function resolveLocalUrl(value: string, documentPath: string, includeRootRelative: boolean): ResolvedUrl | null {
@@ -270,7 +289,20 @@ function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
   if (!core.startsWith("/") || core.startsWith("//")) return value;
   const resolved = resolveLocalUrl(core, "index.html", true);
   if (!resolved) return value;
+  if (unmountRootPath(resolved.url.pathname, rootPath) !== null) return value;
   return `${leading}${mountPath(rootPath, resolved.url.pathname)}${resolved.url.search}${resolved.url.hash}${trailing}`;
+}
+
+function unmountRootPath(pathname: string, rootPath?: string): string | null {
+  if (!rootPath) return null;
+  const decodedPath = decodePath(pathname);
+  if (decodedPath === null) return null;
+  const root = rootPath.trim().replace(/\/+$/, "") || "/";
+  if (root === "/") return decodedPath.replace(/^\/+/, "") || "index.html";
+  const prefix = `${root}/`;
+  if (decodedPath !== root && !decodedPath.startsWith(prefix)) return null;
+  const suffix = decodedPath.slice(prefix.length);
+  return suffix || "index.html";
 }
 
 function mountPath(rootPath: string, pathname: string): string {
@@ -405,11 +437,15 @@ export function addCacheBusterToCss(
   });
 }
 
-export async function rewriteRootRelativeHtmlUrls(html: string, rootPath: string): Promise<string> {
+export async function rewriteRootRelativeHtmlUrls(
+  html: string,
+  rootPath: string,
+  documentPath = "index.html"
+): Promise<string> {
   return rewriteMarkup(
     html,
     (url) => rewriteRootRelativeUrl(url, rootPath),
-    { documentPath: "index.html", includeRootRelative: true, rootPath }
+    { documentPath, includeRootRelative: true, rootPath }
   );
 }
 
@@ -438,11 +474,15 @@ export async function collectPreviewResourcePaths(
   return [...paths].sort();
 }
 
-export function collectPreviewCssResourcePaths(css: string, documentPath: string): string[] {
+export function collectPreviewCssResourcePaths(
+  css: string,
+  documentPath: string,
+  rootPath?: string
+): string[] {
   const paths = new Set<string>();
   rewriteCssUrls(css, (url) => {
     const resolved = resolveLocalUrl(url, documentPath, true);
-    if (resolved) paths.add(resolved.path);
+    if (resolved) paths.add(unmountRootPath(resolved.url.pathname, rootPath) ?? resolved.path);
     return url;
   });
   return [...paths].sort();

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -177,7 +177,10 @@ function rewriteMarkupUrl(
   if (state.baseExternal) return value;
   const resolved = resolveLocalUrl(core, state.documentPath, options.includeRootRelative);
   if (!resolved) return value;
-  state.paths?.add(unmountRootPath(resolved.url.pathname, options.rootPath) ?? resolved.path);
+  const mountedPath = isRootRelative(core)
+    ? unmountRootPath(resolved.url.pathname, options.rootPath)
+    : null;
+  state.paths?.add(mountedPath ?? resolved.path);
   return `${leading}${rewrite(core, resolved)}${trailing}`;
 }
 
@@ -195,7 +198,9 @@ function resolveBase(
   }
   const resolved = resolveLocalUrl(trimmed, documentPath, true);
   if (!resolved) return null;
-  const unmountedPath = unmountRootPath(resolved.url.pathname, rootPath);
+  const unmountedPath = isRootRelative(trimmed)
+    ? unmountRootPath(resolved.url.pathname, rootPath)
+    : null;
   return {
     ...resolved,
     path: unmountedPath ?? resolved.path,
@@ -291,6 +296,11 @@ function rewriteRootRelativeUrl(value: string, rootPath?: string): string {
   if (!resolved) return value;
   if (unmountRootPath(resolved.url.pathname, rootPath) !== null) return value;
   return `${leading}${mountPath(rootPath, resolved.url.pathname)}${resolved.url.search}${resolved.url.hash}${trailing}`;
+}
+
+function isRootRelative(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("/") && !trimmed.startsWith("//");
 }
 
 function unmountRootPath(pathname: string, rootPath?: string): string | null {
@@ -482,7 +492,12 @@ export function collectPreviewCssResourcePaths(
   const paths = new Set<string>();
   rewriteCssUrls(css, (url) => {
     const resolved = resolveLocalUrl(url, documentPath, true);
-    if (resolved) paths.add(unmountRootPath(resolved.url.pathname, rootPath) ?? resolved.path);
+    if (resolved) {
+      const mountedPath = isRootRelative(url)
+        ? unmountRootPath(resolved.url.pathname, rootPath)
+        : null;
+      paths.add(mountedPath ?? resolved.path);
+    }
     return url;
   });
   return [...paths].sort();

--- a/packages/app/src/lib/preview-token.ts
+++ b/packages/app/src/lib/preview-token.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 import { z } from "zod";
 import type { Env, User } from "../types";
+import { decodeServedPath } from "./path";
 
 const PREVIEW_TOKEN_TTL_SECONDS = 600;
 
@@ -114,7 +115,11 @@ export const previewTokenAuth = createMiddleware<{
   }
 
   const prefix = `${match[0]}${url.pathname.startsWith(`${match[0]}/`) ? "/" : ""}`;
-  const requestedPath = url.pathname.slice(prefix.length) || "index.html";
+  const requestedPath = decodeServedPath(url.pathname.slice(prefix.length));
+  if (requestedPath === null) {
+    await next();
+    return;
+  }
   const grant = await validatePreviewToken(
     c.env.SESSION_KV,
     token,

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -134,6 +134,26 @@ describe("preview file resolution", () => {
     );
   }
 
+  it("redirects the root alias to a canonical index URL", async () => {
+    const response = await app.request(
+      "http://site-studio.test/preview/proj",
+      { redirect: "manual" },
+      createEnv(bucket, kv)
+    );
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("/preview/proj/index.html");
+  });
+
+  it("keeps the configured ingress mount in the root-alias redirect", async () => {
+    const response = await app.request(
+      "http://site-studio.test/preview/proj?from=editor",
+      { redirect: "manual" },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("/site-studio/preview/proj/index.html?from=editor");
+  });
+
   it("serves index.html at the project root", async () => {
     const res = await get("");
     expect(res.status).toBe(200);
@@ -227,10 +247,51 @@ describe("preview file resolution", () => {
     const response = await get("index.html", "text/html");
     const html = await response.text();
     expect(response.status).toBe(200);
-    expect(html).toContain('<script src="app.js"></script>');
-    const token = /\/preview\/proj\/logo\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(html).toContain('<base href="https://outside.example/">');
+    expect(html).toContain('<script src="app.js">');
+    expect(html).toContain('<img src="/logo.png">');
+    const effectiveBase = new URL(
+      /<base href="([^"]+)">/.exec(html)?.[1] ?? "",
+      "http://site-studio.test/preview/proj/index.html"
+    );
+    const script = /<script src="([^"]+)">/.exec(html)?.[1] ?? "";
+    const image = /<img src="([^"]+)">/.exec(html)?.[1] ?? "";
+    expect(effectiveBase.origin).toBe("https://outside.example");
+    expect(new URL(script, effectiveBase).origin).toBe("https://outside.example");
+    expect(new URL(image, effectiveBase).origin).toBe("https://outside.example");
+    expect([...kv.store.keys()].filter((key) => key.startsWith("preview-token:"))).toEqual([]);
+  });
+
+  it("serves a preview asset whose authored name contains a space", async () => {
+    await storage.writeFile(userId, "proj", "index.html", '<img src="my%20image.png"><img src="%C3%A9.png">');
+    await storage.writeFile(userId, "proj", "my image.png", "spaced asset");
+    await storage.writeFile(userId, "proj", "é.png", "unicode asset");
+
+    const page = await get("index.html", "text/html");
+    const html = await page.text();
+    const token = /my%20image\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(page.status).toBe(200);
     expect(token).toMatch(/^[0-9a-f]{64}$/);
-    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual(["logo.png"]);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual([
+      "my image.png",
+      "é.png"
+    ]);
+
+    const asset = await app.request(
+      `http://site-studio.test/preview/proj/my%20image.png?pt=${token}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toBe("spaced asset");
+
+    const unicodeAsset = await app.request(
+      `http://site-studio.test/preview/proj/%C3%A9.png?pt=${token}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(unicodeAsset.status).toBe(200);
+    expect(await unicodeAsset.text()).toBe("unicode asset");
   });
 
   it("keeps the configured ingress mount on rewritten preview URLs", async () => {
@@ -669,6 +730,63 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     expect(publishedDirectory.status).toBe(200);
     expect(await publishedDirectory.text()).toContain("Docs");
+  });
+
+  it("preserves an external base and its governed URLs on published HTML", async () => {
+    await storage.writeFile(userId, slug, "index.html", [
+      '<base href="https://outside.example/">',
+      '<script src="app.js"></script>',
+      '<img src="/logo.png">'
+    ].join(""));
+
+    const page = await app.request(
+      "http://site-studio.test/u/janedoe/site/index.html",
+      {},
+      createEnv(bucket)
+    );
+    const html = await page.text();
+    expect(page.status).toBe(200);
+    expect(html).toContain('<base href="https://outside.example/">');
+    expect(html).toContain('<script src="app.js">');
+    expect(html).toContain('<img src="/logo.png">');
+
+    const documentUrl = new URL("http://site-studio.test/u/janedoe/site/index.html");
+    const base = new URL(/<base href="([^"]+)">/.exec(html)?.[1] ?? "", documentUrl);
+    const script = /<script src="([^"]+)">/.exec(html)?.[1] ?? "";
+    const image = /<img src="([^"]+)">/.exec(html)?.[1] ?? "";
+    expect(base.origin).toBe("https://outside.example");
+    expect(new URL(script, base).origin).toBe("https://outside.example");
+    expect(new URL(image, base).origin).toBe("https://outside.example");
+  });
+
+  it("serves a published asset whose authored name contains a space", async () => {
+    await storage.writeFile(userId, slug, "index.html", '<img src="/my%20image.png"><img src="/%C3%A9.png">');
+    await storage.writeFile(userId, slug, "my image.png", "spaced published asset");
+    await storage.writeFile(userId, slug, "é.png", "unicode published asset");
+
+    const page = await app.request(
+      "http://site-studio.test/u/janedoe/site/index.html",
+      {},
+      createEnv(bucket)
+    );
+    expect(page.status).toBe(200);
+    expect(await page.text()).toContain('src="/u/janedoe/site/my%20image.png"');
+
+    const asset = await app.request(
+      "http://site-studio.test/u/janedoe/site/my%20image.png",
+      {},
+      createEnv(bucket)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toBe("spaced published asset");
+
+    const unicodeAsset = await app.request(
+      "http://site-studio.test/u/janedoe/site/%C3%A9.png",
+      {},
+      createEnv(bucket)
+    );
+    expect(unicodeAsset.status).toBe(200);
+    expect(await unicodeAsset.text()).toBe("unicode published asset");
   });
 
   it("rewrites root-relative URLs in published CSS", async () => {

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -183,6 +183,101 @@ describe("preview file resolution", () => {
     expect(stored.allowedPaths).toEqual(["about.html", "app.js", "photo.png", "styles.css"]);
   });
 
+  it("rewrites root-relative HTML URLs to the project preview mount", async () => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      '<link rel="stylesheet" href="/styles.css">',
+      '<script src="/app.js"></script>',
+      '<a href="/docs/">Docs</a>'
+    ].join(""));
+    await storage.writeFile(userId, "proj", "styles.css", "body { color: red; }");
+    await storage.writeFile(userId, "proj", "app.js", "console.log('ok');");
+    await storage.writeFile(userId, "proj", "docs/index.html", "<h1>Docs</h1>");
+
+    const res = await get("index.html?v=42", "text/html");
+    const html = await res.text();
+    const token = /\/preview\/proj\/styles\.css\?v=42&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    const directoryToken = /\/preview\/proj\/docs\/\?v=42&pt=([0-9a-f]{64})/.exec(html)?.[1];
+
+    expect(res.status).toBe(200);
+    expect(html).toContain(`/preview/proj/app.js?v=42&pt=${token}`);
+    expect(html).toContain(`/preview/proj/docs/?v=42&pt=${directoryToken}`);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(directoryToken).toMatch(/^[0-9a-f]{64}$/);
+    const stored = JSON.parse(kv.store.get(`preview-token:${token}`) || "{}");
+    expect(stored.allowedPaths).toEqual(["app.js", "docs/", "styles.css"]);
+
+    const directory = await app.request(
+      `http://site-studio.test/preview/proj/docs/?pt=${directoryToken}`,
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv)
+    );
+    expect(directory.status).toBe(200);
+    expect(await directory.text()).toContain("Docs");
+  });
+
+  it("keeps the configured ingress mount on rewritten preview URLs", async () => {
+    await storage.writeFile(userId, "proj", "index.html", '<script src="/app.js"></script>');
+    await storage.writeFile(userId, "proj", "app.js", "console.log('ok');");
+
+    const res = await app.request(
+      "http://site-studio.test/preview/proj/index.html",
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toMatch(/\/site-studio\/preview\/proj\/app\.js\?v=\d+&pt=[0-9a-f]{64}/);
+  });
+
+  it("does not add the production mount to loopback preview URLs", async () => {
+    await storage.writeFile(userId, "proj", "index.html", '<script src="/app.js"></script>');
+    await storage.writeFile(userId, "proj", "app.js", "console.log('ok');");
+
+    const res = await app.request(
+      "http://localhost:8792/preview/proj/index.html",
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toMatch(/\/preview\/proj\/app\.js\?v=\d+&pt=[0-9a-f]{64}/);
+    expect(html).not.toContain("/site-studio/preview/");
+  });
+
+  it("propagates scoped preview access through nested CSS URLs", async () => {
+    await storage.writeFile(userId, "proj", "index.html", '<link rel="stylesheet" href="styles/main.css">');
+    await storage.writeFile(userId, "proj", "styles/main.css", [
+      '@import "/theme.css";',
+      ".hero { background: url(/images/hero.png); }",
+      "@font-face { src: url(../fonts/body.woff2); }"
+    ].join("\n"));
+    await storage.writeFile(userId, "proj", "images/hero.png", "hero");
+    await storage.writeFile(userId, "proj", "fonts/body.woff2", "font");
+    await storage.writeFile(userId, "proj", "theme.css", "body { color: blue; }");
+
+    const page = await get("index.html", "text/html");
+    const pageHtml = await page.text();
+    const pageToken = /styles\/main\.css\?v=\d+&pt=([0-9a-f]{64})/.exec(pageHtml)?.[1];
+    expect(pageToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${pageToken}`) || "{}").allowedPaths).toEqual([
+      "styles/main.css"
+    ]);
+
+    const css = await get(`styles/main.css?pt=${pageToken}`, "text/css");
+    const cssText = await css.text();
+    const cssToken = /\/preview\/proj\/images\/hero\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(cssText)?.[1];
+    expect(cssToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(cssText).toContain(`/preview/proj/theme.css?v=`);
+    expect(cssText).toContain(`../fonts/body.woff2?v=`);
+    expect(JSON.parse(kv.store.get(`preview-token:${cssToken}`) || "{}").allowedPaths).toEqual([
+      "fonts/body.woff2",
+      "images/hero.png",
+      "theme.css"
+    ]);
+  });
+
   it("does not disclose a preview bearer to protocol-relative authored URLs", async () => {
     await storage.writeFile(
       userId,
@@ -334,6 +429,89 @@ describe("preview token authentication", () => {
     expect(stored.expiresAt).toBe(expiresAt);
     expect(stored.allowedPaths).toEqual(["app.js"]);
   });
+
+  it("serves a root-relative asset through its scoped child preview grant", async () => {
+    await storage.writeFile(
+      userId,
+      "proj",
+      "index.html",
+      '<link rel="stylesheet" href="/styles.css"><script src="/app.js"></script>'
+    );
+    await storage.writeFile(userId, "proj", "app.js", "console.log('ok')");
+    const parent = await mintPreviewToken(kv, userId, "proj", ["index.html"]);
+    const page = await app.request(
+      `http://site-studio.test/preview/proj/index.html?pt=${parent}`,
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv)
+    );
+
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    const child = /\/preview\/proj\/app\.js\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(child).toMatch(/^[0-9a-f]{64}$/);
+
+    const asset = await app.request(
+      `http://site-studio.test/preview/proj/app.js?pt=${child}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toContain("console.log('ok')");
+  });
+
+  it("serves nested CSS assets through a scoped child preview grant", async () => {
+    await storage.writeFile(userId, "proj", "styles/main.css", [
+      ".hero { background: url(/images/hero.png); }",
+      "@font-face { src: url(../fonts/body.woff2); }"
+    ].join("\n"));
+    await storage.writeFile(userId, "proj", "images/hero.png", "hero");
+    await storage.writeFile(userId, "proj", "fonts/body.woff2", "font");
+    const parent = await mintPreviewToken(kv, userId, "proj", ["styles/main.css"]);
+
+    const page = await app.request(
+      `http://site-studio.test/preview/proj/styles/main.css?pt=${parent}`,
+      { headers: { Accept: "text/css" } },
+      createEnv(bucket, kv)
+    );
+    expect(page.status).toBe(200);
+    const css = await page.text();
+    const child = /\/preview\/proj\/images\/hero\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(css)?.[1];
+    expect(child).toMatch(/^[0-9a-f]{64}$/);
+
+    const asset = await app.request(
+      `http://site-studio.test/preview/proj/images/hero.png?pt=${child}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toBe("hero");
+  });
+
+  it("rewrites standalone SVG URLs with a scoped child preview grant", async () => {
+    await storage.writeFile(userId, "proj", "icon.svg", [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">',
+      '<image href="/images/icon.png" xlink:href="/images/icon.png" />',
+      "</svg>"
+    ].join(""));
+    await storage.writeFile(userId, "proj", "images/icon.png", "icon");
+    const parent = await mintPreviewToken(kv, userId, "proj", ["icon.svg"]);
+
+    const response = await app.request(
+      `http://site-studio.test/preview/proj/icon.svg?pt=${parent}`,
+      { headers: { Accept: "image/svg+xml" } },
+      createEnv(bucket, kv)
+    );
+    const svg = await response.text();
+    const token = /\/preview\/proj\/images\/icon\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(svg)?.[1];
+
+    expect(response.status).toBe(200);
+    expect(svg).toContain(`/preview/proj/images/icon.png?v=`);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual([
+      "images/icon.png"
+    ]);
+  });
 });
 
 /**
@@ -398,4 +576,115 @@ describe("preview ↔ publish extensionless parity", () => {
       expect(marker(preview.body)).toBe(marker(publish.body));
     });
   }
+
+  it("rewrites root-relative assets on preview and published HTML", async () => {
+    await storage.writeFile(userId, slug, "index.html", [
+      '<link rel="stylesheet" href="/styles.css">',
+      '<script src="/app.js"></script>',
+      '<a href="/docs/">Docs</a>'
+    ].join(""));
+    await storage.writeFile(userId, slug, "styles.css", "body { color: red; }");
+    await storage.writeFile(userId, slug, "app.js", "console.log('ok');");
+    await storage.writeFile(userId, slug, "docs/index.html", "<h1>Docs</h1>");
+
+    const preview = await previewBody("index.html");
+    const publish = await publishBody("index.html");
+    expect(preview.status).toBe(200);
+    expect(publish.status).toBe(200);
+    expect(preview.body).toMatch(/\/preview\/site\/styles\.css\?v=\d+&pt=[0-9a-f]{64}/);
+    expect(preview.body).toMatch(/\/preview\/site\/app\.js\?v=\d+&pt=[0-9a-f]{64}/);
+    expect(publish.body).toContain('href="/u/janedoe/site/styles.css"');
+    expect(publish.body).toContain('src="/u/janedoe/site/app.js"');
+    expect(publish.body).toContain('href="/u/janedoe/site/docs/"');
+
+    const publishedPage = await app.request(
+      "http://site-studio.test/u/janedoe/site/index.html",
+      {},
+      createEnv(bucket)
+    );
+    expect(publishedPage.headers.get("ETag")).toBeNull();
+
+    const asset = await app.request(
+      "http://site-studio.test/u/janedoe/site/styles.css",
+      {},
+      createEnv(bucket)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toContain("color: red");
+
+    const publishedDirectory = await app.request(
+      "http://site-studio.test/u/janedoe/site/docs/",
+      {},
+      createEnv(bucket)
+    );
+    expect(publishedDirectory.status).toBe(200);
+    expect(await publishedDirectory.text()).toContain("Docs");
+  });
+
+  it("rewrites root-relative URLs in published CSS", async () => {
+    await storage.writeFile(userId, slug, "styles/main.css", [
+      '@import "/theme.css";',
+      ".hero { background: url(/images/hero.png); }"
+    ].join("\n"));
+    await storage.writeFile(userId, slug, "images/hero.png", "hero");
+    await storage.writeFile(userId, slug, "theme.css", "body { color: blue; }");
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/styles/main.css",
+      {},
+      createEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    const css = await response.text();
+    expect(css).toContain("url(/u/janedoe/site/images/hero.png)");
+    expect(css).toContain('@import "/u/janedoe/site/theme.css";');
+  });
+
+  it("rewrites root-relative URLs in published SVG", async () => {
+    await storage.writeFile(userId, slug, "icon.svg", '<svg><image href="/images/icon.png" /></svg>');
+    await storage.writeFile(userId, slug, "images/icon.png", "icon");
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/icon.svg",
+      {},
+      createEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('href="/u/janedoe/site/images/icon.png"');
+  });
+
+  it("rewrites root-relative URLs in published XML", async () => {
+    await storage.writeFile(userId, slug, "manifest.xml", [
+      '<?xml version="1.0"?>',
+      '<?xml-stylesheet type="text/css" href="/style.css"?>',
+      '<manifest><asset href="/images/icon.png" /></manifest>'
+    ].join(""));
+    await storage.writeFile(userId, slug, "images/icon.png", "icon");
+    await storage.writeFile(userId, slug, "style.css", "manifest { display: block; }");
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/manifest.xml",
+      {},
+      createEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    const xml = await response.text();
+    expect(xml).toContain('href="/u/janedoe/site/images/icon.png"');
+    expect(xml).toContain('href="/u/janedoe/site/style.css"');
+  });
+
+  it("preserves published HTML bytes when no mount rewrite is needed", async () => {
+    const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x3c, 0x68, 0x31, 0x3e, 0xff, 0x3c, 0x2f, 0x68, 0x31, 0x3e]);
+    bucket.store.set(`projects/${userId}/${slug}/index.html`, {
+      data: bytes.buffer
+    });
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/index.html",
+      {},
+      createEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+  });
 });

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -398,6 +398,55 @@ describe("preview file resolution", () => {
     );
   });
 
+  it("keeps relative project paths that collide with the configured ingress", async () => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      '<base href="site-studio/preview/proj/">',
+      '<link rel="stylesheet" href="styles.css">',
+      '<script src="app.js"></script>'
+    ].join(""));
+    await storage.writeFile(
+      userId,
+      "proj",
+      "site-studio/preview/proj/styles.css",
+      ".hero { background: url(images/bg.png); }"
+    );
+    await storage.writeFile(userId, "proj", "site-studio/preview/proj/app.js", "console.log('collision');");
+    await storage.writeFile(userId, "proj", "site-studio/preview/proj/images/bg.png", "background");
+
+    const response = await app.request(
+      "http://site-studio.test/preview/proj/index.html",
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const html = await response.text();
+    const token = /app\.js\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+
+    expect(response.status).toBe(200);
+    expect(html).toContain(
+      '<base href="/site-studio/preview/proj/site-studio/preview/proj/">'
+    );
+    expect(html).not.toContain("/site-studio/preview/proj/site-studio/preview/proj/site-studio/");
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual([
+      "site-studio/preview/proj/app.js",
+      "site-studio/preview/proj/styles.css"
+    ]);
+
+    const stylesheet = await app.request(
+      `http://site-studio.test/preview/proj/site-studio/preview/proj/styles.css?pt=${token}`,
+      { headers: { Accept: "text/css" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const css = await stylesheet.text();
+    const cssToken = /images\/bg\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(css)?.[1];
+    expect(stylesheet.status).toBe(200);
+    expect(css).toContain("url(images/bg.png?v=");
+    expect(cssToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${cssToken}`) || "{}").allowedPaths).toEqual([
+      "site-studio/preview/proj/images/bg.png"
+    ]);
+  });
+
   it("does not add the production mount to loopback preview URLs", async () => {
     await storage.writeFile(userId, "proj", "index.html", '<script src="/app.js"></script>');
     await storage.writeFile(userId, "proj", "app.js", "console.log('ok');");
@@ -882,6 +931,43 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     expect(asset.status).toBe(200);
     expect(await asset.text()).toContain("console.log('nested');");
+  });
+
+  it("resolves custom 404 assets from the requested nested browser path", async () => {
+    await storage.writeFile(
+      userId,
+      slug,
+      "404.html",
+      '<base href="assets/"><script src="app.js"></script>'
+    );
+    await storage.writeFile(userId, slug, "missing/assets/app.js", "console.log('missing');");
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/missing/page",
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket)
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(html).toContain('<base href="/u/janedoe/site/missing/assets/">');
+    expect(html).toContain('<script src="app.js"></script>');
+    expect(html).not.toContain('<base href="/u/janedoe/site/assets/">');
+    const effectiveBase = new URL(
+      "/u/janedoe/site/missing/assets/",
+      "https://site-studio.test/u/janedoe/site/missing/page"
+    );
+    expect(new URL("app.js", effectiveBase).pathname).toBe(
+      "/u/janedoe/site/missing/assets/app.js"
+    );
+
+    const asset = await app.request(
+      "http://site-studio.test/u/janedoe/site/missing/assets/app.js",
+      {},
+      createEnv(bucket)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toContain("console.log('missing');");
   });
 
   it("serves a published asset whose authored name contains a space", async () => {

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -141,7 +141,7 @@ describe("preview file resolution", () => {
   });
 
   it("serves a directory's index.html for a trailing-slash path", async () => {
-    await storage.writeFile(userId, "proj", "docs/index.html", "<h1>Docs</h1>");
+    await storage.writeFile(userId, "proj", "docs/index.html", '<a href="./?x">Directory</a><h1>Docs</h1>');
     const res = await get("docs/");
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("Docs");
@@ -212,7 +212,25 @@ describe("preview file resolution", () => {
       createEnv(bucket, kv)
     );
     expect(directory.status).toBe(200);
-    expect(await directory.text()).toContain("Docs");
+    const directoryHtml = await directory.text();
+    expect(directoryHtml).toContain("Docs");
+  });
+
+  it("does not leak a preview token through an external base URL", async () => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      '<base href="https://outside.example/">',
+      '<script src="app.js"></script>',
+      '<img src="/logo.png">'
+    ].join(""));
+    await storage.writeFile(userId, "proj", "logo.png", "logo");
+
+    const response = await get("index.html", "text/html");
+    const html = await response.text();
+    expect(response.status).toBe(200);
+    expect(html).toContain('<script src="app.js"></script>');
+    const token = /\/preview\/proj\/logo\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual(["logo.png"]);
   });
 
   it("keeps the configured ingress mount on rewritten preview URLs", async () => {
@@ -355,6 +373,38 @@ describe("preview token authentication", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("color: red");
     expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("scopes query-only and dot-directory links to their actual preview paths", async () => {
+    await storage.writeFile(userId, "proj", "docs/index.html", '<a href="?x">Current</a><a href="./?x">Directory</a>');
+    const parent = await mintPreviewToken(kv, userId, "proj", ["docs/index.html"]);
+    const page = await app.request(
+      `http://site-studio.test/preview/proj/docs/index.html?pt=${parent}`,
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv)
+    );
+
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    const child = /[?&]v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(child).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${child}`) || "{}").allowedPaths).toEqual([
+      "docs/",
+      "docs/index.html"
+    ]);
+
+    const current = await app.request(
+      `http://site-studio.test/preview/proj/docs/index.html?pt=${child}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    const directory = await app.request(
+      `http://site-studio.test/preview/proj/docs/?pt=${child}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(current.status).toBe(200);
+    expect(directory.status).toBe(200);
   });
 
   it("does not authorize a different project with a valid token", async () => {
@@ -651,26 +701,6 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.text()).toContain('href="/u/janedoe/site/images/icon.png"');
-  });
-
-  it("rewrites root-relative URLs in published XML", async () => {
-    await storage.writeFile(userId, slug, "manifest.xml", [
-      '<?xml version="1.0"?>',
-      '<?xml-stylesheet type="text/css" href="/style.css"?>',
-      '<manifest><asset href="/images/icon.png" /></manifest>'
-    ].join(""));
-    await storage.writeFile(userId, slug, "images/icon.png", "icon");
-    await storage.writeFile(userId, slug, "style.css", "manifest { display: block; }");
-
-    const response = await app.request(
-      "http://site-studio.test/u/janedoe/site/manifest.xml",
-      {},
-      createEnv(bucket)
-    );
-    expect(response.status).toBe(200);
-    const xml = await response.text();
-    expect(xml).toContain('href="/u/janedoe/site/images/icon.png"');
-    expect(xml).toContain('href="/u/janedoe/site/style.css"');
   });
 
   it("preserves published HTML bytes when no mount rewrite is needed", async () => {

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -262,6 +262,34 @@ describe("preview file resolution", () => {
     expect([...kv.store.keys()].filter((key) => key.startsWith("preview-token:"))).toEqual([]);
   });
 
+  it.each(["", "#section"])("keeps a %j preview base on the current document", async (baseHref) => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      `<base href="${baseHref}">`,
+      '<script src="app.js"></script>',
+      '<img src="/images/hero.png">'
+    ].join(""));
+    await storage.writeFile(userId, "proj", "app.js", "console.log('nested');");
+    await storage.writeFile(userId, "proj", "images/hero.png", "hero");
+
+    const response = await get("index.html", "text/html");
+    const html = await response.text();
+    const token = /app\.js\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+
+    expect(response.status).toBe(200);
+    expect(html).toContain(`<base href="${baseHref}">`);
+    expect(html).toContain('src="app.js?v=');
+    expect(html).toContain('/preview/proj/images/hero.png?v=');
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual([
+      "app.js",
+      "images/hero.png"
+    ]);
+
+    const effectiveBase = new URL(baseHref, "http://site-studio.test/preview/proj/index.html");
+    expect(effectiveBase.pathname).toBe("/preview/proj/index.html");
+    expect(new URL("app.js", effectiveBase).pathname).toBe("/preview/proj/app.js");
+  });
+
   it("serves a preview asset whose authored name contains a space", async () => {
     await storage.writeFile(userId, "proj", "index.html", '<img src="my%20image.png"><img src="%C3%A9.png">');
     await storage.writeFile(userId, "proj", "my image.png", "spaced asset");
@@ -307,6 +335,67 @@ describe("preview file resolution", () => {
 
     expect(res.status).toBe(200);
     expect(html).toMatch(/\/site-studio\/preview\/proj\/app\.js\?v=\d+&pt=[0-9a-f]{64}/);
+  });
+
+  it("keeps an authored mounted preview base and scopes its child paths correctly", async () => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      '<base href="/site-studio/preview/proj/docs/">',
+      '<link rel="stylesheet" href="styles.css">',
+      '<script src="app.js"></script>',
+      '<img src="/site-studio/preview/proj/images/hero.png">'
+    ].join(""));
+    await storage.writeFile(
+      userId,
+      "proj",
+      "docs/styles.css",
+      ".hero { background: url(/site-studio/preview/proj/images/bg.png); }"
+    );
+    await storage.writeFile(userId, "proj", "docs/app.js", "console.log('nested');");
+    await storage.writeFile(userId, "proj", "images/hero.png", "hero");
+    await storage.writeFile(userId, "proj", "images/bg.png", "background");
+
+    const response = await app.request(
+      "http://site-studio.test/preview/proj/index.html",
+      { headers: { Accept: "text/html" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const html = await response.text();
+    const token = /app\.js\?v=\d+&pt=([0-9a-f]{64})/.exec(html)?.[1];
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<base href="/site-studio/preview/proj/docs/">');
+    expect(html).not.toContain("/site-studio/preview/proj/site-studio/preview/proj/");
+    expect(html).toContain(`app.js?v=`);
+    expect(html).toContain(`/site-studio/preview/proj/images/hero.png?v=`);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${token}`) || "{}").allowedPaths).toEqual([
+      "docs/app.js",
+      "docs/styles.css",
+      "images/hero.png"
+    ]);
+
+    const stylesheet = await app.request(
+      `http://site-studio.test/preview/proj/docs/styles.css?pt=${token}`,
+      { headers: { Accept: "text/css" } },
+      createEnv(bucket, kv, { CSRF_COOKIE_PATH: "/site-studio" })
+    );
+    const css = await stylesheet.text();
+    const cssToken = /images\/bg\.png\?v=\d+&pt=([0-9a-f]{64})/.exec(css)?.[1];
+    expect(stylesheet.status).toBe(200);
+    expect(css).toContain("/site-studio/preview/proj/images/bg.png?v=");
+    expect(css).not.toContain("/site-studio/preview/proj/site-studio/preview/proj/");
+    expect(cssToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(kv.store.get(`preview-token:${cssToken}`) || "{}").allowedPaths).toEqual([
+      "images/bg.png"
+    ]);
+
+    const effectiveBase = new URL(
+      "/site-studio/preview/proj/docs/",
+      "https://site-studio.test/preview/proj/index.html"
+    );
+    expect(new URL("app.js", effectiveBase).pathname).toBe(
+      "/site-studio/preview/proj/docs/app.js"
+    );
   });
 
   it("does not add the production mount to loopback preview URLs", async () => {
@@ -757,6 +846,42 @@ describe("preview ↔ publish extensionless parity", () => {
     expect(base.origin).toBe("https://outside.example");
     expect(new URL(script, base).origin).toBe("https://outside.example");
     expect(new URL(image, base).origin).toBe("https://outside.example");
+  });
+
+  it("resolves a published nested document base from its real document path", async () => {
+    await storage.writeFile(
+      userId,
+      slug,
+      "docs/index.html",
+      '<base href="assets/"><script src="app.js"></script>'
+    );
+    await storage.writeFile(userId, slug, "docs/assets/app.js", "console.log('nested');");
+
+    const response = await app.request(
+      "http://site-studio.test/u/janedoe/site/docs/index.html",
+      {},
+      createEnv(bucket)
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<base href="/u/janedoe/site/docs/assets/">');
+    expect(html).toContain('<script src="app.js"></script>');
+    const effectiveBase = new URL(
+      "/u/janedoe/site/docs/assets/",
+      "https://site-studio.test/u/janedoe/site/docs/index.html"
+    );
+    expect(new URL("app.js", effectiveBase).pathname).toBe(
+      "/u/janedoe/site/docs/assets/app.js"
+    );
+
+    const asset = await app.request(
+      "http://site-studio.test/u/janedoe/site/docs/assets/app.js",
+      {},
+      createEnv(bucket)
+    );
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toContain("console.log('nested');");
   });
 
   it("serves a published asset whose authored name contains a space", async () => {

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -1,6 +1,11 @@
 import { Hono, type Context } from "hono";
 import type { Env } from "../types";
-import { addCacheBusterToHtml, collectPreviewResourcePaths } from "../lib/path";
+import {
+  addCacheBusterToCss,
+  addCacheBusterToHtml,
+  collectPreviewCssResourcePaths,
+  collectPreviewResourcePaths
+} from "../lib/path";
 import { getServedContentType } from "../lib/constants";
 import { binaryBody } from "../lib/http";
 import { renderNotFoundPage } from "../lib/not-found-page";
@@ -9,6 +14,7 @@ import { looksLikePageNavigation } from "../lib/page-navigation";
 import { resolveExtensionlessFile } from "../lib/extensionless";
 import { isProtectedServedPath } from "../lib/protected-files";
 import { getUser } from "../lib/session";
+import { isLoopbackOrigin } from "../lib/csrf";
 import { mintPreviewToken } from "../lib/preview-token";
 import { FileNotFoundError, R2ProjectStorage } from "../storage/r2";
 import { getLoggingContext, type LoggingVariables } from "../lib/logging";
@@ -24,6 +30,16 @@ function previewNotFound(c: AppContext, filePath: string, siteRootPath?: string)
     return c.html(renderNotFoundPage(siteRootPath), 404, headers);
   }
   return c.text("Not found", 404, headers);
+}
+
+function getPreviewRootPath(c: AppContext, projectId: string): string {
+  const requestOrigin = new URL(c.req.url).origin;
+  const configuredMount = c.env.CSRF_COOKIE_PATH?.trim().replace(/\/+$/, "") || "";
+  const normalizedMount = configuredMount && configuredMount !== "/"
+    ? (configuredMount.startsWith("/") ? configuredMount : `/${configuredMount}`)
+    : "";
+  const mountPath = isLoopbackOrigin(requestOrigin) ? "" : normalizedMount;
+  return `${mountPath}/preview/${projectId}/`;
 }
 
 export function createPreviewRouter() {
@@ -57,7 +73,7 @@ async function servePreviewFile(
     return previewNotFound(c, requestedPath);
   }
 
-  const siteRootPath = `/preview/${projectId}/`;
+  const siteRootPath = getPreviewRootPath(c, projectId);
 
   if (isProtectedServedPath(requestedPath)) {
     return previewNotFound(c, requestedPath, siteRootPath);
@@ -111,7 +127,10 @@ async function servePreviewFile(
   c.header("Cache-Control", "no-cache");
   c.header("Pragma", "no-cache");
 
-  if (contentType.startsWith("text/html")) {
+  const isMarkup = contentType.startsWith("text/html")
+    || contentType.startsWith("image/svg+xml")
+    || contentType.startsWith("application/xml");
+  if (isMarkup) {
     const version = c.req.query("v") || undefined;
     // The ownership check above ensures preview tokens are never minted for a
     // non-owner. Opaque-origin sandbox documents cannot send the session cookie,
@@ -127,13 +146,39 @@ async function servePreviewFile(
           c.get("previewTokenExpiresAt") ?? undefined
         )
       : null;
-    content = new TextEncoder().encode(
-      addCacheBusterToHtml(html, version, previewToken ? { pt: previewToken } : {})
+    // Root-relative authored URLs belong to this project, not the app shell.
+    // Include the public mount so production ingress requests return to the
+    // same preview route after the Worker strips /site-studio internally.
+    const rewritten = addCacheBusterToHtml(
+      html,
+      version,
+      previewToken ? { pt: previewToken } : {},
+      siteRootPath,
+      requestedPath
     );
+    if (rewritten !== html) content = new TextEncoder().encode(rewritten);
+  } else if (contentType.startsWith("text/css")) {
+    const version = c.req.query("v") || undefined;
+    const css = new TextDecoder().decode(content);
+    const allowedPaths = collectPreviewCssResourcePaths(css, requestedPath);
+    const previewToken = allowedPaths.length > 0
+      ? await mintPreviewToken(
+          c.env.SESSION_KV,
+          user.id,
+          projectId,
+          allowedPaths,
+          c.get("previewTokenExpiresAt") ?? undefined
+        )
+      : null;
+    const rewritten = addCacheBusterToCss(
+      css,
+      version,
+      previewToken ? { pt: previewToken } : {},
+      siteRootPath,
+      requestedPath
+    );
+    if (rewritten !== css) content = new TextEncoder().encode(rewritten);
   }
-
-  // Known limitation: url(...) references inside CSS are not rewritten, so
-  // nested fonts/background images still need a future CSS-aware pass.
 
   // §3¾: the preview renders agent/student-authored HTML on our origin. The
   // opaque-origin CSP (see lib/serving-headers.ts) makes document.cookie /

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -164,7 +164,7 @@ async function servePreviewFile(
   } else if (contentType.startsWith("text/css")) {
     const version = c.req.query("v") || undefined;
     const css = new TextDecoder().decode(content);
-    const allowedPaths = collectPreviewCssResourcePaths(css, requestedPath);
+    const allowedPaths = collectPreviewCssResourcePaths(css, requestedPath, siteRootPath);
     const previewToken = allowedPaths.length > 0
       ? await mintPreviewToken(
           c.env.SESSION_KV,

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -4,7 +4,8 @@ import {
   addCacheBusterToCss,
   addCacheBusterToHtml,
   collectPreviewCssResourcePaths,
-  collectPreviewResourcePaths
+  collectPreviewResourcePaths,
+  decodeServedPath
 } from "../lib/path";
 import { getServedContentType } from "../lib/constants";
 import { binaryBody } from "../lib/http";
@@ -45,14 +46,18 @@ function getPreviewRootPath(c: AppContext, projectId: string): string {
 export function createPreviewRouter() {
   const app = new Hono<{ Bindings: Env; Variables: LoggingVariables & { user: { id: string } } }>();
 
-  app.get("/preview/:id", async (c) => {
-    return servePreviewFile(c, "index.html");
+  app.get("/preview/:id", (c) => {
+    const url = new URL(c.req.url);
+    const projectId = c.req.param("id");
+    return c.redirect(`${getPreviewRootPath(c, projectId)}index.html${url.search}`, 308);
   });
 
   app.get("/preview/:id/*", async (c) => {
     const prefix = `/preview/${c.req.param("id")}/`;
     const url = new URL(c.req.url);
-    const filePath = url.pathname.slice(prefix.length) || "index.html";
+    const rawPath = url.pathname.slice(prefix.length);
+    const filePath = decodeServedPath(rawPath);
+    if (filePath === null) return previewNotFound(c, rawPath);
     return servePreviewFile(c, filePath);
   });
 
@@ -135,7 +140,7 @@ async function servePreviewFile(
     // non-owner. Opaque-origin sandbox documents cannot send the session cookie,
     // so carry this short-lived, project-scoped token on rewritten requests.
     const html = new TextDecoder().decode(content);
-    const allowedPaths = await collectPreviewResourcePaths(html, requestedPath);
+    const allowedPaths = await collectPreviewResourcePaths(html, requestedPath, siteRootPath);
     const previewToken = allowedPaths.length > 0
       ? await mintPreviewToken(
           c.env.SESSION_KV,

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -128,15 +128,14 @@ async function servePreviewFile(
   c.header("Pragma", "no-cache");
 
   const isMarkup = contentType.startsWith("text/html")
-    || contentType.startsWith("image/svg+xml")
-    || contentType.startsWith("application/xml");
+    || contentType.startsWith("image/svg+xml");
   if (isMarkup) {
     const version = c.req.query("v") || undefined;
     // The ownership check above ensures preview tokens are never minted for a
     // non-owner. Opaque-origin sandbox documents cannot send the session cookie,
     // so carry this short-lived, project-scoped token on rewritten requests.
     const html = new TextDecoder().decode(content);
-    const allowedPaths = collectPreviewResourcePaths(html, requestedPath);
+    const allowedPaths = await collectPreviewResourcePaths(html, requestedPath);
     const previewToken = allowedPaths.length > 0
       ? await mintPreviewToken(
           c.env.SESSION_KV,
@@ -149,7 +148,7 @@ async function servePreviewFile(
     // Root-relative authored URLs belong to this project, not the app shell.
     // Include the public mount so production ingress requests return to the
     // same preview route after the Worker strips /site-studio internally.
-    const rewritten = addCacheBusterToHtml(
+    const rewritten = await addCacheBusterToHtml(
       html,
       version,
       previewToken ? { pt: previewToken } : {},

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -124,7 +124,7 @@ async function missingPublishedFile(
           headers: publishedResponseHeaders("404.html", custom)
         });
       }
-      const html = await rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath, "404.html");
+      const html = await rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath, filePath);
       const headers = publishedResponseHeaders("404.html", custom);
       const transformed = html !== originalHtml;
       const content = transformed ? new TextEncoder().encode(html) : originalBytes;

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -124,7 +124,7 @@ async function missingPublishedFile(
           headers: publishedResponseHeaders("404.html", custom)
         });
       }
-      const html = await rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath);
+      const html = await rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath, "404.html");
       const headers = publishedResponseHeaders("404.html", custom);
       const transformed = html !== originalHtml;
       const content = transformed ? new TextEncoder().encode(html) : originalBytes;
@@ -556,7 +556,7 @@ async function servePublishedFile(
     try {
       const originalText = new TextDecoder("utf-8", { fatal: true }).decode(originalBytes);
       const rewritten = isMarkup
-        ? await rewriteRootRelativeHtmlUrls(originalText, siteRootPath)
+        ? await rewriteRootRelativeHtmlUrls(originalText, siteRootPath, resolved.filePath)
         : rewriteRootRelativeCssUrls(originalText, siteRootPath);
       if (rewritten !== originalText) {
         content = new TextEncoder().encode(rewritten);

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -111,8 +111,16 @@ async function missingPublishedFile(
       // goes through the same header builder as a 200 so the content-type,
       // caching validators and CSP match normal published responses.
       const originalBytes = new Uint8Array(await custom.arrayBuffer());
-      const originalHtml = new TextDecoder().decode(originalBytes);
-      const html = rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath);
+      let originalHtml: string;
+      try {
+        originalHtml = new TextDecoder("utf-8", { fatal: true }).decode(originalBytes);
+      } catch {
+        return new Response(binaryBody(originalBytes), {
+          status: 404,
+          headers: publishedResponseHeaders("404.html", custom)
+        });
+      }
+      const html = await rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath);
       const headers = publishedResponseHeaders("404.html", custom);
       const transformed = html !== originalHtml;
       const content = transformed ? new TextEncoder().encode(html) : originalBytes;
@@ -537,16 +545,20 @@ async function servePublishedFile(
   let content = originalBytes;
   let transformed = false;
   const isMarkup = contentType.startsWith("text/html")
-    || contentType.startsWith("image/svg+xml")
-    || contentType.startsWith("application/xml");
+    || contentType.startsWith("image/svg+xml");
   if (isMarkup || contentType.startsWith("text/css")) {
-    const originalText = new TextDecoder().decode(originalBytes);
-    const rewritten = isMarkup
-      ? rewriteRootRelativeHtmlUrls(originalText, siteRootPath)
-      : rewriteRootRelativeCssUrls(originalText, siteRootPath);
-    if (rewritten !== originalText) {
-      content = new TextEncoder().encode(rewritten);
-      transformed = true;
+    try {
+      const originalText = new TextDecoder("utf-8", { fatal: true }).decode(originalBytes);
+      const rewritten = isMarkup
+        ? await rewriteRootRelativeHtmlUrls(originalText, siteRootPath)
+        : rewriteRootRelativeCssUrls(originalText, siteRootPath);
+      if (rewritten !== originalText) {
+        content = new TextEncoder().encode(rewritten);
+        transformed = true;
+      }
+    } catch {
+      // Preserve non-UTF-8 authored bytes exactly instead of corrupting them
+      // while attempting a mount rewrite.
     }
   }
   const headers = publishedResponseHeaders(resolved.filePath, resolved.object);

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -20,7 +20,11 @@ import { lintProject, type A11yFinding } from "../lib/a11y-lint";
 import { R2ProjectStorage } from "../storage/r2";
 import type { RequireProjectVariables } from "../lib/require-project";
 import { isLoopbackOrigin } from "../lib/csrf";
-import { rewriteRootRelativeCssUrls, rewriteRootRelativeHtmlUrls } from "../lib/path";
+import {
+  decodeServedPath,
+  rewriteRootRelativeCssUrls,
+  rewriteRootRelativeHtmlUrls
+} from "../lib/path";
 import { OBSERVABILITY_CONTRACT } from "../../../observability-core/src/contract";
 import {
   SiteStudioActionLifecycle,
@@ -468,7 +472,9 @@ export function createPublishRouter() {
   app.get("/u/:handle/:slug/*", async (c) => {
     const base = `/u/${c.req.param("handle")}/${c.req.param("slug")}/`;
     const url = new URL(c.req.url);
-    const filePath = url.pathname.slice(base.length) || "index.html";
+    const rawPath = url.pathname.slice(base.length);
+    const filePath = decodeServedPath(rawPath);
+    if (filePath === null) return publishedNotFound(c, rawPath);
     return serveByHandle(c, filePath);
   });
 

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -20,6 +20,7 @@ import { lintProject, type A11yFinding } from "../lib/a11y-lint";
 import { R2ProjectStorage } from "../storage/r2";
 import type { RequireProjectVariables } from "../lib/require-project";
 import { isLoopbackOrigin } from "../lib/csrf";
+import { rewriteRootRelativeCssUrls, rewriteRootRelativeHtmlUrls } from "../lib/path";
 import { OBSERVABILITY_CONTRACT } from "../../../observability-core/src/contract";
 import {
   SiteStudioActionLifecycle,
@@ -109,9 +110,21 @@ async function missingPublishedFile(
       // on our origin — §3¾ containment applies (see lib/serving-headers.ts). It
       // goes through the same header builder as a 200 so the content-type,
       // caching validators and CSP match normal published responses.
-      return new Response(binaryBody(new Uint8Array(await custom.arrayBuffer())), {
+      const originalBytes = new Uint8Array(await custom.arrayBuffer());
+      const originalHtml = new TextDecoder().decode(originalBytes);
+      const html = rewriteRootRelativeHtmlUrls(originalHtml, siteRootPath);
+      const headers = publishedResponseHeaders("404.html", custom);
+      const transformed = html !== originalHtml;
+      const content = transformed ? new TextEncoder().encode(html) : originalBytes;
+      if (transformed) {
+        // The served bytes now include the canonical site mount, so validators
+        // from the unrewritten R2 object no longer describe this response.
+        headers.delete("ETag");
+        headers.delete("Last-Modified");
+      }
+      return new Response(binaryBody(content), {
         status: 404,
-        headers: publishedResponseHeaders("404.html", custom)
+        headers
       });
     }
   }
@@ -519,12 +532,34 @@ async function servePublishedFile(
     return missingPublishedFile(c, storage, userId, projectId, rawPath, siteRootPath);
   }
 
+  const contentType = getServedContentType(resolved.filePath);
+  const originalBytes = new Uint8Array(await resolved.object.arrayBuffer());
+  let content = originalBytes;
+  let transformed = false;
+  const isMarkup = contentType.startsWith("text/html")
+    || contentType.startsWith("image/svg+xml")
+    || contentType.startsWith("application/xml");
+  if (isMarkup || contentType.startsWith("text/css")) {
+    const originalText = new TextDecoder().decode(originalBytes);
+    const rewritten = isMarkup
+      ? rewriteRootRelativeHtmlUrls(originalText, siteRootPath)
+      : rewriteRootRelativeCssUrls(originalText, siteRootPath);
+    if (rewritten !== originalText) {
+      content = new TextEncoder().encode(rewritten);
+      transformed = true;
+    }
+  }
   const headers = publishedResponseHeaders(resolved.filePath, resolved.object);
-  if (publishedObjectNotModified(c.req.raw, resolved.object)) {
+  if (transformed) {
+    // The served bytes now include the canonical site mount, so validators
+    // from the unrewritten R2 object no longer describe this response.
+    headers.delete("ETag");
+    headers.delete("Last-Modified");
+  } else if (publishedObjectNotModified(c.req.raw, resolved.object)) {
     return new Response(null, { status: 304, headers });
   }
 
-  return new Response(binaryBody(new Uint8Array(await resolved.object.arrayBuffer())), {
+  return new Response(binaryBody(content), {
     headers
   });
 }

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    setupFiles: ["./src/lib/htmlrewriter-test-setup.ts"],
     include: ["src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Outcome

Site previews and published pages now rewrite and authorize browser asset URLs from the actual document URL, including nested pages, mounted production paths, CSS imports, encoded paths, and custom 404 pages. Relative storage paths remain owned by the project even when they collide with the public mount.

## Production boundary

The canonical public coordinate remains `/site-studio/...`; unprefixed internal Worker routes are not treated as browser aliases.

## Verification

- Real Worker route reproductions for the missing CSS/JS and nested custom-404 failures
- Full app check and production dry bundle
- Native HTMLRewriter/WHATWG URL smoke
- Two independent reviews accepted exact head `66fdae8d7baeb1861c98ede6c6333dff301cc180`

No deployment is performed by this PR until CI and merge.