### PR TITLE
Fail closed for missing Site Studio assets

### DIFF
--- a/packages/app/src/app.test.ts
+++ b/packages/app/src/app.test.ts
@@ -257,6 +257,47 @@ describe("mounted SPA assets", () => {
 
     expect(assetFetch).toHaveBeenCalledTimes(3);
   });
+
+  it("rejects a cached SPA fallback but preserves a valid hashed asset 304", async () => {
+    const assetFetch = vi.fn(async (request: Request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/missing.js")) {
+        return new Response(null, {
+          status: 304,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+            etag: "\"spa-index-etag\"",
+          },
+        });
+      }
+      return new Response(null, {
+        status: 304,
+        headers: {
+          "content-type": "text/javascript; charset=utf-8",
+          etag: "\"hashed-asset-etag\"",
+        },
+      });
+    });
+    const env = createEnv();
+    env.ASSETS = asTestFetcher(assetFetch);
+
+    const missing = await app.request(
+      `${BASE}/site-studio/_app/immutable/chunks/missing.js`,
+      { headers: { "If-None-Match": '"spa-index-etag"' } },
+      env,
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).toBe('{"error":"Not found"}');
+
+    const valid = await app.request(
+      `${BASE}/site-studio/_app/immutable/entry/start.js`,
+      { headers: { "If-None-Match": '"hashed-asset-etag"' } },
+      env,
+    );
+    expect(valid.status).toBe(304);
+    expect(valid.headers.get("content-type")).toContain("text/javascript");
+    expect(valid.headers.get("etag")).toBe('"hashed-asset-etag"');
+  });
 });
 
 describe("subject session retirement", () => {

--- a/packages/app/src/app.test.ts
+++ b/packages/app/src/app.test.ts
@@ -235,6 +235,28 @@ describe("mounted SPA assets", () => {
     expect(asset.headers.get("content-type")).toContain("application/javascript");
     expect(requestedPaths).toEqual(["/", "/_app/immutable/entry/start.js"]);
   });
+
+  it("does not turn missing static assets into the SPA fallback", async () => {
+    const assetFetch = vi.fn(async () => new Response("<html>Site Studio</html>", {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    }));
+    const env = createEnv();
+    env.ASSETS = asTestFetcher(assetFetch);
+
+    for (const path of [
+      "/site-studio/_app/immutable/chunks/missing.js",
+      "/site-studio/_app/immutable/assets/missing.css",
+      "/site-studio/icon-missing.png",
+    ]) {
+      const response = await app.request(`${BASE}${path}`, {}, env);
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).not.toContain("Site Studio");
+    }
+
+    expect(assetFetch).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("subject session retirement", () => {

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -16,6 +16,7 @@ import { createQuotaRouter } from "./routes/quota";
 import { previewTokenAuth } from "./lib/preview-token";
 import { requireProject, type RequireProjectVariables } from "./lib/require-project";
 import { requestLogging, type LoggingVariables } from "./lib/logging";
+import { getServedContentType } from "./lib/constants";
 
 /**
  * App assembly lives here (separate from index.ts) so tests can exercise the
@@ -51,6 +52,17 @@ export function normalizeMountedRequest(
 
 function assetRequest(c: { req: { raw: Request; url: string }; env: Env }): Request {
   return normalizeMountedRequest(c.req.raw, c.env);
+}
+
+/**
+ * The asset binding is configured for SPA fallback so extensionless Svelte
+ * routes can load the app shell. A missing known static asset must not inherit
+ * that fallback: the browser needs a real 404 instead of HTML for a script,
+ * stylesheet, image, or other authored static resource.
+ */
+function isStandaloneStaticAsset(pathname: string): boolean {
+  const contentType = getServedContentType(pathname);
+  return contentType !== "application/octet-stream" && !contentType.startsWith("text/html");
 }
 
 // Fleet logging standard (cail-log): adopt/mint correlation at the fetch
@@ -153,7 +165,22 @@ app.notFound(async (c) => {
     || pathname.startsWith("/sites/");
 
   if (!isWorkerRoute && c.env.ASSETS) {
-    return c.env.ASSETS.fetch(assetRequest(c));
+    const assetResponse = await c.env.ASSETS.fetch(assetRequest(c));
+    const assetContentType = assetResponse.headers.get("content-type")?.toLowerCase() || "";
+    if (isStandaloneStaticAsset(pathname) && assetResponse.status === 200 && assetContentType.startsWith("text/html")) {
+      return c.json(
+        { error: "Not found" },
+        404,
+        {
+          "Cache-Control": "no-store",
+          "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+          "Referrer-Policy": "no-referrer",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "DENY"
+        }
+      );
+    }
+    return assetResponse;
   }
 
   return c.json(

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -167,7 +167,11 @@ app.notFound(async (c) => {
   if (!isWorkerRoute && c.env.ASSETS) {
     const assetResponse = await c.env.ASSETS.fetch(assetRequest(c));
     const assetContentType = assetResponse.headers.get("content-type")?.toLowerCase() || "";
-    if (isStandaloneStaticAsset(pathname) && assetResponse.status === 200 && assetContentType.startsWith("text/html")) {
+    if (
+      isStandaloneStaticAsset(pathname)
+      && (assetResponse.status === 200 || assetResponse.status === 304)
+      && assetContentType.startsWith("text/html")
+    ) {
       return c.json(
         { error: "Not found" },
         404,


### PR DESCRIPTION
Prevents missing JS/CSS/image paths from falling through to the SPA HTML shell, including the real stale-index-ETag 304 case that can make browsers reuse HTML as JavaScript during a rollout. Valid hashed assets keep their 200/304 content types and cache headers; extensionless SPA, preview, published, and chat routes are unchanged.\n\nIndependent review accepted exact head 9096567248a37837f0f69ccea9dab6ec67d554d3 after real local Worker conditional requests and the full 753-app/209-frontend gate.