### PR TITLE
Make Site Studio preview refreshes authoritative

### DIFF
--- a/packages/frontend/src/lib/components/Preview.svelte
+++ b/packages/frontend/src/lib/components/Preview.svelte
@@ -1,74 +1,180 @@
 <script lang="ts">
+    import { onDestroy } from 'svelte';
     import { resolvePath } from '$lib/utils/paths';
     import { Skeleton } from '$lib/components/ui/skeleton';
     import { fade } from 'svelte/transition';
 
     let { projectId, onRefresh }: { projectId: string; onRefresh?: () => void } = $props();
 
+    type FrameSlot = 1 | 2;
+
     let iframe1 = $state<HTMLIFrameElement | null>(null);
     let iframe2 = $state<HTMLIFrameElement | null>(null);
     let showIframe1 = $state(true);
     let previewUrl = $derived(resolvePath(`/preview/${projectId}/index.html`));
-    let refreshKey = $state(0);
+    let initialPreviewSource = $derived(`${previewUrl}?v=0`);
+
+    // Every load gets a monotonically increasing generation. A hidden frame is
+    // never allowed to become visible just because an older request eventually
+    // fired `load` after a faster refresh.
+    let refreshGeneration = 0;
+    let expectedSource1: string | null = null;
+    let expectedSource2: string | null = null;
+    let sourceGeneration1 = 0;
+    let sourceGeneration2 = 0;
+    let disposed = false;
+    let loadRequestFrame: number | null = null;
+    let paintFrameOne: number | null = null;
+    let paintFrameTwo: number | null = null;
 
     // Loading state tracking
     let isLoading = $state(true); // Start as loading for initial load
-    let hasLoadedOnce = $state(false);
     let activeLoadingIframe = $state<1 | 2 | null>(1); // Track which iframe is actively loading (1 for initial load)
 
-    // Dual iframe swap technique to prevent white flash
+    function getIframe(slot: FrameSlot): HTMLIFrameElement | null {
+        return slot === 1 ? iframe1 : iframe2;
+    }
+
+    function getExpectedSource(slot: FrameSlot): string | null {
+        return slot === 1 ? expectedSource1 ?? initialPreviewSource : expectedSource2;
+    }
+
+    function getSourceGeneration(slot: FrameSlot): number {
+        return slot === 1 ? sourceGeneration1 : sourceGeneration2;
+    }
+
+    function setExpectedSource(slot: FrameSlot, source: string | null, generation: number): void {
+        if (slot === 1) {
+            expectedSource1 = source;
+            sourceGeneration1 = generation;
+        } else {
+            expectedSource2 = source;
+            sourceGeneration2 = generation;
+        }
+    }
+
+    function normalizeSource(source: string): string {
+        return new URL(source, globalThis.document.baseURI).href;
+    }
+
+    function cancelPaintCommit(): void {
+        if (paintFrameOne !== null) {
+            cancelAnimationFrame(paintFrameOne);
+            paintFrameOne = null;
+        }
+        if (paintFrameTwo !== null) {
+            cancelAnimationFrame(paintFrameTwo);
+            paintFrameTwo = null;
+        }
+    }
+
+    function cancelPendingLoad(): void {
+        if (loadRequestFrame !== null) {
+            cancelAnimationFrame(loadRequestFrame);
+            loadRequestFrame = null;
+        }
+    }
+
+    function stopFrame(slot: FrameSlot): void {
+        const frame = getIframe(slot);
+        // Clear the expected source before blanking the frame. The resulting
+        // about:blank load must never be mistaken for the preview generation.
+        setExpectedSource(slot, null, -1);
+        if (frame) frame.src = 'about:blank';
+    }
+
+    function schedulePaintCommit(slot: FrameSlot, generation: number, previousSlot: FrameSlot): void {
+        cancelPaintCommit();
+
+        paintFrameOne = requestAnimationFrame(() => {
+            paintFrameOne = null;
+            paintFrameTwo = requestAnimationFrame(() => {
+                paintFrameTwo = null;
+                if (
+                    disposed ||
+                    generation !== refreshGeneration ||
+                    activeLoadingIframe !== slot
+                ) {
+                    return;
+                }
+
+                // The new frame has had two paint opportunities. Stop the old
+                // document only now, after the visible swap, so its
+                // scripts/timers/network cannot outlive the active page.
+                stopFrame(previousSlot);
+                isLoading = false;
+                activeLoadingIframe = null;
+            });
+        });
+    }
+
+    // Dual iframe swap technique to prevent white flash. A refresh first
+    // blanks the hidden frame to cancel any older request, then schedules the
+    // new source on the next frame. This gives each source a clear generation
+    // boundary even when refresh is clicked repeatedly.
     export function refresh() {
         isLoading = true; // Show loading skeleton
-        refreshKey++;
-        const targetIframe = showIframe1 ? iframe2 : iframe1;
-        activeLoadingIframe = showIframe1 ? 2 : 1; // Track which iframe we're loading into
+        const generation = ++refreshGeneration;
+        const targetSlot: FrameSlot = showIframe1 ? 2 : 1;
+        const targetIframe = getIframe(targetSlot);
+        activeLoadingIframe = targetSlot; // Track which iframe we're loading into
 
-        if (targetIframe) {
-            // Load new content in hidden iframe
-            targetIframe.src = `${previewUrl}?v=${refreshKey}`;
-        }
+        cancelPendingLoad();
+        cancelPaintCommit();
+        stopFrame(targetSlot);
+
+        loadRequestFrame = requestAnimationFrame(() => {
+            loadRequestFrame = null;
+            if (disposed || generation !== refreshGeneration || !targetIframe) return;
+
+            const source = `${previewUrl}?v=${generation}`;
+            setExpectedSource(targetSlot, source, generation);
+            targetIframe.src = source;
+        });
 
         if (onRefresh) {
             onRefresh();
         }
     }
 
-    function handleIframeLoad(isIframe1: boolean) {
-        const iframeNum = isIframe1 ? 1 : 2;
+    function handleIframeLoad(slot: FrameSlot, event: Event): void {
+        const frame = event.currentTarget;
+        if (!(frame instanceof HTMLIFrameElement)) return;
 
-        // Ignore load events from iframes we're not actively loading
-        // This prevents about:blank in iframe2 from triggering premature hiding
-        if (activeLoadingIframe !== null && activeLoadingIframe !== iframeNum) {
+        const expectedSource = getExpectedSource(slot);
+        // Ignore about:blank and stale loads. Comparing the actual frame source
+        // protects the visible swap from an old response after rapid refreshes.
+        if (
+            activeLoadingIframe !== slot ||
+            expectedSource === null ||
+            getSourceGeneration(slot) !== refreshGeneration ||
+            normalizeSource(frame.getAttribute('src') ?? '') !== normalizeSource(expectedSource)
+        ) {
             return;
         }
 
-        // When hidden iframe loads, swap to show it
-        if ((isIframe1 && !showIframe1) || (!isIframe1 && showIframe1)) {
-            showIframe1 = !showIframe1;
-
-            // Double RAF ensures browser has painted the iframe content
-            // Then wait additional time for fonts and initial render
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    setTimeout(() => {
-                        isLoading = false;
-                        hasLoadedOnce = true;
-                        activeLoadingIframe = null; // Clear active loading state
-                    }, 200); // Increased from 50ms to 200ms
-                });
-            });
-        } else if (hasLoadedOnce) {
-            // Only hide loading on subsequent loads (not first mount)
+        const visibleSlot: FrameSlot = showIframe1 ? 1 : 2;
+        if (slot === visibleSlot) {
+            // Initial load: there is no old preview to retire. The frame is
+            // already visible and its source is the expected generation.
             isLoading = false;
             activeLoadingIframe = null;
-        } else {
-            // First load completed
-            isLoading = false;
-            hasLoadedOnce = true;
-            activeLoadingIframe = null;
+            return;
         }
 
+        const previousSlot = visibleSlot;
+        showIframe1 = slot === 1;
+        schedulePaintCommit(slot, refreshGeneration, previousSlot);
     }
+
+    onDestroy(() => {
+        disposed = true;
+        cancelPendingLoad();
+        cancelPaintCommit();
+        activeLoadingIframe = null;
+        stopFrame(1);
+        stopFrame(2);
+    });
 </script>
 
 <div class="preview">
@@ -87,22 +193,22 @@
 		containment explicit — the preview still renders, but the parent can no
 		longer read `contentDocument` (it is cross-origin once opaque).
 	-->
-	<iframe
-		bind:this={iframe1}
-		src="{previewUrl}?v=0"
-		title="Site Preview"
-		sandbox="allow-scripts"
-		style="display: {showIframe1 ? 'block' : 'none'}; width: 100%; height: 100%; border: none;"
-		onload={() => handleIframeLoad(true)}
-	></iframe>
+		<iframe
+			bind:this={iframe1}
+			src={initialPreviewSource}
+			title="Site Preview"
+			sandbox="allow-scripts"
+			style="display: {showIframe1 ? 'block' : 'none'}; width: 100%; height: 100%; border: none;"
+			onload={(event) => handleIframeLoad(1, event)}
+		></iframe>
 	<iframe
 		bind:this={iframe2}
 		src="about:blank"
-		title="Site Preview"
-		sandbox="allow-scripts"
-		style="display: {showIframe1 ? 'none' : 'block'}; width: 100%; height: 100%; border: none;"
-		onload={() => handleIframeLoad(false)}
-	></iframe>
+			title="Site Preview"
+			sandbox="allow-scripts"
+			style="display: {showIframe1 ? 'none' : 'block'}; width: 100%; height: 100%; border: none;"
+			onload={(event) => handleIframeLoad(2, event)}
+		></iframe>
 </div>
 
 <style>

--- a/packages/frontend/src/lib/components/Preview.test.ts
+++ b/packages/frontend/src/lib/components/Preview.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+import Preview from './Preview.svelte';
+
+type RafCallback = (timestamp: number) => void;
+
+describe('Preview lifecycle', () => {
+	let callbacks: Map<number, RafCallback>;
+	let nextCallbackId: number;
+	let originalAnimate: typeof Element.prototype.animate;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		originalAnimate = Element.prototype.animate;
+		Object.defineProperty(Element.prototype, 'animate', {
+			configurable: true,
+			value: vi.fn(() => ({ cancel: vi.fn(), finished: Promise.resolve() }))
+		});
+		callbacks = new Map();
+		nextCallbackId = 0;
+		vi.stubGlobal('requestAnimationFrame', (callback: RafCallback) => {
+			const id = ++nextCallbackId;
+			callbacks.set(id, callback);
+			return id;
+		});
+		vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+			callbacks.delete(id);
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(Element.prototype, 'animate', {
+			configurable: true,
+			value: originalAnimate
+		});
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	function flushAnimationFrame(): void {
+		const pending = [...callbacks.values()];
+		callbacks.clear();
+		for (const callback of pending) callback(0);
+		flushSync();
+	}
+
+	function previewFrameSources(container: HTMLElement): HTMLIFrameElement[] {
+		return [...container.querySelectorAll<HTMLIFrameElement>('iframe')];
+	}
+
+	it('does not let an older delayed frame load replace a newer refresh', async () => {
+		const rendered = render(Preview, { props: { projectId: 'project-a' } });
+		const [activeFrame, loadingFrame] = previewFrameSources(rendered.container);
+
+		await fireEvent.load(activeFrame);
+		flushSync();
+		rendered.component.refresh();
+		flushAnimationFrame();
+		expect(loadingFrame.src).toContain('?v=1');
+
+		// Refresh again before the first response is accepted. The hidden frame is
+		// blanked and receives a strictly newer source.
+		rendered.component.refresh();
+		flushAnimationFrame();
+		expect(loadingFrame.src).toContain('?v=2');
+
+		// Simulate a delayed v=1 response. The expected URL is v=2, so the old
+		// frame cannot be shown.
+		loadingFrame.src = '/preview/project-a/index.html?v=1';
+		await fireEvent.load(loadingFrame);
+		flushSync();
+		expect(activeFrame.style.display).toBe('block');
+		expect(loadingFrame.style.display).toBe('none');
+
+		loadingFrame.src = '/preview/project-a/index.html?v=2';
+		await fireEvent.load(loadingFrame);
+		flushSync();
+		expect(loadingFrame.style.display).toBe('block');
+		expect(activeFrame.src).toContain('?v=0');
+
+		// The old document is retired only after the new frame gets paint time.
+		flushAnimationFrame();
+		expect(activeFrame.src).toContain('?v=0');
+		flushAnimationFrame();
+		expect(activeFrame.src).toBe('about:blank');
+	});
+
+	it('cancels a pending refresh when the preview is unmounted', () => {
+		const rendered = render(Preview, { props: { projectId: 'project-a' } });
+		const [, loadingFrame] = previewFrameSources(rendered.container);
+
+		rendered.component.refresh();
+		rendered.unmount();
+		flushAnimationFrame();
+
+		expect(loadingFrame.src).toBe('about:blank');
+		expect(callbacks.size).toBe(0);
+	});
+});

--- a/packages/frontend/src/lib/components/ProjectDashboard.svelte
+++ b/packages/frontend/src/lib/components/ProjectDashboard.svelte
@@ -13,6 +13,7 @@
 	import HandleClaimDialog from './HandleClaimDialog.svelte';
 	import { hasCompletedOnboarding, createDashboardTour } from '$lib/utils/onboarding';
 	import { toast } from '$lib/toast.svelte';
+	import type { Driver } from 'driver.js';
 	import 'driver.js/dist/driver.css';
 	import '$lib/styles/onboarding-tour.css';
 
@@ -31,14 +32,21 @@
 	// project whose publish triggered it, so we can retry after claiming.
 	let showHandleDialog = $state(false);
 	let pendingPublishProject = $state<Project | null>(null);
+	let dashboardTourTimer: ReturnType<typeof setTimeout> | null = null;
+	let dashboardTour: Driver | null = null;
+	let dashboardMounted = false;
 
 	onMount(() => {
+		dashboardMounted = true;
 		void loadProjects().then(() => {
 			// Show onboarding tour for first-time users with no projects
-			if (!loading && projects.length === 0 && !hasCompletedOnboarding()) {
-				setTimeout(() => {
-					const tour = createDashboardTour();
-					tour.drive();
+			if (dashboardMounted && !loading && projects.length === 0 && !hasCompletedOnboarding()) {
+				dashboardTourTimer = setTimeout(() => {
+					dashboardTourTimer = null;
+					if (!dashboardMounted) return;
+					dashboardTour?.destroy();
+					dashboardTour = createDashboardTour();
+					dashboardTour.drive();
 				}, 500);
 			}
 		});
@@ -47,19 +55,28 @@
 		const handleKeyPress = (e: KeyboardEvent) => {
 			if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'H') {
 				e.preventDefault();
-				const tour = createDashboardTour();
-				tour.drive();
+				dashboardTour?.destroy();
+				dashboardTour = createDashboardTour();
+				dashboardTour.drive();
 			}
 		};
 		window.addEventListener('keydown', handleKeyPress);
 
 		// Expose function to force tutorial from console
 		window.showTutorial = () => {
-			const tour = createDashboardTour();
-			tour.drive();
+			dashboardTour?.destroy();
+			dashboardTour = createDashboardTour();
+			dashboardTour.drive();
 		};
 
 		return () => {
+			dashboardMounted = false;
+			if (dashboardTourTimer !== null) {
+				clearTimeout(dashboardTourTimer);
+				dashboardTourTimer = null;
+			}
+			dashboardTour?.destroy();
+			dashboardTour = null;
 			window.removeEventListener('keydown', handleKeyPress);
 			delete window.showTutorial;
 		};

--- a/packages/frontend/src/routes/editor/[projectId]/+page.svelte
+++ b/packages/frontend/src/routes/editor/[projectId]/+page.svelte
@@ -26,6 +26,7 @@
 	import { toast } from '$lib/toast.svelte';
 	import { Pane } from 'paneforge';
 	import { z } from 'zod';
+	import type { Driver } from 'driver.js';
 
 	type OnboardingModule = typeof import('$lib/utils/onboarding');
 
@@ -84,6 +85,10 @@
 	let previousProjectId = $state<string | null>(null);
 	let stableProjectId = $state<string | null>(null);
 	let onboardingModulePromise: Promise<OnboardingModule> | null = null;
+	let editorTourTimer: ReturnType<typeof setTimeout> | null = null;
+	let editorTour: Driver | null = null;
+	let editorTourGeneration = 0;
+	let editorPageMounted = false;
 
 	// Get projectId from URL params
 	let projectId = $derived($page.params.projectId ?? '');
@@ -151,15 +156,20 @@
 	}
 
 	async function maybeStartEditorTour(force = false) {
+		const generation = editorTourGeneration;
 		const onboarding = await loadOnboardingModule();
+		if (!editorPageMounted || generation !== editorTourGeneration) return;
 		if (!force && onboarding.hasCompletedOnboarding()) {
 			return;
 		}
 
-		onboarding.createEditorTour().drive();
+		editorTour?.destroy();
+		editorTour = onboarding.createEditorTour();
+		editorTour.drive();
 	}
 
 	onMount(() => {
+		editorPageMounted = true;
 		void getCsrfToken()
 			.then((token) => {
 				draftSecret = token;
@@ -174,7 +184,8 @@
 		}
 
 		// Show onboarding tour for first-time users after the editor layout settles.
-		setTimeout(() => {
+		editorTourTimer = setTimeout(() => {
+			editorTourTimer = null;
 			void maybeStartEditorTour();
 		}, 1000);
 
@@ -206,6 +217,14 @@
 		};
 
 		return () => {
+			editorPageMounted = false;
+			editorTourGeneration += 1;
+			if (editorTourTimer !== null) {
+				clearTimeout(editorTourTimer);
+				editorTourTimer = null;
+			}
+			editorTour?.destroy();
+			editorTour = null;
 			window.removeEventListener('keydown', handleKeyPress);
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 			delete window.showEditorTutorial;
@@ -958,6 +977,7 @@
 									class="publish-button published"
 									onclick={() => openPublishedSite(currentProject!.publishedUrl!)}
 									title="View published site"
+									aria-label={`View published site for ${currentProject.name}`}
 								>
 									<Check size={14} class="publish-icon" />
 									<span>Published</span>
@@ -968,6 +988,9 @@
 									class="publish-button"
 									onclick={handlePublishProject}
 									disabled={publishingProjectId === currentProject.id}
+									aria-label={publishingProjectId === currentProject.id
+										? `Publishing ${currentProject.name}`
+										: `Publish ${currentProject.name}`}
 								>
 									{#if publishingProjectId === currentProject.id}
 										<Loader2 size={14} class="publish-icon spinning" />
@@ -1044,7 +1067,9 @@
 		<!-- Center: Preview (always visible) -->
 		<Resizable.Pane defaultSize={70} minSize={30}>
 			<main class="preview-area">
-				<Preview bind:this={previewComponent} {projectId} />
+				{#key projectId}
+					<Preview bind:this={previewComponent} {projectId} />
+				{/key}
 			</main>
 		</Resizable.Pane>
 	</Resizable.PaneGroup>


### PR DESCRIPTION
Prevent delayed preview iframes from replacing newer generations, retire superseded iframe activity after paint, and clean up preview/tour state across navigation and unmount. Mobile publish controls now keep explicit accessible names.

Independent real-browser acceptance proves applied CSS, executed JavaScript, delayed refresh ordering, old timer shutdown, project switching, unmount cleanup, and unchanged iframe sandbox. Full repository checks pass.

Reviewed exact head: `be6772a7c2fa9fdb6490798859c5460f64fd5ac3`.