### PR TITLE
Finish preview, history, and download recovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "agents": "0.20.1",
         "ai": "6.0.225",
+        "es-module-lexer": "2.3.1",
         "fflate": "0.8.3",
         "hono": "4.13.1",
         "unpdf": "1.6.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,8 +12,9 @@
     "cf-typegen": "wrangler types",
     "test": "vitest run",
     "test:chat-boundary": "node --experimental-loader ./scripts/chat-runtime-contract-loader.mjs ./scripts/chat-runtime-contract.mjs",
+    "test:preview-boundary": "bun scripts/preview-route-contract.mjs",
     "test:watch": "vitest",
-    "check": "bun run prebuild && vitest run && bun run test:chat-boundary && tsc --noEmit"
+    "check": "bun run prebuild && vitest run && bun run test:chat-boundary && bun run test:preview-boundary && tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "2.0.59",
@@ -26,6 +27,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "agents": "0.20.1",
     "ai": "6.0.225",
+    "es-module-lexer": "2.3.1",
     "fflate": "0.8.3",
     "hono": "4.13.1",
     "unpdf": "1.6.2",

--- a/packages/app/scripts/preview-route-contract.mjs
+++ b/packages/app/scripts/preview-route-contract.mjs
@@ -1,0 +1,300 @@
+import { Hono } from "hono";
+import { HTMLRewriter as NodeHTMLRewriter } from "htmlrewriter";
+import { z } from "zod";
+import { createPreviewRouter } from "../src/routes/preview.ts";
+import { createPublishRouter } from "../src/routes/publish.ts";
+import { previewTokenAuth } from "../src/lib/preview-token.ts";
+
+const OWNER_ID = "user_boundary";
+const PROJECT_ID = "site";
+const HANDLE = "janedoe";
+const serverAddressSchema = z.object({ port: z.number().int().positive() });
+
+function createR2Body(key, stored) {
+  const bytes = stored.bytes.slice();
+  return {
+    key,
+    version: "1",
+    size: bytes.byteLength,
+    etag: stored.etag,
+    httpEtag: `"${stored.etag}"`,
+    checksums: {},
+    uploaded: stored.uploaded,
+    httpMetadata: stored.httpMetadata,
+    customMetadata: {},
+    storageClass: "Standard",
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      }
+    }),
+    bodyUsed: false,
+    arrayBuffer: async () => bytes.slice().buffer,
+    text: async () => new TextDecoder().decode(bytes),
+    json: async () => JSON.parse(new TextDecoder().decode(bytes)),
+    blob: async () => new Blob([bytes]),
+    writeHttpMetadata(headers) {
+      if (stored.httpMetadata?.contentType) headers.set("Content-Type", stored.httpMetadata.contentType);
+    }
+  };
+}
+
+function createBucket(initial) {
+  const stored = new Map();
+  let generation = 0;
+  for (const [key, value] of Object.entries(initial)) {
+    generation += 1;
+    stored.set(key, {
+      bytes: new TextEncoder().encode(value),
+      etag: `etag-${generation}`,
+      uploaded: new Date("2026-08-24T00:00:00.000Z")
+    });
+  }
+
+  return {
+    async get(key) {
+      const value = stored.get(key);
+      return value ? createR2Body(key, value) : null;
+    },
+    async head(key) {
+      const value = stored.get(key);
+      return value ? createR2Body(key, value) : null;
+    },
+    async list(options = {}) {
+      const prefix = options.prefix ?? "";
+      const delimiter = options.delimiter;
+      const objects = [];
+      const delimitedPrefixes = new Set();
+      for (const [key, value] of stored) {
+        if (!key.startsWith(prefix)) continue;
+        const relative = key.slice(prefix.length);
+        const delimiterIndex = delimiter ? relative.indexOf(delimiter) : -1;
+        if (delimiter && delimiterIndex >= 0) {
+          delimitedPrefixes.add(`${prefix}${relative.slice(0, delimiterIndex + delimiter.length)}`);
+        } else {
+          objects.push(createR2Body(key, value));
+        }
+      }
+      return {
+        objects,
+        delimitedPrefixes: [...delimitedPrefixes],
+        truncated: false
+      };
+    }
+  };
+}
+
+function createKv() {
+  const stored = new Map();
+  return {
+    async get(key) {
+      return stored.get(key) ?? null;
+    },
+    async put(key, value) {
+      stored.set(key, value);
+    },
+    async delete(key) {
+      stored.delete(key);
+    }
+  };
+}
+
+function createEnvironment() {
+  const createdAt = "2026-08-24T00:00:00.000Z";
+  const prefix = `projects/${OWNER_ID}/${PROJECT_ID}`;
+  const bucket = createBucket({
+    [`${prefix}/.metadata.json`]: JSON.stringify({
+      id: PROJECT_ID,
+      name: "Boundary Site",
+      createdAt,
+      updatedAt: createdAt,
+      published: true,
+      publishedAt: createdAt,
+      slug: PROJECT_ID
+    }),
+    [`${prefix}/index.html`]: [
+      '<source srcset="/images/small.png 1x, /images/large.png 2x">',
+      '<script type="module" src="/scripts/main.js"></script>'
+    ].join(""),
+    [`${prefix}/scripts/main.js`]: "import './nested.js'; void import('/lazy.js');",
+    [`${prefix}/scripts/nested.js`]: "import './deep.js';",
+    [`${prefix}/scripts/deep.js`]: "export const ready = true;",
+    [`${prefix}/lazy.js`]: "export const lazy = true;",
+    [`${prefix}/images/small.png`]: "small",
+    [`${prefix}/images/large.png`]: "large",
+    [`handles/${HANDLE}.json`]: JSON.stringify({ ownerId: OWNER_ID, claimedAt: createdAt })
+  });
+
+  return {
+    CAIL_LOG_ENV: "test",
+    SESSION_KV: createKv(),
+    SITE_STUDIO_BUCKET: bucket,
+    SITE_BUILDER_AGENT: {},
+    MIGRATION_COORDINATOR: {},
+    LOADER: {},
+    PUBLISHED_BASE_URL: "https://tools.ailab.gc.cuny.edu/site-studio"
+  };
+}
+
+function createApp() {
+  const app = new Hono();
+  app.use("/preview/*", previewTokenAuth);
+  app.use("/preview/:id", previewTokenAuth);
+  app.use("/preview/*", async (context, next) => {
+    if (!context.get("user") && context.req.header("X-Boundary-Owner") === OWNER_ID) {
+      context.set("user", { id: OWNER_ID, createdAt: new Date().toISOString() });
+      context.set("sessionId", "boundary-owner");
+    }
+    if (!context.get("user")) return context.text("Unauthorized", 401);
+    await next();
+  });
+  app.route("/", createPreviewRouter());
+  app.route("/", createPublishRouter());
+  return app;
+}
+
+function requireMatch(value, expression, label) {
+  const match = expression.exec(value)?.[1];
+  if (!match) throw new Error(`Missing ${label}`);
+  return match;
+}
+
+async function expectResponse(response, status, label) {
+  const body = await response.text();
+  if (response.status !== status) {
+    throw new Error(`${label} returned ${response.status}: ${body}`);
+  }
+  return body;
+}
+
+async function runServer() {
+  globalThis.HTMLRewriter = NodeHTMLRewriter;
+  const environment = createEnvironment();
+  const app = createApp();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: (request) => app.fetch(request, environment)
+  });
+  console.log(JSON.stringify({ port: server.port }));
+  await new Promise(() => {});
+}
+
+async function readServerPort(child) {
+  const reader = child.stdout.getReader();
+  let buffer = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) throw new Error("Boundary server exited before reporting its port");
+    buffer += new TextDecoder().decode(chunk.value);
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) continue;
+    return serverAddressSchema.parse(JSON.parse(buffer.slice(0, newline))).port;
+  }
+}
+
+async function runContract() {
+  const child = Bun.spawn([process.execPath, import.meta.path, "--server"], {
+    cwd: import.meta.dir,
+    stdout: "pipe",
+    stderr: "inherit"
+  });
+
+  try {
+    const port = await readServerPort(child);
+    const origin = `http://127.0.0.1:${port}`;
+    const page = await expectResponse(await fetch(`${origin}/preview/${PROJECT_ID}/index.html?v=42`, {
+      headers: { "X-Boundary-Owner": OWNER_ID }
+    }), 200, "preview page");
+    const pageToken = requireMatch(page, /scripts\/main\.js\?v=42&pt=([0-9a-f]{64})/, "page token");
+    if (!page.includes(`images/large.png?v=42&pt=${pageToken} 2x`)) {
+      throw new Error("Preview page did not rewrite every srcset candidate");
+    }
+
+    const main = await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/scripts/main.js?v=42&pt=${pageToken}`),
+      200,
+      "main module"
+    );
+    const moduleToken = requireMatch(main, /nested\.js\?v=42&pt=([0-9a-f]{64})/, "module token");
+    if (!main.includes(`/preview/${PROJECT_ID}/lazy.js?v=42&pt=${moduleToken}`)) {
+      throw new Error("Dynamic module import did not receive the child capability");
+    }
+
+    const nested = await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/scripts/nested.js?v=42&pt=${moduleToken}`),
+      200,
+      "nested module"
+    );
+    const deepToken = requireMatch(nested, /deep\.js\?v=42&pt=([0-9a-f]{64})/, "nested module token");
+    await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/scripts/deep.js?pt=${deepToken}`),
+      200,
+      "deep module"
+    );
+    await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/images/large.png?pt=${pageToken}`),
+      200,
+      "responsive image"
+    );
+    await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/unlinked.txt?pt=${pageToken}`),
+      401,
+      "unlinked preview resource"
+    );
+
+    const publicHeaders = { Host: "site-studio.test" };
+    const publishedPage = await expectResponse(
+      await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/index.html`, { headers: publicHeaders }),
+      200,
+      "published page"
+    );
+    if (!publishedPage.includes("/site-studio/u/janedoe/site/images/large.png 2x")) {
+      throw new Error("Published srcset candidate missed the configured mount");
+    }
+    if (!publishedPage.includes('src="/site-studio/u/janedoe/site/scripts/main.js"')) {
+      throw new Error("Published module entry missed the configured mount");
+    }
+    await expectResponse(
+      await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/images/large.png`, { headers: publicHeaders }),
+      200,
+      "published responsive image"
+    );
+
+    const publishedModule = await expectResponse(
+      await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/scripts/main.js`, {
+        headers: publicHeaders
+      }),
+      200,
+      "published module"
+    );
+    if (!publishedModule.includes('import("/site-studio/u/janedoe/site/lazy.js")')) {
+      throw new Error("Published root-relative module import missed the configured mount");
+    }
+    if (!publishedModule.includes("import './nested.js'")) {
+      throw new Error("Published relative module import changed unexpectedly");
+    }
+    await expectResponse(
+      await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/scripts/nested.js`, { headers: publicHeaders }),
+      200,
+      "published nested module"
+    );
+    await expectResponse(
+      await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/lazy.js`, { headers: publicHeaders }),
+      200,
+      "published dynamic module"
+    );
+
+    console.log("preview route contract: nested preview capabilities and public mount rewriting crossed a child HTTP process");
+  } finally {
+    child.kill();
+    await child.exited;
+  }
+}
+
+if (process.argv.includes("--server")) {
+  await runServer();
+} else {
+  await runContract();
+}

--- a/packages/app/src/lib/path.test.ts
+++ b/packages/app/src/lib/path.test.ts
@@ -6,9 +6,12 @@ import {
   isTextContentType,
   addCacheBusterToCss,
   addCacheBusterToHtml,
+  addCacheBusterToJavaScript,
   collectPreviewCssResourcePaths,
+  collectPreviewJavaScriptResourcePaths,
   rewriteRootRelativeCssUrls,
   rewriteRootRelativeHtmlUrls,
+  rewriteRootRelativeJavaScriptUrls,
   buildFileTree,
   collectPreviewResourcePaths
 } from "./path";
@@ -188,6 +191,31 @@ describe("addCacheBusterToHtml", () => {
     expect(result).toContain('src="photo.png?v=123&pt=preview-token"');
   });
 
+  it("rewrites and grants every local srcset and imagesrcset candidate", async () => {
+    const html = [
+      '<img srcset="images/small.jpg 1x, /images/large.jpg 2x, https://cdn.example/remote.jpg 3x">',
+      '<link rel="preload" imagesrcset="images/card.jpg 400w, data:image/png;base64,AAAA 800w">'
+    ].join("");
+    const rewritten = await addCacheBusterToHtml(
+      html,
+      "123",
+      { pt: "token" },
+      "/preview/proj/",
+      "pages/index.html"
+    );
+
+    expect(rewritten).toContain("images/small.jpg?v=123&pt=token 1x");
+    expect(rewritten).toContain("/preview/proj/images/large.jpg?v=123&pt=token 2x");
+    expect(rewritten).toContain("https://cdn.example/remote.jpg 3x");
+    expect(rewritten).toContain("images/card.jpg?v=123&pt=token 400w");
+    expect(rewritten).toContain("data:image/png;base64,AAAA 800w");
+    expect(await collectPreviewResourcePaths(html, "pages/index.html", "/preview/proj/")).toEqual([
+      "images/large.jpg",
+      "pages/images/card.jpg",
+      "pages/images/small.jpg"
+    ]);
+  });
+
   it("maps root navigation and rejects parent escapes", async () => {
     const html = '<a href="/">Home</a><script src="../outside.js"></script><img src="/../secret.png">';
     const result = await addCacheBusterToHtml(html, "123", { pt: "token" }, "/preview/proj/", "index.html");
@@ -344,6 +372,45 @@ describe("addCacheBusterToHtml", () => {
       "docs/styles.css",
       "/site-studio/preview/proj/"
     )).toEqual(["images/hero.png"]);
+  });
+
+  it("rewrites literal static and dynamic module imports without touching computed or bare imports", () => {
+    const source = [
+      'import value from "./nested.js";',
+      "export { shared } from '../shared.js';",
+      "const lazy = import('/lazy.js');",
+      "const computed = import('./chunks/' + name);",
+      "import 'package-name';",
+      "import 'https://cdn.example/module.js';"
+    ].join("\n");
+    const rewritten = addCacheBusterToJavaScript(
+      source,
+      "123",
+      { pt: "token" },
+      "/preview/proj/",
+      "scripts/main.js"
+    );
+
+    expect(rewritten).toContain('from "./nested.js?v=123&pt=token"');
+    expect(rewritten).toContain("from '../shared.js?v=123&pt=token'");
+    expect(rewritten).toContain('import("/preview/proj/lazy.js?v=123&pt=token")');
+    expect(rewritten).toContain("import('./chunks/' + name)");
+    expect(rewritten).toContain("import 'package-name'");
+    expect(rewritten).toContain("import 'https://cdn.example/module.js'");
+    expect(collectPreviewJavaScriptResourcePaths(source, "scripts/main.js", "/preview/proj/")).toEqual([
+      "lazy.js",
+      "scripts/nested.js",
+      "shared.js"
+    ]);
+
+    const published = rewriteRootRelativeJavaScriptUrls(
+      source,
+      "/site-studio/u/janedoe/site/",
+      "scripts/main.js"
+    );
+    expect(published).toContain('from "./nested.js"');
+    expect(published).toContain("from '../shared.js'");
+    expect(published).toContain('import("/site-studio/u/janedoe/site/lazy.js")');
   });
 
 });

--- a/packages/app/src/lib/path.ts
+++ b/packages/app/src/lib/path.ts
@@ -1,5 +1,6 @@
 import { CONTENT_TYPES } from "./constants";
 import type { ProjectTreeNode, StorageFile } from "../types";
+import { parse as parseModuleSyntax } from "es-module-lexer/js";
 
 const URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 const PREVIEW_ORIGIN = "https://preview.invalid";
@@ -162,6 +163,9 @@ function rewriteMarkupAttribute(
   const lowerName = name.toLowerCase();
   if (lowerName === "style") {
     return rewriteCssUrls(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
+  }
+  if (lowerName === "srcset" || lowerName === "imagesrcset") {
+    return rewriteSrcset(value, (url) => rewriteMarkupUrl(url, state, options, rewrite));
   }
   if (lowerName !== "href" && lowerName !== "src" && lowerName !== "xlink:href") return value;
   return rewriteMarkupUrl(value, state, options, rewrite);
@@ -333,6 +337,113 @@ function splitTrimmed(value: string) {
   };
 }
 
+function isAsciiWhitespace(value: string): boolean {
+  return value === "\t" || value === "\n" || value === "\f" || value === "\r" || value === " ";
+}
+
+/** Rewrite only the URL token in each candidate while preserving authored descriptors and spacing. */
+function rewriteSrcset(srcset: string, rewrite: (url: string) => string): string {
+  const ranges: Array<{ start: number; end: number; replacement: string }> = [];
+  let position = 0;
+
+  while (position < srcset.length) {
+    while (position < srcset.length && (isAsciiWhitespace(srcset[position]) || srcset[position] === ",")) {
+      position += 1;
+    }
+    if (position >= srcset.length) break;
+
+    const start = position;
+    while (position < srcset.length && !isAsciiWhitespace(srcset[position])) position += 1;
+    let end = position;
+    while (end > start && srcset[end - 1] === ",") end -= 1;
+
+    if (end > start) {
+      const url = srcset.slice(start, end);
+      const replacement = rewrite(url);
+      if (replacement !== url) ranges.push({ start, end, replacement });
+    }
+
+    // A trailing comma on the URL token ends a descriptorless candidate.
+    if (end < position) continue;
+
+    let inParentheses = false;
+    while (position < srcset.length) {
+      const character = srcset[position];
+      position += 1;
+      if (character === "(") {
+        inParentheses = true;
+      } else if (character === ")") {
+        inParentheses = false;
+      } else if (character === "," && !inParentheses) {
+        break;
+      }
+    }
+  }
+
+  let rewritten = srcset;
+  for (const range of ranges.reverse()) {
+    rewritten = `${rewritten.slice(0, range.start)}${range.replacement}${rewritten.slice(range.end)}`;
+  }
+  return rewritten;
+}
+
+function isLocalModuleSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./")
+    || specifier.startsWith("../")
+    || (specifier.startsWith("/") && !specifier.startsWith("//"));
+}
+
+function escapeStaticModuleSpecifier(specifier: string, quote: string): string {
+  const jsonContent = JSON.stringify(specifier).slice(1, -1);
+  return quote === "'" ? jsonContent.replaceAll("'", "\\'") : jsonContent;
+}
+
+function rewriteJavaScriptModuleSpecifiers(
+  source: string,
+  documentPath: string,
+  rootPath: string | undefined,
+  rewrite: UrlRewrite,
+  paths?: Set<string>
+): string {
+  let imports: ReturnType<typeof parseModuleSyntax>[0];
+  try {
+    [imports] = parseModuleSyntax(source);
+  } catch {
+    return source;
+  }
+
+  const ranges: Array<{ start: number; end: number; replacement: string }> = [];
+  for (const imported of imports) {
+    const specifier = imported.n;
+    if (!specifier || !isLocalModuleSpecifier(specifier)) continue;
+    const resolved = resolveLocalUrl(specifier, documentPath, true);
+    if (!resolved) continue;
+
+    const mountedPath = isRootRelative(specifier)
+      ? unmountRootPath(resolved.url.pathname, rootPath)
+      : null;
+    paths?.add(mountedPath ?? resolved.path);
+
+    const rewritten = rewrite(specifier, resolved);
+    if (rewritten === specifier) continue;
+    if (imported.d >= 0) {
+      ranges.push({ start: imported.s, end: imported.e, replacement: JSON.stringify(rewritten) });
+    } else {
+      ranges.push({
+        start: imported.s,
+        end: imported.e,
+        replacement: escapeStaticModuleSpecifier(rewritten, source[imported.s - 1] ?? "\"")
+      });
+    }
+  }
+
+  let rewritten = source;
+  for (const range of ranges.reverse()) {
+    rewritten = `${rewritten.slice(0, range.start)}${range.replacement}${rewritten.slice(range.end)}`;
+  }
+  return rewritten;
+}
+
 // This deliberately handles only CSS url(...) and quoted @import references;
 // comments, quoted text, external/data URLs, and the rest of CSS stay opaque.
 function rewriteCssUrls(css: string, rewrite: (url: string) => string): string {
@@ -447,6 +558,22 @@ export function addCacheBusterToCss(
   });
 }
 
+export function addCacheBusterToJavaScript(
+  source: string,
+  version?: string,
+  extraParams: Record<string, string> = {},
+  rootPath?: string,
+  documentPath = "index.js"
+): string {
+  const params = { v: version || Date.now().toString(), ...extraParams };
+  return rewriteJavaScriptModuleSpecifiers(
+    source,
+    documentPath,
+    rootPath,
+    (url) => addQueryParams(rewriteRootRelativeUrl(url, rootPath), params)
+  );
+}
+
 export async function rewriteRootRelativeHtmlUrls(
   html: string,
   rootPath: string,
@@ -461,6 +588,19 @@ export async function rewriteRootRelativeHtmlUrls(
 
 export function rewriteRootRelativeCssUrls(css: string, rootPath: string): string {
   return rewriteCssUrls(css, (url) => rewriteRootRelativeUrl(url, rootPath));
+}
+
+export function rewriteRootRelativeJavaScriptUrls(
+  source: string,
+  rootPath: string,
+  documentPath = "index.js"
+): string {
+  return rewriteJavaScriptModuleSpecifiers(
+    source,
+    documentPath,
+    rootPath,
+    (url) => rewriteRootRelativeUrl(url, rootPath)
+  );
 }
 
 function addQueryParams(value: string, params: Record<string, string>): string {
@@ -500,6 +640,16 @@ export function collectPreviewCssResourcePaths(
     }
     return url;
   });
+  return [...paths].sort();
+}
+
+export function collectPreviewJavaScriptResourcePaths(
+  source: string,
+  documentPath: string,
+  rootPath?: string
+): string[] {
+  const paths = new Set<string>();
+  rewriteJavaScriptModuleSpecifiers(source, documentPath, rootPath, (url) => url, paths);
   return [...paths].sort();
 }
 

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -495,6 +495,78 @@ describe("preview file resolution", () => {
     ]);
   });
 
+  it("propagates preview access through srcset candidates and nested module imports", async () => {
+    await storage.writeFile(userId, "proj", "index.html", [
+      '<source srcset="images/small.png 1x, images/large.png 2x">',
+      '<script type="module" src="scripts/main.js"></script>'
+    ].join(""));
+    await storage.writeFile(
+      userId,
+      "proj",
+      "scripts/main.js",
+      "import './nested.js'; void import('/lazy.js');"
+    );
+    await storage.writeFile(userId, "proj", "scripts/nested.js", "import './deep.js';");
+    await storage.writeFile(userId, "proj", "scripts/deep.js", "export const ready = true;");
+    await storage.writeFile(userId, "proj", "lazy.js", "export const lazy = true;");
+    await storage.writeFile(userId, "proj", "images/small.png", "small");
+    await storage.writeFile(userId, "proj", "images/large.png", "large");
+
+    const page = await get("index.html?v=42", "text/html");
+    const html = await page.text();
+    const pageToken = /scripts\/main\.js\?v=42&pt=([0-9a-f]{64})/.exec(html)?.[1];
+    expect(page.status).toBe(200);
+    expect(pageToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(html).toContain(`images/small.png?v=42&pt=${pageToken} 1x`);
+    expect(html).toContain(`images/large.png?v=42&pt=${pageToken} 2x`);
+    expect(JSON.parse(kv.store.get(`preview-token:${pageToken}`) || "{}").allowedPaths).toEqual([
+      "images/large.png",
+      "images/small.png",
+      "scripts/main.js"
+    ]);
+
+    const tokenApp = createAuthenticatedPreviewApp();
+    const main = await tokenApp.request(
+      `http://site-studio.test/preview/proj/scripts/main.js?v=42&pt=${pageToken}`,
+      { headers: { Accept: "application/javascript" } },
+      createEnv(bucket, kv)
+    );
+    const mainSource = await main.text();
+    const moduleToken = /nested\.js\?v=42&pt=([0-9a-f]{64})/.exec(mainSource)?.[1];
+    expect(main.status).toBe(200);
+    expect(moduleToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(mainSource).toContain(`/preview/proj/lazy.js?v=42&pt=${moduleToken}`);
+    expect(JSON.parse(kv.store.get(`preview-token:${moduleToken}`) || "{}").allowedPaths).toEqual([
+      "lazy.js",
+      "scripts/nested.js"
+    ]);
+
+    const nested = await tokenApp.request(
+      `http://site-studio.test/preview/proj/scripts/nested.js?v=42&pt=${moduleToken}`,
+      { headers: { Accept: "application/javascript" } },
+      createEnv(bucket, kv)
+    );
+    const nestedSource = await nested.text();
+    const nestedToken = /deep\.js\?v=42&pt=([0-9a-f]{64})/.exec(nestedSource)?.[1];
+    expect(nested.status).toBe(200);
+    expect(nestedToken).toMatch(/^[0-9a-f]{64}$/);
+
+    const deep = await tokenApp.request(
+      `http://site-studio.test/preview/proj/scripts/deep.js?pt=${nestedToken}`,
+      { headers: { Accept: "application/javascript" } },
+      createEnv(bucket, kv)
+    );
+    const responsiveImage = await tokenApp.request(
+      `http://site-studio.test/preview/proj/images/large.png?pt=${pageToken}`,
+      { headers: { Accept: "image/png" } },
+      createEnv(bucket, kv)
+    );
+    expect(deep.status).toBe(200);
+    expect(await deep.text()).toContain("ready = true");
+    expect(responsiveImage.status).toBe(200);
+    expect(await responsiveImage.text()).toBe("large");
+  });
+
   it("does not disclose a preview bearer to protocol-relative authored URLs", async () => {
     await storage.writeFile(
       userId,
@@ -868,6 +940,54 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     expect(publishedDirectory.status).toBe(200);
     expect(await publishedDirectory.text()).toContain("Docs");
+  });
+
+  it("keeps responsive images and module graphs under the configured public mount", async () => {
+    await storage.writeFile(userId, slug, "index.html", [
+      '<source srcset="/images/small.png 1x, /images/large.png 2x">',
+      '<script type="module" src="/scripts/main.js"></script>'
+    ].join(""));
+    await storage.writeFile(
+      userId,
+      slug,
+      "scripts/main.js",
+      "import '/scripts/nested.js'; void import('./relative.js');"
+    );
+    await storage.writeFile(userId, slug, "scripts/nested.js", "export const nested = true;");
+    await storage.writeFile(userId, slug, "scripts/relative.js", "export const relative = true;");
+    const env = createEnv(bucket, createMockKV(), {
+      PUBLISHED_BASE_URL: "https://tools.ailab.gc.cuny.edu/site-studio"
+    });
+
+    const page = await app.request(
+      "https://site-studio.test/u/janedoe/site/index.html",
+      {},
+      env
+    );
+    const html = await page.text();
+    expect(page.status).toBe(200);
+    expect(html).toContain("/site-studio/u/janedoe/site/images/small.png 1x");
+    expect(html).toContain("/site-studio/u/janedoe/site/images/large.png 2x");
+    expect(html).toContain('src="/site-studio/u/janedoe/site/scripts/main.js"');
+
+    const module = await app.request(
+      "https://site-studio.test/u/janedoe/site/scripts/main.js",
+      {},
+      env
+    );
+    const source = await module.text();
+    expect(module.status).toBe(200);
+    expect(source).toContain("import '/site-studio/u/janedoe/site/scripts/nested.js'");
+    expect(source).toContain("import('./relative.js')");
+    expect(module.headers.get("ETag")).toBeNull();
+
+    const nested = await app.request(
+      "https://site-studio.test/u/janedoe/site/scripts/nested.js",
+      {},
+      env
+    );
+    expect(nested.status).toBe(200);
+    expect(await nested.text()).toContain("nested = true");
   });
 
   it("preserves an external base and its governed URLs on published HTML", async () => {

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -3,7 +3,9 @@ import type { Env } from "../types";
 import {
   addCacheBusterToCss,
   addCacheBusterToHtml,
+  addCacheBusterToJavaScript,
   collectPreviewCssResourcePaths,
+  collectPreviewJavaScriptResourcePaths,
   collectPreviewResourcePaths,
   decodeServedPath
 } from "../lib/path";
@@ -182,6 +184,27 @@ async function servePreviewFile(
       requestedPath
     );
     if (rewritten !== css) content = new TextEncoder().encode(rewritten);
+  } else if (contentType.includes("javascript")) {
+    const version = c.req.query("v") || undefined;
+    const source = new TextDecoder().decode(content);
+    const allowedPaths = collectPreviewJavaScriptResourcePaths(source, resolvedPath, siteRootPath);
+    const previewToken = allowedPaths.length > 0
+      ? await mintPreviewToken(
+          c.env.SESSION_KV,
+          user.id,
+          projectId,
+          allowedPaths,
+          c.get("previewTokenExpiresAt") ?? undefined
+        )
+      : null;
+    const rewritten = addCacheBusterToJavaScript(
+      source,
+      version,
+      previewToken ? { pt: previewToken } : {},
+      siteRootPath,
+      resolvedPath
+    );
+    if (rewritten !== source) content = new TextEncoder().encode(rewritten);
   }
 
   // §3¾: the preview renders agent/student-authored HTML on our origin. The

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -23,7 +23,8 @@ import { isLoopbackOrigin } from "../lib/csrf";
 import {
   decodeServedPath,
   rewriteRootRelativeCssUrls,
-  rewriteRootRelativeHtmlUrls
+  rewriteRootRelativeHtmlUrls,
+  rewriteRootRelativeJavaScriptUrls
 } from "../lib/path";
 import { OBSERVABILITY_CONTRACT } from "../../../observability-core/src/contract";
 import {
@@ -552,12 +553,16 @@ async function servePublishedFile(
   let transformed = false;
   const isMarkup = contentType.startsWith("text/html")
     || contentType.startsWith("image/svg+xml");
-  if (isMarkup || contentType.startsWith("text/css")) {
+  const isCss = contentType.startsWith("text/css");
+  const isJavaScript = contentType.includes("javascript");
+  if (isMarkup || isCss || isJavaScript) {
     try {
       const originalText = new TextDecoder("utf-8", { fatal: true }).decode(originalBytes);
       const rewritten = isMarkup
         ? await rewriteRootRelativeHtmlUrls(originalText, siteRootPath, resolved.filePath)
-        : rewriteRootRelativeCssUrls(originalText, siteRootPath);
+        : isCss
+          ? rewriteRootRelativeCssUrls(originalText, siteRootPath)
+          : rewriteRootRelativeJavaScriptUrls(originalText, siteRootPath, resolved.filePath);
       if (rewritten !== originalText) {
         content = new TextEncoder().encode(rewritten);
         transformed = true;

--- a/packages/frontend/src/lib/components/CodeView.svelte
+++ b/packages/frontend/src/lib/components/CodeView.svelte
@@ -4,6 +4,7 @@
 	import Editor from './Editor.svelte';
 	import * as Resizable from '$lib/components/ui/resizable';
 	import { RefreshCw } from 'lucide-svelte';
+	import { toast } from '$lib/toast.svelte';
 
 	let {
 		projectId,
@@ -32,10 +33,19 @@
 		currentFileLoadFailed?: boolean;
 		onFileSelect: (path: string) => void;
 		onEditorChange: (content: string) => void;
-		onDownloadFile: (path: string) => void;
+		onDownloadFile: (path: string) => void | Promise<void>;
 		onRefreshFiles: () => void;
 		isSaving: boolean;
 	} = $props();
+
+	async function handleCurrentFileDownload() {
+		try {
+			await onDownloadFile(currentFile);
+		} catch (error) {
+			console.error('Error downloading file:', error);
+			toast.error('Failed to download file. Please try again.');
+		}
+	}
 </script>
 
 <div class="code-view">
@@ -109,7 +119,7 @@
 							<p class="binary-description">
 								{currentFileContentType || 'Binary content'} files open as assets or downloads. Use the agent's document tool for PDFs, or download the file directly.
 							</p>
-							<button class="download-current-file" type="button" onclick={() => onDownloadFile(currentFile)}>
+							<button class="download-current-file" type="button" onclick={handleCurrentFileDownload}>
 								Download file
 							</button>
 						</div>

--- a/packages/frontend/src/lib/components/CodeView.test.ts
+++ b/packages/frontend/src/lib/components/CodeView.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import CodeView from './CodeView.svelte';
+import Toaster from './Toaster.svelte';
+import { toasts } from '$lib/toast.svelte';
+
+describe('CodeView downloads', () => {
+	beforeEach(() => {
+		toasts.splice(0, toasts.length);
+	});
+
+	it('contains a rejected download, shows the existing toast, and leaves retry available', async () => {
+		const user = userEvent.setup({ delay: null });
+		const onDownloadFile = vi
+			.fn<(path: string) => Promise<void>>()
+			.mockRejectedValueOnce(new Error('network unavailable'))
+			.mockResolvedValueOnce();
+		render(Toaster);
+		render(CodeView, {
+			props: {
+				projectId: 'project-a',
+				files: [],
+				currentFile: 'assets/report.pdf',
+				fileContent: '',
+				currentFileIsText: false,
+				currentFileContentType: 'application/pdf',
+				onFileSelect: vi.fn(),
+				onEditorChange: vi.fn(),
+				onDownloadFile,
+				onRefreshFiles: vi.fn(),
+				isSaving: false
+			}
+		});
+
+		const download = screen.getByRole('button', { name: 'Download file' });
+		await user.click(download);
+		expect(await screen.findByRole('alert')).toHaveTextContent(
+			'Failed to download file. Please try again.'
+		);
+
+		await user.click(download);
+		expect(onDownloadFile).toHaveBeenCalledTimes(2);
+		expect(download).toBeEnabled();
+	});
+});

--- a/packages/frontend/src/lib/components/Preview.svelte
+++ b/packages/frontend/src/lib/components/Preview.svelte
@@ -1,31 +1,56 @@
 <script lang="ts">
-    import { resolvePath } from '$lib/utils/paths';
-    import { Skeleton } from '$lib/components/ui/skeleton';
+	import { resolvePath } from '$lib/utils/paths';
+	import { Skeleton } from '$lib/components/ui/skeleton';
+	import { RefreshCw } from 'lucide-svelte';
 
-    let { projectId, onRefresh }: { projectId: string; onRefresh?: () => void } = $props();
+	let { projectId }: { projectId: string } = $props();
 
-    let previewUrl = $derived(resolvePath(`/preview/${projectId}/index.html`));
-    let previewVersion = $state(0);
-    let previewSource = $derived(`${previewUrl}?v=${previewVersion}`);
+	const PREVIEW_NAVIGATION_TIMEOUT_MS = 15_000;
 
-    let isLoading = $state(true);
+	let previewUrl = $derived(resolvePath(`/preview/${projectId}/index.html`));
+	let previewVersion = $state(0);
+	let previewSource = $derived(`${previewUrl}?v=${previewVersion}`);
+	let navigationState = $state<'loading' | 'ready' | 'failed'>('loading');
 
-    export function refresh() {
-        isLoading = true;
-        previewVersion += 1;
-        onRefresh?.();
-    }
+	$effect(() => {
+		const activeSource = previewSource;
+		navigationState = 'loading';
+		const timeout = setTimeout(() => {
+			if (previewSource === activeSource && navigationState === 'loading') {
+				navigationState = 'failed';
+			}
+		}, PREVIEW_NAVIGATION_TIMEOUT_MS);
 
-    function handleIframeLoad(): void {
-        isLoading = false;
-    }
+		return () => clearTimeout(timeout);
+	});
+
+	export function refresh() {
+		previewVersion += 1;
+	}
+
+	function handleIframeLoad(): void {
+		navigationState = 'ready';
+	}
+
+	function handleIframeError(): void {
+		navigationState = 'failed';
+	}
 </script>
 
 <div class="preview">
 	<!-- Loading skeleton overlay -->
-	{#if isLoading}
+	{#if navigationState === 'loading'}
 		<div class="loading-overlay">
 			<Skeleton class="loading-skeleton" />
+		</div>
+	{:else if navigationState === 'failed'}
+		<div class="preview-error" role="alert">
+			<p class="preview-error-title">The preview could not be loaded.</p>
+			<p class="preview-error-detail">Your site is still saved. Try loading the preview again.</p>
+			<button class="preview-retry" type="button" onclick={refresh}>
+				<RefreshCw size={15} />
+				Retry preview
+			</button>
 		</div>
 	{/if}
 
@@ -43,6 +68,7 @@
 		sandbox="allow-scripts"
 		style="width: 100%; height: 100%; border: none;"
 		onload={handleIframeLoad}
+		onerror={handleIframeError}
 	></iframe>
 </div>
 
@@ -70,5 +96,52 @@
 		width: 100%;
 		height: 100%;
 		border-radius: 0;
+	}
+
+	.preview-error {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-overlay);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 2rem;
+		text-align: center;
+		background: var(--color-bg-primary);
+	}
+
+	.preview-error-title,
+	.preview-error-detail {
+		margin: 0;
+	}
+
+	.preview-error-title {
+		font-weight: 600;
+		color: var(--color-text-primary);
+	}
+
+	.preview-error-detail {
+		max-width: 28rem;
+		color: var(--color-text-secondary);
+		line-height: 1.5;
+	}
+
+	.preview-retry {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.625rem 0.95rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-secondary);
+		color: var(--color-text-primary);
+		cursor: pointer;
+	}
+
+	.preview-retry:hover {
+		background: var(--color-bg-tertiary);
+		border-color: var(--color-border-hover);
 	}
 </style>

--- a/packages/frontend/src/lib/components/Preview.test.ts
+++ b/packages/frontend/src/lib/components/Preview.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { fireEvent, render } from '@testing-library/svelte';
 import Preview from './Preview.svelte';
 
 describe('Preview lifecycle', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	function previewFrame(container: HTMLElement): HTMLIFrameElement {
 		const frame = container.querySelector<HTMLIFrameElement>('iframe');
 		if (!frame) throw new Error('Preview iframe was not rendered');
@@ -11,8 +15,7 @@ describe('Preview lifecycle', () => {
 	}
 
 	it('owns the loading state with the active iframe load', async () => {
-		const onRefresh = vi.fn();
-		const rendered = render(Preview, { props: { projectId: 'project-a', onRefresh } });
+		const rendered = render(Preview, { props: { projectId: 'project-a' } });
 		const frame = previewFrame(rendered.container);
 		expect(rendered.container.querySelectorAll('iframe')).toHaveLength(1);
 
@@ -34,6 +37,33 @@ describe('Preview lifecycle', () => {
 		await fireEvent.load(frame);
 		flushSync();
 		expect(rendered.container.querySelector('.loading-overlay')).toBeNull();
-		expect(onRefresh).toHaveBeenCalledTimes(2);
+	});
+
+	it('shows a retryable error when iframe navigation fails', async () => {
+		const rendered = render(Preview, { props: { projectId: 'project-a' } });
+		const frame = previewFrame(rendered.container);
+
+		await fireEvent.error(frame);
+		flushSync();
+		expect(rendered.getByRole('alert')).toHaveTextContent('The preview could not be loaded.');
+
+		await fireEvent.click(rendered.getByRole('button', { name: 'Retry preview' }));
+		flushSync();
+		expect(frame.src).toContain('?v=1');
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
+		expect(rendered.queryByRole('alert')).toBeNull();
+	});
+
+	it('turns a stalled navigation into the same retryable error', async () => {
+		vi.useFakeTimers();
+		const rendered = render(Preview, { props: { projectId: 'project-a' } });
+
+		vi.advanceTimersByTime(14_999);
+		flushSync();
+		expect(rendered.queryByRole('alert')).toBeNull();
+
+		vi.advanceTimersByTime(1);
+		flushSync();
+		expect(rendered.getByRole('alert')).toHaveTextContent('The preview could not be loaded.');
 	});
 });

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
@@ -38,7 +38,7 @@
 	let restoringSnapshotId = $state<string | null>(null);
 	let errorMessage = $state('');
 	let snapshotLabel = $state('');
-	let lastLoadedProjectId = $state<string | null>(null);
+	let loadVersion = 0;
 
 	const TRIGGER_LABELS = {
 		agent: 'AI run',
@@ -65,25 +65,25 @@
 		return TRIGGER_LABELS[snapshot.trigger];
 	}
 
-	async function loadSnapshots(force = false) {
+	async function loadSnapshots() {
 		if (!open || !projectId) {
 			return;
 		}
 
-		if (!force && lastLoadedProjectId === projectId) {
-			return;
-		}
-
+		const targetProjectId = projectId;
+		const version = ++loadVersion;
 		isLoading = true;
 		errorMessage = '';
 
 		try {
-			snapshots = await fetchProjectSnapshots(projectId);
-			lastLoadedProjectId = projectId;
+			const loadedSnapshots = await fetchProjectSnapshots(targetProjectId);
+			if (version !== loadVersion || targetProjectId !== projectId) return;
+			snapshots = loadedSnapshots;
 		} catch (error) {
+			if (version !== loadVersion || targetProjectId !== projectId) return;
 			errorMessage = getErrorMessage(error instanceof Error ? error : undefined);
 		} finally {
-			isLoading = false;
+			if (version === loadVersion) isLoading = false;
 		}
 	}
 
@@ -97,6 +97,8 @@
 
 	$effect(() => {
 		if (!open) {
+			loadVersion += 1;
+			isLoading = false;
 			snapshotLabel = '';
 			errorMessage = '';
 			restoringSnapshotId = null;
@@ -140,7 +142,7 @@
 			restoringSnapshotId = snapshotId;
 			errorMessage = '';
 			await restoreProjectSnapshot(projectId, snapshotId);
-			await loadSnapshots(true);
+			await loadSnapshots();
 			if (onRestoreSuccess) {
 				await onRestoreSuccess();
 			}

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import ProjectHistoryDialog from './ProjectHistoryDialog.svelte';
+import type { ProjectSnapshot } from '$lib/api/projects';
+
+const firstSnapshot: ProjectSnapshot = {
+	id: 'snapshot-1',
+	createdAt: '2026-08-24T12:00:00.000Z',
+	projectId: 'project-a',
+	trigger: 'manual',
+	label: 'Before the agent run',
+	fileCount: 2
+};
+
+const agentSnapshot: ProjectSnapshot = {
+	id: 'snapshot-2',
+	createdAt: '2026-08-24T12:05:00.000Z',
+	projectId: 'project-a',
+	trigger: 'agent',
+	label: 'Agent changes',
+	fileCount: 3
+};
+
+describe('ProjectHistoryDialog', () => {
+	let fetchMock: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchMock = vi.spyOn(globalThis, 'fetch');
+	});
+
+	it('reloads snapshots whenever the dialog opens', async () => {
+		fetchMock
+			.mockResolvedValueOnce(new Response(JSON.stringify({ snapshots: [firstSnapshot] }), { status: 200 }))
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ snapshots: [agentSnapshot, firstSnapshot] }), { status: 200 })
+			);
+		const props = {
+			open: true,
+			projectId: 'project-a',
+			projectName: 'Project A',
+			onOpenChange: vi.fn()
+		};
+		const rendered = render(ProjectHistoryDialog, { props });
+
+		await screen.findByText('Before the agent run');
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await rendered.rerender({ ...props, open: false });
+		await rendered.rerender({ ...props, open: true });
+
+		await screen.findByText('Agent changes');
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+	});
+});


### PR DESCRIPTION
## Summary
- add visible preview stall/failure retry
- serve responsive images and nested static/dynamic modules across private previews and public mounts
- refresh history safely on every open
- surface download failures and preserve retry

## Verification
- independent review accepted exact commit 8e6f44dc609ddd1a9fd0b407d5da502c7644e66f
- bun run check: 758 app tests, 182 frontend tests, process-boundary chat and preview contracts, lint, types, production build
- CSP and 300-second chat watchdog unchanged

No development, OpenWebUI, Bedrock, or legacy-model changes.