### PR TITLE
Polish user-facing error and dialog copy

### DIFF
--- a/packages/app/scripts/chat-runtime-contract.mjs
+++ b/packages/app/scripts/chat-runtime-contract.mjs
@@ -221,7 +221,10 @@ await agent.onMessage(connectionB, JSON.stringify({
   type: "cf_agent_use_chat_request",
   id: "request-a",
 }));
-assert.equal(connectionB.sent.some((message) => String(message).includes("chat_request_conflict")), true);
+assert.equal(
+  connectionB.sent.some((message) => String(message).includes("This conversation is active in another window")),
+  true,
+);
 
 const controlFrame = JSON.stringify({ type: "cf_agent_stream_resuming", id: "request-a" });
 connectionB.send(controlFrame);

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -1986,7 +1986,10 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
       connection.send(JSON.stringify({
         type: CF_AGENT_USE_CHAT_RESPONSE_TYPE,
         id: requestId,
-        body: JSON.stringify({ type: "error", errorText: "chat_request_conflict" }),
+        body: JSON.stringify({
+          type: "error",
+          errorText: "This conversation is active in another window. Continue there, or send your message again here.",
+        }),
         done: true,
         error: true,
       }));

--- a/packages/app/src/lib/handles.ts
+++ b/packages/app/src/lib/handles.ts
@@ -135,19 +135,19 @@ export function validateHandle(candidate: string): HandleValidation {
   const handle = candidate.trim();
 
   if (handle.length === 0) {
-    return { valid: false, reason: "Enter a handle." };
+    return { valid: false, reason: "Enter an address." };
   }
   if (handle !== handle.toLowerCase()) {
-    return { valid: false, reason: "Handles must be lowercase." };
+    return { valid: false, reason: "Addresses must be lowercase." };
   }
   if (handle.length < HANDLE_MIN_LENGTH) {
-    return { valid: false, reason: `Handles must be at least ${HANDLE_MIN_LENGTH} characters.` };
+    return { valid: false, reason: `Addresses must be at least ${HANDLE_MIN_LENGTH} characters.` };
   }
   if (handle.length > HANDLE_MAX_LENGTH) {
-    return { valid: false, reason: `Handles must be at most ${HANDLE_MAX_LENGTH} characters.` };
+    return { valid: false, reason: `Addresses must be at most ${HANDLE_MAX_LENGTH} characters.` };
   }
   if (handle.includes("--")) {
-    return { valid: false, reason: "Handles cannot contain consecutive hyphens." };
+    return { valid: false, reason: "Addresses cannot contain consecutive hyphens." };
   }
   if (!HANDLE_PATTERN.test(handle)) {
     return {
@@ -156,7 +156,7 @@ export function validateHandle(candidate: string): HandleValidation {
     };
   }
   if (RESERVED_HANDLES.has(handle)) {
-    return { valid: false, reason: "That handle is reserved." };
+    return { valid: false, reason: "That address is reserved." };
   }
 
   return { valid: true, handle };
@@ -321,7 +321,7 @@ export async function checkHandle(bucket: R2Bucket, candidate: string): Promise<
       handle: validation.handle,
       valid: true,
       available: false,
-      reason: "That handle is taken."
+      reason: "That address is taken."
     };
   }
 
@@ -422,7 +422,7 @@ export async function claimHandle(
         return {
           ok: false,
           status: 409,
-          reason: "You already have a handle. Handles can't be changed."
+          reason: "You already have an address. Addresses can't be changed."
         };
       }
       const claimedAtMs = Date.parse(existingRecord!.claimedAt);
@@ -436,7 +436,7 @@ export async function claimHandle(
         return {
           ok: false,
           status: 409,
-          reason: "Your handle claim is still in progress. Try again shortly."
+          reason: "Your address claim is still in progress. Try again shortly."
         };
       }
       // Cases A/B: the reverse slot is an orphan (forward missing or owned by
@@ -450,7 +450,7 @@ export async function claimHandle(
         return {
           ok: false,
           status: 409,
-          reason: "You already have a handle. Handles can't be changed."
+          reason: "You already have an address. Addresses can't be changed."
         };
       }
       let latest: UserHandleRecord | null = null;
@@ -471,7 +471,7 @@ export async function claimHandle(
         return {
           ok: false,
           status: 409,
-          reason: "You already have a handle. Handles can't be changed."
+          reason: "You already have an address. Addresses can't be changed."
         };
       }
 
@@ -489,7 +489,7 @@ export async function claimHandle(
         return {
           ok: false,
           status: 409,
-          reason: "You already have a handle. Handles can't be changed."
+          reason: "You already have an address. Addresses can't be changed."
         };
       }
 
@@ -507,7 +507,7 @@ export async function claimHandle(
         return { ok: true, handle, alreadyOwned: true };
       }
       await retireReverseClaim(bucket, reverseKey, replaced.etag, handle);
-      return { ok: false, status: 409, reason: "That handle is taken." };
+      return { ok: false, status: 409, reason: "That address is taken." };
     }
 
     const claimedAt = now();
@@ -530,7 +530,7 @@ export async function claimHandle(
       return {
         ok: false,
         status: 409,
-        reason: "You already have a handle. Handles can't be changed."
+        reason: "You already have an address. Addresses can't be changed."
       };
     }
 
@@ -556,13 +556,13 @@ export async function claimHandle(
     // Another user owns the handle. Retire only the exact reverse generation we
     // wrote in step 1, without risking a newer healthy replacement, then 409.
     await retireReverseClaim(bucket, reverseKey, reverseClaim.etag, handle);
-    return { ok: false, status: 409, reason: "That handle is taken." };
+    return { ok: false, status: 409, reason: "That address is taken." };
   }
 
   return {
     ok: false,
     status: 409,
-    reason: "You already have a handle. Handles can't be changed."
+    reason: "You already have an address. Addresses can't be changed."
   };
 }
 

--- a/packages/app/src/lib/owner-mutations.ts
+++ b/packages/app/src/lib/owner-mutations.ts
@@ -155,14 +155,14 @@ export class OwnerMutationService {
     }
     const projectBytes = await this.prefixBytes(`projects/${ownerId}/${projectId}/`);
     if (projectBytes + additionalBytes > policy.maxProjectBytes) {
-      throw new Error("Project storage quota exceeded.");
+      throw new Error("This project is out of storage space. Delete some files or images, then try again.");
     }
     const ownerBytes =
       await this.prefixBytes(`projects/${ownerId}/`) +
       await this.prefixBytes(`snapshots/${ownerId}/`) +
       await this.prefixBytes(`uploads/${ownerId}/`);
     if (ownerBytes + additionalBytes > policy.maxOwnerBytes) {
-      throw new Error("Owner storage quota exceeded.");
+      throw new Error("Your account is out of storage space. Delete files from a project, then try again.");
     }
     return { recent, now, admissionId, alreadyRecorded };
   }

--- a/packages/app/src/storage/r2.test.ts
+++ b/packages/app/src/storage/r2.test.ts
@@ -1501,7 +1501,7 @@ describe("OwnerMutationService recovery journal", () => {
       content: new Uint8Array(10),
       ...policy,
       now: 100_001
-    })).rejects.toThrow("Project storage quota exceeded");
+    })).rejects.toThrow("This project is out of storage space");
     expect(await storage.fileExists("user-a", "site", "images/two.png")).toBe(false);
   });
 

--- a/packages/frontend/src/lib/api/errors.test.ts
+++ b/packages/frontend/src/lib/api/errors.test.ts
@@ -4,7 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	ApiError,
 	apiResponseFetch,
-	handleApiError
+	getErrorMessage,
+	handleApiError,
+	UserFacingError
 } from './errors';
 
 const AUTHENTICATION_REQUIRED = {
@@ -48,6 +50,26 @@ async function thrownApiError(response: Response): Promise<ApiError> {
 	}
 	throw new Error('Expected handleApiError to throw');
 }
+
+describe('getErrorMessage', () => {
+	it('passes through ApiError user messages', () => {
+		expect(getErrorMessage(new ApiError(403, 'Request access to continue.'))).toBe(
+			'Request access to continue.'
+		);
+	});
+
+	it('passes through UserFacingError messages', () => {
+		expect(
+			getErrorMessage(new UserFacingError('The connection to the assistant expired. Send your message again.'))
+		).toBe('The connection to the assistant expired. Send your message again.');
+	});
+
+	it('collapses plain Errors to the generic message', () => {
+		expect(getErrorMessage(new Error('ReferenceError: x is not defined'))).toBe(
+			'Something went wrong. Try again.'
+		);
+	});
+});
 
 describe('canonical Doorway API errors', () => {
 	beforeEach(() => {

--- a/packages/frontend/src/lib/api/errors.ts
+++ b/packages/frontend/src/lib/api/errors.ts
@@ -66,11 +66,23 @@ export function isApiError(error: CaughtError): error is ApiError {
 	return error instanceof ApiError;
 }
 
+/**
+ * An error whose message was written for end users and may be shown verbatim.
+ * Throw this (or ApiError) when the message is intentional copy; plain Errors
+ * are treated as internal and collapse to a generic message.
+ */
+export class UserFacingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'UserFacingError';
+	}
+}
+
 export function getErrorMessage(error: CaughtError): string {
 	if (isApiError(error)) {
 		return error.getUserMessage();
 	}
-	if (error instanceof Error) {
+	if (error instanceof UserFacingError) {
 		return error.message;
 	}
 	return 'Something went wrong. Try again.';

--- a/packages/frontend/src/lib/api/handles.test.ts
+++ b/packages/frontend/src/lib/api/handles.test.ts
@@ -59,9 +59,9 @@ describe('claimHandle response parsing (tri-state)', () => {
 	});
 
 	it('surfaces the server message on a 409', async () => {
-		csrfFetch.mockResolvedValue(jsonResponse({ message: 'That handle is taken.' }, 409));
+		csrfFetch.mockResolvedValue(jsonResponse({ message: 'That address is taken.' }, 409));
 		const result = await claimHandle('jane', csrfFetch);
-		expect(result).toEqual({ ok: false, message: 'That handle is taken.' });
+		expect(result).toEqual({ ok: false, message: 'That address is taken.' });
 	});
 
 	it('falls back to the error field then a default on failures', async () => {

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -6,7 +6,7 @@
 	import type { UIMessage as SDKUIMessage } from 'ai';
 	import { resolvePath } from '$lib/utils/paths';
 	import { resolveWebSocketPath } from '$lib/utils/ws';
-	import { apiResponseFetch, getErrorMessage, handleApiError, isApiError } from '$lib/api/errors';
+	import { apiResponseFetch, getErrorMessage, handleApiError, isApiError, UserFacingError } from '$lib/api/errors';
 	import { csrfFetch, getCsrfToken, refreshCsrfToken } from '$lib/api/csrf';
 import {
 		decodeToolInput,
@@ -933,7 +933,7 @@ import {
 					socket = null;
 					socketProjectId = null;
 				}
-				reject(new Error('Unable to connect to the agent'));
+				reject(new UserFacingError('Unable to connect to the assistant. Check your connection and try again.'));
 			};
 
 			nextSocket.addEventListener('open', onOpen, { once: true });
@@ -1052,7 +1052,7 @@ import {
 			{ method: 'POST' }
 		);
 		if (!response.ok) {
-			throw new Error('The connection to the assistant expired. Send your message again.');
+			throw new UserFacingError('The connection to the assistant expired. Send your message again.');
 		}
 		if (!isCurrentProjectContext(targetProjectId, targetEpoch)) {
 			throw new Error('Project changed while refreshing the agent connection');
@@ -1105,7 +1105,12 @@ import {
 		}
 
 		if (isError) {
-			const errorText = getErrorMessage(chat.error);
+			// Stream errors arrive as plain Errors from the AI SDK, but their
+			// messages are server-authored user copy (the agent sanitizes them
+			// through describeModelStreamError and curated errorText frames), so
+			// pass the message through instead of collapsing it via
+			// getErrorMessage.
+			const errorText = chat.error?.message || getErrorMessage(chat.error);
 			const lastMessage = uiMessages[uiMessages.length - 1];
 			if (
 				lastMessage?.role !== 'assistant' ||

--- a/packages/frontend/src/lib/components/HandleClaimDialog.test.ts
+++ b/packages/frontend/src/lib/components/HandleClaimDialog.test.ts
@@ -117,12 +117,12 @@ describe('HandleClaimDialog', () => {
 				handle: 'taken',
 				valid: true,
 				available: false,
-				reason: 'That handle is taken.'
+				reason: 'That address is taken.'
 			});
 			open();
 			await user.type(screen.getByLabelText('Address'), 'taken');
 			await vi.advanceTimersByTimeAsync(400);
-			expect(screen.getByText('That handle is taken.')).toBeInTheDocument();
+			expect(screen.getByText('That address is taken.')).toBeInTheDocument();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/packages/frontend/src/lib/components/NewProjectDialog.svelte
+++ b/packages/frontend/src/lib/components/NewProjectDialog.svelte
@@ -222,7 +222,7 @@
 		<Dialog.Header>
 			<Dialog.Title>Create New Project</Dialog.Title>
 			<Dialog.Description>
-				Choose a starting template and customize the static website with the AI assistant. Site Studio saves prompts and attached files with your private project. Model-provider routes are configured not to retain prompts or outputs; that setting does not cover Site Studio storage. Publishing separately makes the site files public. AI use is subject to your CAIL usage limit.
+				Choose a starting template and build on it with the assistant. Your project and chats stay private until you publish.
 			</Dialog.Description>
 		</Dialog.Header>
 

--- a/packages/frontend/src/lib/components/NewProjectDialog.test.ts
+++ b/packages/frontend/src/lib/components/NewProjectDialog.test.ts
@@ -154,11 +154,10 @@ describe('NewProjectDialog data disclosure', () => {
 		mockFetchTemplateCategories.mockResolvedValue(categories);
 	});
 
-	it('distinguishes project storage, model-provider retention, and publishing', () => {
+	it('describes the flow and privacy in plain language', () => {
 		openDialog();
 
-		expect(screen.getByText(/Site Studio saves prompts and attached files with your private project/)).toBeInTheDocument();
-		expect(screen.getByText(/Model-provider routes are configured not to retain prompts or outputs/)).toBeInTheDocument();
-		expect(screen.getByText(/Publishing separately makes the site files public/)).toBeInTheDocument();
+		expect(screen.getByText(/Choose a starting template and build on it with the assistant/)).toBeInTheDocument();
+		expect(screen.getByText(/Your project and chats stay private until you publish/)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Five approved copy fixes from the user-facing copy audit:

1. **New-project dialog** (`NewProjectDialog.svelte`): the multi-sentence privacy/retention recital (including the "CAIL" acronym) is replaced with one description sentence — "Choose a starting template and build on it with the assistant." — plus one short privacy sentence: "Your project and chats stay private until you publish."
2. **Chat conflict error** (`site-builder.ts`): the error frame's `errorText` is now the full sentence "This conversation is active in another window. Continue there, or send your message again here." instead of the raw `chat_request_conflict` code that rendered verbatim in the transcript. (The HTTP 409 envelope keeps the machine code.)
3. **Error passthrough** (`errors.ts`): `getErrorMessage` now passes through only `ApiError` user messages and a new `UserFacingError` type for intentionally authored copy; all other Errors collapse to "Something went wrong. Try again." Intentional connection copy in `AgentChat.svelte` was converted to `UserFacingError`, and the chat stream error path passes server-curated `errorText` through directly (the agent already sanitizes it via `describeModelStreamError`).
4. **Storage quota errors** (`owner-mutations.ts`): reworded to "This project is out of storage space. Delete some files or images, then try again." and "Your account is out of storage space. Delete files from a project, then try again."
5. **Handle claim reasons** (`handles.ts`): every user-visible reason now uses the claim dialog's settled "address" vocabulary ("Enter an address.", "Addresses must be lowercase.", "That address is taken.", "You already have an address. Addresses can't be changed.", etc.). Internal identifiers and API field names are unchanged.

Tests pinning the old strings were updated (`NewProjectDialog.test.ts`, `HandleClaimDialog.test.ts`, `api/handles.test.ts`, `r2.test.ts`, `chat-runtime-contract.mjs`), and `getErrorMessage` gained direct unit tests. `bun run check` passes locally (lint, both package checks, frontend build; 33 + 16 test files green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)