### PR TITLE
Remove the stuck preview overlay

### DIFF
--- a/packages/frontend/src/lib/components/Preview.svelte
+++ b/packages/frontend/src/lib/components/Preview.svelte
@@ -1,186 +1,30 @@
 <script lang="ts">
-    import { onDestroy } from 'svelte';
     import { resolvePath } from '$lib/utils/paths';
     import { Skeleton } from '$lib/components/ui/skeleton';
-    import { fade } from 'svelte/transition';
 
     let { projectId, onRefresh }: { projectId: string; onRefresh?: () => void } = $props();
 
-    type FrameSlot = 1 | 2;
-
-    let iframe1 = $state<HTMLIFrameElement | null>(null);
-    let iframe2 = $state<HTMLIFrameElement | null>(null);
-    let showIframe1 = $state(true);
     let previewUrl = $derived(resolvePath(`/preview/${projectId}/index.html`));
-    let initialPreviewSource = $derived(`${previewUrl}?v=0`);
+    let previewVersion = $state(0);
+    let previewSource = $derived(`${previewUrl}?v=${previewVersion}`);
 
-    // Every load gets a monotonically increasing generation. A hidden frame is
-    // never allowed to become visible just because an older request eventually
-    // fired `load` after a faster refresh.
-    let refreshGeneration = 0;
-    let expectedSource1: string | null = null;
-    let expectedSource2: string | null = null;
-    let sourceGeneration1 = 0;
-    let sourceGeneration2 = 0;
-    let disposed = false;
-    let loadRequestFrame: number | null = null;
-    let paintFrameOne: number | null = null;
-    let paintFrameTwo: number | null = null;
+    let isLoading = $state(true);
 
-    // Loading state tracking
-    let isLoading = $state(true); // Start as loading for initial load
-    let activeLoadingIframe = $state<1 | 2 | null>(1); // Track which iframe is actively loading (1 for initial load)
-
-    function getIframe(slot: FrameSlot): HTMLIFrameElement | null {
-        return slot === 1 ? iframe1 : iframe2;
-    }
-
-    function getExpectedSource(slot: FrameSlot): string | null {
-        return slot === 1 ? expectedSource1 ?? initialPreviewSource : expectedSource2;
-    }
-
-    function getSourceGeneration(slot: FrameSlot): number {
-        return slot === 1 ? sourceGeneration1 : sourceGeneration2;
-    }
-
-    function setExpectedSource(slot: FrameSlot, source: string | null, generation: number): void {
-        if (slot === 1) {
-            expectedSource1 = source;
-            sourceGeneration1 = generation;
-        } else {
-            expectedSource2 = source;
-            sourceGeneration2 = generation;
-        }
-    }
-
-    function normalizeSource(source: string): string {
-        return new URL(source, globalThis.document.baseURI).href;
-    }
-
-    function cancelPaintCommit(): void {
-        if (paintFrameOne !== null) {
-            cancelAnimationFrame(paintFrameOne);
-            paintFrameOne = null;
-        }
-        if (paintFrameTwo !== null) {
-            cancelAnimationFrame(paintFrameTwo);
-            paintFrameTwo = null;
-        }
-    }
-
-    function cancelPendingLoad(): void {
-        if (loadRequestFrame !== null) {
-            cancelAnimationFrame(loadRequestFrame);
-            loadRequestFrame = null;
-        }
-    }
-
-    function stopFrame(slot: FrameSlot): void {
-        const frame = getIframe(slot);
-        // Clear the expected source before blanking the frame. The resulting
-        // about:blank load must never be mistaken for the preview generation.
-        setExpectedSource(slot, null, -1);
-        if (frame) frame.src = 'about:blank';
-    }
-
-    function schedulePaintCommit(slot: FrameSlot, generation: number, previousSlot: FrameSlot): void {
-        cancelPaintCommit();
-
-        paintFrameOne = requestAnimationFrame(() => {
-            paintFrameOne = null;
-            paintFrameTwo = requestAnimationFrame(() => {
-                paintFrameTwo = null;
-                if (
-                    disposed ||
-                    generation !== refreshGeneration ||
-                    activeLoadingIframe !== slot
-                ) {
-                    return;
-                }
-
-                // The new frame has had two paint opportunities. Stop the old
-                // document only now, after the visible swap, so its
-                // scripts/timers/network cannot outlive the active page.
-                stopFrame(previousSlot);
-                isLoading = false;
-                activeLoadingIframe = null;
-            });
-        });
-    }
-
-    // Dual iframe swap technique to prevent white flash. A refresh first
-    // blanks the hidden frame to cancel any older request, then schedules the
-    // new source on the next frame. This gives each source a clear generation
-    // boundary even when refresh is clicked repeatedly.
     export function refresh() {
-        isLoading = true; // Show loading skeleton
-        const generation = ++refreshGeneration;
-        const targetSlot: FrameSlot = showIframe1 ? 2 : 1;
-        const targetIframe = getIframe(targetSlot);
-        activeLoadingIframe = targetSlot; // Track which iframe we're loading into
-
-        cancelPendingLoad();
-        cancelPaintCommit();
-        stopFrame(targetSlot);
-
-        loadRequestFrame = requestAnimationFrame(() => {
-            loadRequestFrame = null;
-            if (disposed || generation !== refreshGeneration || !targetIframe) return;
-
-            const source = `${previewUrl}?v=${generation}`;
-            setExpectedSource(targetSlot, source, generation);
-            targetIframe.src = source;
-        });
-
-        if (onRefresh) {
-            onRefresh();
-        }
+        isLoading = true;
+        previewVersion += 1;
+        onRefresh?.();
     }
 
-    function handleIframeLoad(slot: FrameSlot, event: Event): void {
-        const frame = event.currentTarget;
-        if (!(frame instanceof HTMLIFrameElement)) return;
-
-        const expectedSource = getExpectedSource(slot);
-        // Ignore about:blank and stale loads. Comparing the actual frame source
-        // protects the visible swap from an old response after rapid refreshes.
-        if (
-            activeLoadingIframe !== slot ||
-            expectedSource === null ||
-            getSourceGeneration(slot) !== refreshGeneration ||
-            normalizeSource(frame.getAttribute('src') ?? '') !== normalizeSource(expectedSource)
-        ) {
-            return;
-        }
-
-        const visibleSlot: FrameSlot = showIframe1 ? 1 : 2;
-        if (slot === visibleSlot) {
-            // Initial load: there is no old preview to retire. The frame is
-            // already visible and its source is the expected generation.
-            isLoading = false;
-            activeLoadingIframe = null;
-            return;
-        }
-
-        const previousSlot = visibleSlot;
-        showIframe1 = slot === 1;
-        schedulePaintCommit(slot, refreshGeneration, previousSlot);
+    function handleIframeLoad(): void {
+        isLoading = false;
     }
-
-    onDestroy(() => {
-        disposed = true;
-        cancelPendingLoad();
-        cancelPaintCommit();
-        activeLoadingIframe = null;
-        stopFrame(1);
-        stopFrame(2);
-    });
 </script>
 
 <div class="preview">
 	<!-- Loading skeleton overlay -->
 	{#if isLoading}
-		<div class="loading-overlay" transition:fade={{ duration: 150 }}>
+		<div class="loading-overlay">
 			<Skeleton class="loading-skeleton" />
 		</div>
 	{/if}
@@ -193,22 +37,13 @@
 		containment explicit — the preview still renders, but the parent can no
 		longer read `contentDocument` (it is cross-origin once opaque).
 	-->
-		<iframe
-			bind:this={iframe1}
-			src={initialPreviewSource}
-			title="Site Preview"
-			sandbox="allow-scripts"
-			style="display: {showIframe1 ? 'block' : 'none'}; width: 100%; height: 100%; border: none;"
-			onload={(event) => handleIframeLoad(1, event)}
-		></iframe>
 	<iframe
-		bind:this={iframe2}
-		src="about:blank"
-			title="Site Preview"
-			sandbox="allow-scripts"
-			style="display: {showIframe1 ? 'none' : 'block'}; width: 100%; height: 100%; border: none;"
-			onload={(event) => handleIframeLoad(2, event)}
-		></iframe>
+		src={previewSource}
+		title="Site Preview"
+		sandbox="allow-scripts"
+		style="width: 100%; height: 100%; border: none;"
+		onload={handleIframeLoad}
+	></iframe>
 </div>
 
 <style>

--- a/packages/frontend/src/lib/components/Preview.test.ts
+++ b/packages/frontend/src/lib/components/Preview.test.ts
@@ -1,100 +1,39 @@
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { fireEvent, render } from '@testing-library/svelte';
 import Preview from './Preview.svelte';
 
-type RafCallback = (timestamp: number) => void;
-
 describe('Preview lifecycle', () => {
-	let callbacks: Map<number, RafCallback>;
-	let nextCallbackId: number;
-	let originalAnimate: typeof Element.prototype.animate;
-
-	beforeEach(() => {
-		vi.useFakeTimers();
-		originalAnimate = Element.prototype.animate;
-		Object.defineProperty(Element.prototype, 'animate', {
-			configurable: true,
-			value: vi.fn(() => ({ cancel: vi.fn(), finished: Promise.resolve() }))
-		});
-		callbacks = new Map();
-		nextCallbackId = 0;
-		vi.stubGlobal('requestAnimationFrame', (callback: RafCallback) => {
-			const id = ++nextCallbackId;
-			callbacks.set(id, callback);
-			return id;
-		});
-		vi.stubGlobal('cancelAnimationFrame', (id: number) => {
-			callbacks.delete(id);
-		});
-	});
-
-	afterEach(() => {
-		Object.defineProperty(Element.prototype, 'animate', {
-			configurable: true,
-			value: originalAnimate
-		});
-		vi.useRealTimers();
-		vi.unstubAllGlobals();
-	});
-
-	function flushAnimationFrame(): void {
-		const pending = [...callbacks.values()];
-		callbacks.clear();
-		for (const callback of pending) callback(0);
-		flushSync();
+	function previewFrame(container: HTMLElement): HTMLIFrameElement {
+		const frame = container.querySelector<HTMLIFrameElement>('iframe');
+		if (!frame) throw new Error('Preview iframe was not rendered');
+		return frame;
 	}
 
-	function previewFrameSources(container: HTMLElement): HTMLIFrameElement[] {
-		return [...container.querySelectorAll<HTMLIFrameElement>('iframe')];
-	}
+	it('owns the loading state with the active iframe load', async () => {
+		const onRefresh = vi.fn();
+		const rendered = render(Preview, { props: { projectId: 'project-a', onRefresh } });
+		const frame = previewFrame(rendered.container);
+		expect(rendered.container.querySelectorAll('iframe')).toHaveLength(1);
 
-	it('does not let an older delayed frame load replace a newer refresh', async () => {
-		const rendered = render(Preview, { props: { projectId: 'project-a' } });
-		const [activeFrame, loadingFrame] = previewFrameSources(rendered.container);
-
-		await fireEvent.load(activeFrame);
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
+		await fireEvent.load(frame);
 		flushSync();
-		rendered.component.refresh();
-		flushAnimationFrame();
-		expect(loadingFrame.src).toContain('?v=1');
-
-		// Refresh again before the first response is accepted. The hidden frame is
-		// blanked and receives a strictly newer source.
-		rendered.component.refresh();
-		flushAnimationFrame();
-		expect(loadingFrame.src).toContain('?v=2');
-
-		// Simulate a delayed v=1 response. The expected URL is v=2, so the old
-		// frame cannot be shown.
-		loadingFrame.src = '/preview/project-a/index.html?v=1';
-		await fireEvent.load(loadingFrame);
-		flushSync();
-		expect(activeFrame.style.display).toBe('block');
-		expect(loadingFrame.style.display).toBe('none');
-
-		loadingFrame.src = '/preview/project-a/index.html?v=2';
-		await fireEvent.load(loadingFrame);
-		flushSync();
-		expect(loadingFrame.style.display).toBe('block');
-		expect(activeFrame.src).toContain('?v=0');
-
-		// The old document is retired only after the new frame gets paint time.
-		flushAnimationFrame();
-		expect(activeFrame.src).toContain('?v=0');
-		flushAnimationFrame();
-		expect(activeFrame.src).toBe('about:blank');
-	});
-
-	it('cancels a pending refresh when the preview is unmounted', () => {
-		const rendered = render(Preview, { props: { projectId: 'project-a' } });
-		const [, loadingFrame] = previewFrameSources(rendered.container);
+		expect(rendered.container.querySelector('.loading-overlay')).toBeNull();
 
 		rendered.component.refresh();
-		rendered.unmount();
-		flushAnimationFrame();
+		flushSync();
+		expect(frame.src).toContain('?v=1');
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
 
-		expect(loadingFrame.src).toBe('about:blank');
-		expect(callbacks.size).toBe(0);
+		// A second refresh supersedes the first without creating a second frame
+		// whose load event could strand the overlay over the usable preview.
+		rendered.component.refresh();
+		flushSync();
+		expect(frame.src).toContain('?v=2');
+		await fireEvent.load(frame);
+		flushSync();
+		expect(rendered.container.querySelector('.loading-overlay')).toBeNull();
+		expect(onRefresh).toHaveBeenCalledTimes(2);
 	});
 });


### PR DESCRIPTION
## Outcome

The preview now uses one iframe whose own load event owns its loading state. This removes the dual-frame/requestAnimationFrame state machine that could leave a newer preview loaded but hidden beneath a permanent skeleton.

## Direct evidence

- reproduced production with visible `v=13`, hidden ready `v=14`, and a stuck overlay
- real frontend-to-HTTP-preview browser run proved initial load, CSS/JavaScript execution, server update, delayed consecutive refreshes converging on the newest version, full reload, 404/500 documents, recovery, and clickability without a stale skeleton
- preview remains `sandbox="allow-scripts"` without `allow-same-origin`
- independent review accepted the exact head
- full check passed: 754 app tests, 173 frontend tests, lint, typecheck, Svelte check, and production build

No OpenWebUI changes.