### PR TITLE
Fix Site Studio dialog teardown warnings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/svelte": "5.4.2",
         "@testing-library/user-event": "14.6.1",
-        "bits-ui": "2.18.1",
+        "bits-ui": "2.18.2",
         "jsdom": "30.0.1",
         "paneforge": "1.0.2",
         "svelte": "5.56.4",
@@ -627,7 +627,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "bits-ui": ["bits-ui@2.18.1", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA=="],
+    "bits-ui": ["bits-ui@2.18.2", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-NMaVKZUF7JJpZWa3VSHF/prVvKBEPNHMZjOtUroGMDtNvn03MMRfWgLTIFeFwsCIQrL9xrmNhBRHNmdIaCEUbg=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/svelte": "5.4.2",
     "@testing-library/user-event": "14.6.1",
-    "bits-ui": "2.18.1",
+    "bits-ui": "2.18.2",
     "jsdom": "30.0.1",
     "paneforge": "1.0.2",
     "svelte": "5.56.4",

--- a/packages/frontend/src/lib/components/HandleClaimDialog.test.ts
+++ b/packages/frontend/src/lib/components/HandleClaimDialog.test.ts
@@ -12,10 +12,20 @@ interface DialogOverrides {
 	claimHandle?: typeof claimHandle;
 }
 
+declare global {
+	var bitsDismissableLayers: Map<unknown, unknown> | undefined;
+}
+
 function addressInput(): HTMLInputElement {
 	const input = screen.getByLabelText('Address');
 	if (!(input instanceof HTMLInputElement)) throw new Error('expected address input');
 	return input;
+}
+
+function dismissibleLayerCount(): number {
+	const layers = globalThis.bitsDismissableLayers;
+	if (!(layers instanceof Map)) throw new Error('expected the dialog layer registry');
+	return layers.size;
 }
 
 describe('HandleClaimDialog', () => {
@@ -27,7 +37,7 @@ describe('HandleClaimDialog', () => {
 	function open(overrides: DialogOverrides = {}) {
 		const onOpenChange = vi.fn();
 		const onClaimed = vi.fn();
-		render(HandleClaimDialog, {
+		const view = render(HandleClaimDialog, {
 			props: {
 				open: true,
 				onOpenChange,
@@ -37,8 +47,29 @@ describe('HandleClaimDialog', () => {
 				...overrides
 			}
 		});
-		return { onOpenChange, onClaimed };
+		return { onOpenChange, onClaimed, unmount: view.unmount };
 	}
+
+	it('fully tears down an immediately unmounted dialog', async () => {
+		vi.useFakeTimers();
+		try {
+			const { onOpenChange, unmount } = open();
+			unmount();
+
+			// Flush the dialog primitive's deferred listener setup and body-lock
+			// cleanup, then prove a later outside interaction cannot reach the
+			// destroyed dialog.
+			await vi.advanceTimersByTimeAsync(25);
+			expect(dismissibleLayerCount()).toBe(0);
+			document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+			await vi.advanceTimersByTimeAsync(11);
+
+			expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
+			expect(onOpenChange).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 
 	it('has an aria-live status region wired to the input', () => {
 		open();

--- a/packages/frontend/src/lib/components/ImageManagerDialog.test.ts
+++ b/packages/frontend/src/lib/components/ImageManagerDialog.test.ts
@@ -16,6 +16,10 @@ interface DialogOverrides {
 	uploadProjectImage?: typeof uploadProjectImage;
 }
 
+declare global {
+	var bitsDismissableLayers: Map<unknown, unknown> | undefined;
+}
+
 const imagesResult: ProjectImagesResult = {
 	images: [
 		{ path: 'images/one.png', size: 1024 },
@@ -29,7 +33,7 @@ const imagesResult: ProjectImagesResult = {
 function open(overrides: DialogOverrides = {}) {
 	const onOpenChange = vi.fn();
 	const onAskAssistant = vi.fn();
-	render(ImageManagerDialog, {
+	const view = render(ImageManagerDialog, {
 		props: {
 			open: true,
 			projectId: 'proj1',
@@ -40,13 +44,19 @@ function open(overrides: DialogOverrides = {}) {
 			...overrides
 		}
 	});
-	return { onOpenChange, onAskAssistant };
+	return { onOpenChange, onAskAssistant, unmount: view.unmount };
 }
 
 function labeledInput(label: RegExp): HTMLInputElement {
 	const input = screen.getByLabelText(label);
 	if (!(input instanceof HTMLInputElement)) throw new Error('expected input');
 	return input;
+}
+
+function dismissibleLayerCount(): number {
+	const layers = globalThis.bitsDismissableLayers;
+	if (!(layers instanceof Map)) throw new Error('expected the dialog layer registry');
+	return layers.size;
 }
 
 async function waitForImages() {
@@ -76,6 +86,27 @@ describe('ImageManagerDialog', () => {
 	beforeEach(() => {
 		mockFetch.mockReset();
 		mockFetch.mockResolvedValue(imagesResult);
+	});
+
+	it('fully tears down an immediately unmounted dialog', async () => {
+		vi.useFakeTimers();
+		try {
+			const { onOpenChange, unmount } = open();
+			unmount();
+
+			// Settle both the mocked image request and the dialog primitive's
+			// deferred teardown before exercising a later outside interaction.
+			await Promise.resolve();
+			await vi.advanceTimersByTimeAsync(25);
+			expect(dismissibleLayerCount()).toBe(0);
+			document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+			await vi.advanceTimersByTimeAsync(11);
+
+			expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
+			expect(onOpenChange).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('loads and lists the project images when opened', async () => {


### PR DESCRIPTION
## Summary

- upgrade `bits-ui` from 2.18.1 to 2.18.2 for the upstream DismissibleLayer teardown correction
- add deterministic immediate-unmount regressions for both affected dialogs
- prove stale global layers/listeners are gone after teardown

## Verification

- exact 2.18.1 baseline: both new tests fail and emit the upstream `derived_inert` warning flood
- exact 2.18.2 candidate: focused 24/24 with zero warnings
- `bun run check`: app 754/754, frontend 175/175, Svelte diagnostics 0 errors/0 warnings, lint and production builds
- independent review accepted exact commit `26cc9d6e83716ebb4c479a8c52b7b711bd0f9127` against upstream issue #2080/fix #2087

No component, UI, route, model, storage, or network behavior changed.
