### PR TITLE
Fix completion after server tool turns

### DIFF
--- a/packages/app/src/agents/site-builder-concurrency.test.ts
+++ b/packages/app/src/agents/site-builder-concurrency.test.ts
@@ -647,6 +647,75 @@ describe("Site Builder connection logging concurrency", () => {
     }
   });
 
+  it("keeps the owner through a server-tool result and persisted turn commit", () => {
+    const agentParent = siteBuilderTestParent();
+    const sends = new Map<string, (message: string) => void>();
+    const baseBroadcast = vi.fn((message: string, without?: string[]) => {
+      for (const [connectionId, send] of sends) {
+        if (!without?.includes(connectionId)) send(message);
+      }
+    });
+    Object.defineProperty(agentParent, "broadcast", {
+      configurable: true,
+      value: baseBroadcast,
+    });
+    try {
+      const agent = createTestAgent();
+      const connectionA = chatConnection("connection-a", "subject-a");
+      const connectionB = chatConnection("connection-b", "subject-b");
+      sends.set(connectionA.id, connectionA.send);
+      sends.set(connectionB.id, connectionB.send);
+      Object.assign(agent, {
+        getConnections: () => [connectionA, connectionB],
+        getConnection: (id: string) => [connectionA, connectionB].find((connection) => connection.id === id),
+        chatRequestConnections: new Map(),
+        detachedChatRequestConnections: new Map(),
+        chatToolRequestIds: new Map(),
+        buildActionsAwaitingPersistence: new Map(),
+        messages: [{ id: "assistant-a", role: "assistant", parts: [] }],
+      });
+
+      const hooks = siteBuilderTestHooks(agent);
+      hooks.rememberChatRequestConnection("request-a", connectionA);
+      agent.broadcast(JSON.stringify({
+        type: "cf_agent_use_chat_response",
+        id: "request-a",
+        body: JSON.stringify({ type: "tool-input-start", toolCallId: "tool-a" }),
+      }));
+      agent.broadcast(JSON.stringify({
+        type: "cf_agent_use_chat_response",
+        id: "request-a",
+        body: JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "tool-a",
+          output: { ok: true },
+        }),
+      }));
+
+      // A server tool result is not the end of the model turn. The final
+      // response and the post-persistence commit must still reach its owner.
+      expect(hooks.chatRequestConnections.has("request-a")).toBe(true);
+      agent.broadcast(JSON.stringify({
+        type: "cf_agent_use_chat_response",
+        id: "request-a",
+        body: JSON.stringify({ type: "text-delta", id: "text-a", delta: "finished answer" }),
+      }));
+      hooks.onChatResponse({
+        requestId: "request-a",
+        status: "completed",
+        continuation: false,
+        message: { id: "assistant-a", role: "assistant", parts: [] },
+      });
+
+      expect(connectionA.send).toHaveBeenCalledWith(expect.stringContaining("finished answer"));
+      expect(connectionA.send).toHaveBeenCalledWith(expect.stringContaining(SITE_STUDIO_CHAT_COMMITTED_TYPE));
+      expect(connectionB.send).not.toHaveBeenCalled();
+      expect(hooks.chatRequestConnections.has("request-a")).toBe(false);
+    } finally {
+      delete agentParent.broadcast;
+    }
+  });
+
   it("transfers a detached stream to the same-subject reconnect and rejects id reuse", () => {
     const agentParent = siteBuilderTestParent();
     const agent = createTestAgent();

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -1874,6 +1874,16 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
 
   private releaseSettledChatToolOwnership(frame: SiteStudioChatFrame): void {
     this.ensureChatBoundaryState();
+    // A server tool result is one step in the same model turn. Remove only the
+    // tool-call lookup from the response frame, leaving the request connection
+    // until onChatResponse sends the persisted commit and retires the turn.
+    // Otherwise the final model text and commit have no safe owner.
+    if (frame.type === CF_AGENT_USE_CHAT_RESPONSE_TYPE) {
+      for (const toolCallId of settledToolCallIdsFromFrame(frame)) {
+        this.chatToolRequestIds.delete(toolCallId);
+      }
+      return;
+    }
     for (const toolCallId of settledToolCallIdsFromFrame(frame)) {
       const requestId = this.chatToolRequestIds.get(toolCallId);
       if (!requestId) continue;

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -1293,6 +1293,8 @@ import {
 			case AgentMessageType.SITE_STUDIO_CHAT_COMMITTED: {
 				const committed = parseSiteStudioChatCommittedFrame(data);
 				if (!committed) break;
+				const isCurrentRequest = committed.requestId === currentRequestId;
+				const isActiveTransportRequest = activeRequestIds.has(committed.requestId);
 				const matchingReconciliation = pendingHistoryReconciliations.find(
 					(entry) =>
 						entry.requestId === committed.requestId ||
@@ -1302,8 +1304,15 @@ import {
 				const commitContainsCurrentAssistant = currentAssistantId
 					? committed.messages.some((message) => message.id === currentAssistantId)
 					: false;
-				if (isLoading && activeRequestIds.has(committed.requestId)) {
-					void chat.stop();
+				// The persisted commit is the authoritative terminal for this connection.
+				// The maintained transport removes its request id synchronously when it
+				// sees done:true, while the SDK may still be consuming the final tool
+				// message. Correlate against the component's current request as well; a
+				// commit that arrives in that gap must settle the UI immediately rather
+				// than waiting for an SDK finish callback that the tool stream may never
+				// reach.
+				if (isLoading && (isCurrentRequest || isActiveTransportRequest)) {
+					if (isActiveTransportRequest) void chat.stop();
 					chatTransport.handleServerTurnCompleted(committed.requestId);
 					resetRequestState();
 					setChatMessages(committed.messages);


### PR DESCRIPTION
## Outcome

Keeps the owning connection associated through the final response and persisted commit after a server-side tool result, so the chat finishes instead of remaining stuck on Responding. The frontend correlates the final commit with the active request even after the transport completes.

## Verification

- 928 tests across app and frontend
- lint, typecheck, builds, and Wrangler production dry run
- real local Worker/Durable Object/browser server-tool flow through final text, persisted commit, and reload
- independently reviewed and accepted

Production browser acceptance remains required after deployment.