### PR TITLE
Allow sandboxed preview modules to load

### DIFF
--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -71,9 +71,11 @@ deletes it after import closes. No subject continuity cookie is minted.
 Preview and published responses use an opaque sandbox origin
 (`Content-Security-Policy: sandbox allow-scripts` without
 `allow-same-origin`), `nosniff`, and `no-referrer`. System objects are never
-served. Preview grants are random, short-lived, project-bound, and limited to
-normalized resources linked by the rendered document. Chat Markdown strips
-images and sanitizes links.
+served. Authored JavaScript responses allow wildcard, uncredentialed CORS so
+module graphs can load from that opaque origin; other authored resource types
+do not receive that header. Preview grants remain the read boundary: they are
+random, short-lived, project-bound, and limited to normalized resources linked
+by the rendered document. Chat Markdown strips images and sanitizes links.
 
 ## Storage admission and mutation recovery
 

--- a/packages/app/scripts/opaque-module-client.mjs
+++ b/packages/app/scripts/opaque-module-client.mjs
@@ -1,0 +1,39 @@
+import vm from "node:vm";
+
+const entryUrl = process.argv[2];
+if (!entryUrl) throw new Error("An entry module URL is required");
+
+const context = vm.createContext({});
+const loadedModules = new Map();
+
+async function loadModule(url) {
+  const existing = loadedModules.get(url);
+  if (existing) return existing;
+
+  const response = await fetch(url, {
+    credentials: "omit",
+    headers: { Origin: "null" }
+  });
+  if (!response.ok) {
+    throw new Error(`Module fetch failed at ${url}: ${response.status}`);
+  }
+  if (response.headers.get("Access-Control-Allow-Origin") !== "*") {
+    throw new Error(`Opaque-origin module CORS rejected ${url}`);
+  }
+  const module = new vm.SourceTextModule(await response.text(), {
+    context,
+    identifier: url
+  });
+  loadedModules.set(url, module);
+  await module.link((specifier, referencingModule) =>
+    loadModule(new URL(specifier, referencingModule.identifier).href)
+  );
+  return module;
+}
+
+const entryModule = await loadModule(entryUrl);
+await entryModule.evaluate();
+console.log(JSON.stringify({
+  entryMarker: context.entryMarker,
+  nestedMarker: context.nestedMarker
+}));

--- a/packages/app/scripts/preview-route-contract.mjs
+++ b/packages/app/scripts/preview-route-contract.mjs
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { HTMLRewriter as NodeHTMLRewriter } from "htmlrewriter";
 import { z } from "zod";
 import { createPreviewRouter } from "../src/routes/preview.ts";
@@ -117,9 +118,14 @@ function createEnvironment() {
       '<source srcset="/images/small.png 1x, /images/large.png 2x">',
       '<script type="module" src="/scripts/main.js"></script>'
     ].join(""),
-    [`${prefix}/scripts/main.js`]: "import './nested.js'; void import('/lazy.js');",
-    [`${prefix}/scripts/nested.js`]: "import './deep.js';",
-    [`${prefix}/scripts/deep.js`]: "export const ready = true;",
+    [`${prefix}/scripts/main.js`]: [
+      "import { nestedMarker } from './nested.js';",
+      "globalThis.entryMarker = 'entry-module-ok';",
+      "globalThis.nestedMarker = nestedMarker;",
+      "if (globalThis.loadLazy) void import('/lazy.js');"
+    ].join("\n"),
+    [`${prefix}/scripts/nested.js`]: "import { deepMarker } from './deep.js'; export const nestedMarker = `nested-${deepMarker}`;",
+    [`${prefix}/scripts/deep.js`]: "export const deepMarker = 'module-ok';",
     [`${prefix}/lazy.js`]: "export const lazy = true;",
     [`${prefix}/images/small.png`]: "small",
     [`${prefix}/images/large.png`]: "large",
@@ -139,6 +145,15 @@ function createEnvironment() {
 
 function createApp() {
   const app = new Hono();
+  app.get("/boundary/no-cors.js", (context) =>
+    context.body("globalThis.entryMarker = 'must-not-run';", 200, {
+      "Content-Type": "application/javascript"
+    })
+  );
+  app.use("/preview/*", cors({
+    origin: (origin) => origin === "https://tools.ailab.gc.cuny.edu" ? origin : null,
+    credentials: true
+  }));
   app.use("/preview/*", previewTokenAuth);
   app.use("/preview/:id", previewTokenAuth);
   app.use("/preview/*", async (context, next) => {
@@ -194,6 +209,26 @@ async function readServerPort(child) {
   }
 }
 
+async function runOpaqueModuleClient(entryUrl) {
+  const client = Bun.spawn([
+    "node",
+    "--no-warnings",
+    "--experimental-vm-modules",
+    `${import.meta.dir}/opaque-module-client.mjs`,
+    entryUrl
+  ], {
+    cwd: import.meta.dir,
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(client.stdout).text(),
+    new Response(client.stderr).text(),
+    client.exited
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
 async function runContract() {
   const child = Bun.spawn([process.execPath, import.meta.path, "--server"], {
     cwd: import.meta.dir,
@@ -210,6 +245,28 @@ async function runContract() {
     const pageToken = requireMatch(page, /scripts\/main\.js\?v=42&pt=([0-9a-f]{64})/, "page token");
     if (!page.includes(`images/large.png?v=42&pt=${pageToken} 2x`)) {
       throw new Error("Preview page did not rewrite every srcset candidate");
+    }
+
+    const rejectedExecution = await runOpaqueModuleClient(`${origin}/boundary/no-cors.js`);
+    if (
+      rejectedExecution.exitCode === 0
+      || !rejectedExecution.stderr.includes("Opaque-origin module CORS rejected")
+    ) {
+      throw new Error("Opaque module client did not reject the no-CORS negative control");
+    }
+
+    const opaqueClient = await runOpaqueModuleClient(
+      `${origin}/preview/${PROJECT_ID}/scripts/main.js?v=42&pt=${pageToken}`
+    );
+    if (opaqueClient.exitCode !== 0) {
+      throw new Error(`Opaque module client failed: ${opaqueClient.stderr || opaqueClient.stdout}`);
+    }
+    const opaqueExecution = JSON.parse(opaqueClient.stdout);
+    if (
+      opaqueExecution.entryMarker !== "entry-module-ok"
+      || opaqueExecution.nestedMarker !== "nested-module-ok"
+    ) {
+      throw new Error("Opaque-origin module graph did not execute through the preview capability");
     }
 
     const main = await expectResponse(
@@ -272,7 +329,7 @@ async function runContract() {
     if (!publishedModule.includes('import("/site-studio/u/janedoe/site/lazy.js")')) {
       throw new Error("Published root-relative module import missed the configured mount");
     }
-    if (!publishedModule.includes("import './nested.js'")) {
+    if (!publishedModule.includes("from './nested.js'")) {
       throw new Error("Published relative module import changed unexpectedly");
     }
     await expectResponse(
@@ -286,7 +343,7 @@ async function runContract() {
       "published dynamic module"
     );
 
-    console.log("preview route contract: nested preview capabilities and public mount rewriting crossed a child HTTP process");
+    console.log("preview route contract: opaque-origin modules, nested capabilities, and public mounts crossed child HTTP/process boundaries");
   } finally {
     child.kill();
     await child.exited;

--- a/packages/app/src/lib/serving-headers.ts
+++ b/packages/app/src/lib/serving-headers.ts
@@ -7,12 +7,19 @@
  * still allowing ordinary site scripts to render. The remaining headers block
  * MIME confusion and keep the app origin out of outbound referrers.
  */
-export function servedContentHeaders() {
+export function servedContentHeaders(contentType: string) {
   const headers = {
     "Content-Security-Policy": "sandbox allow-scripts",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "no-referrer"
   } satisfies Record<string, string>;
+  if (contentType.includes("javascript")) {
+    // A sandboxed authored document has an opaque origin, so its module graph
+    // is a cross-origin CORS fetch even when the URLs share the app host. The
+    // preview capability in the URL remains the authorization boundary; the
+    // wildcard permits only the resulting uncredentialed response to be read.
+    return { ...headers, "Access-Control-Allow-Origin": "*" };
+  }
   return headers;
 }
 

--- a/packages/app/src/lib/serving.test.ts
+++ b/packages/app/src/lib/serving.test.ts
@@ -65,13 +65,20 @@ describe("app serving content-types (SS-8)", () => {
 
 describe("app serving security headers", () => {
   it("emits the load-bearing opaque-origin CSP (sandbox, NO allow-same-origin)", () => {
-    const headers = servedContentHeaders();
+    const headers = servedContentHeaders("text/html; charset=utf-8");
     expect(headers["Content-Security-Policy"]).toBe("sandbox allow-scripts");
     expect(headers["Content-Security-Policy"]).not.toContain("allow-same-origin");
     expect(headers["X-Content-Type-Options"]).toBe("nosniff");
     expect(headers["Referrer-Policy"]).toBe("no-referrer");
     expect(headers).not.toHaveProperty("Content-Disposition");
     expect(headers["Content-Security-Policy"]).not.toContain("default-src");
+    expect(headers).not.toHaveProperty("Access-Control-Allow-Origin");
+  });
+
+  it("allows only authored JavaScript to satisfy opaque-origin module CORS", () => {
+    const headers = servedContentHeaders("application/javascript; charset=utf-8");
+    expect(headers).toMatchObject({ "Access-Control-Allow-Origin": "*" });
+    expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
   });
 
   it("keeps generated public 404s revalidated and non-embeddable", () => {

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -516,6 +516,7 @@ describe("preview file resolution", () => {
     const html = await page.text();
     const pageToken = /scripts\/main\.js\?v=42&pt=([0-9a-f]{64})/.exec(html)?.[1];
     expect(page.status).toBe(200);
+    expect(page.headers.get("Access-Control-Allow-Origin")).toBeNull();
     expect(pageToken).toMatch(/^[0-9a-f]{64}$/);
     expect(html).toContain(`images/small.png?v=42&pt=${pageToken} 1x`);
     expect(html).toContain(`images/large.png?v=42&pt=${pageToken} 2x`);
@@ -534,6 +535,8 @@ describe("preview file resolution", () => {
     const mainSource = await main.text();
     const moduleToken = /nested\.js\?v=42&pt=([0-9a-f]{64})/.exec(mainSource)?.[1];
     expect(main.status).toBe(200);
+    expect(main.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(main.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     expect(moduleToken).toMatch(/^[0-9a-f]{64}$/);
     expect(mainSource).toContain(`/preview/proj/lazy.js?v=42&pt=${moduleToken}`);
     expect(JSON.parse(kv.store.get(`preview-token:${moduleToken}`) || "{}").allowedPaths).toEqual([
@@ -564,6 +567,7 @@ describe("preview file resolution", () => {
     expect(deep.status).toBe(200);
     expect(await deep.text()).toContain("ready = true");
     expect(responsiveImage.status).toBe(200);
+    expect(responsiveImage.headers.get("Access-Control-Allow-Origin")).toBeNull();
     expect(await responsiveImage.text()).toBe("large");
   });
 
@@ -977,6 +981,8 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     const source = await module.text();
     expect(module.status).toBe(200);
+    expect(module.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(module.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     expect(source).toContain("import '/site-studio/u/janedoe/site/scripts/nested.js'");
     expect(source).toContain("import('./relative.js')");
     expect(module.headers.get("ETag")).toBeNull();

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -216,7 +216,7 @@ async function servePreviewFile(
       "X-Frame-Options": "SAMEORIGIN",
       "Cache-Control": "no-cache",
       Pragma: "no-cache",
-      ...servedContentHeaders()
+      ...servedContentHeaders(contentType)
     }
   });
 }

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -630,7 +630,7 @@ export function publishedResponseHeaders(filePath: string, object: R2ObjectBody)
   // containment (sandbox allow-scripts + nosniff + no-referrer). These COMPOSE
   // with the caching validators above — the CSP/security keys and the caching
   // keys are disjoint, so neither clobbers the other.
-  for (const [key, value] of Object.entries(servedContentHeaders())) {
+  for (const [key, value] of Object.entries(servedContentHeaders(contentType))) {
     headers.set(key, value);
   }
   return headers;


### PR DESCRIPTION
## What changed

- add CORS only to successfully resolved authored JavaScript responses
- keep preview capabilities, CSP, opaque sandboxing, and non-JavaScript responses unchanged
- cross a real child HTTP/process boundary with an opaque-origin nested module graph

## Verification

- `bun run check` (759 app tests, 182 frontend tests, process contracts, types, lint, diagnostics, production build)
- independent review: no actionable findings
- exact live Chrome rerun follows the production deploy