### PR TITLE
Close Site Studio browser lifecycle gaps

### DIFF
--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -71,11 +71,14 @@ deletes it after import closes. No subject continuity cookie is minted.
 Preview and published responses use an opaque sandbox origin
 (`Content-Security-Policy: sandbox allow-scripts` without
 `allow-same-origin`), `nosniff`, and `no-referrer`. System objects are never
-served. Authored JavaScript responses allow wildcard, uncredentialed CORS so
-module graphs can load from that opaque origin; other authored resource types
-do not receive that header. Preview grants remain the read boundary: they are
-random, short-lived, project-bound, and limited to normalized resources linked
-by the rendered document. Chat Markdown strips images and sanitizes links.
+served. Successfully resolved authored JavaScript and font responses allow
+wildcard, uncredentialed CORS so module graphs and fonts can load from that
+opaque origin; missing responses and other authored resource types do not
+receive that header. Preview grants remain the read boundary: they are random,
+short-lived, project-bound, and limited to normalized resources linked by the
+rendered document. Resolved preview HTML reports its navigation token after the
+child load completes, so a browser-generated error document cannot clear the
+preview failure state. Chat Markdown strips images and sanitizes links.
 
 ## Storage admission and mutation recovery
 

--- a/packages/app/scripts/preview-route-contract.mjs
+++ b/packages/app/scripts/preview-route-contract.mjs
@@ -52,7 +52,6 @@ function createBucket(initial) {
       uploaded: new Date("2026-08-24T00:00:00.000Z")
     });
   }
-
   return {
     async get(key) {
       const value = stored.get(key);
@@ -115,9 +114,12 @@ function createEnvironment() {
       slug: PROJECT_ID
     }),
     [`${prefix}/index.html`]: [
+      '<link rel="stylesheet" href="/styles/main.css">',
       '<source srcset="/images/small.png 1x, /images/large.png 2x">',
       '<script type="module" src="/scripts/main.js"></script>'
     ].join(""),
+    [`${prefix}/styles/main.css`]: "@font-face { font-family: Boundary; src: url('../fonts/body.woff2'); }",
+    [`${prefix}/fonts/body.woff2`]: "font",
     [`${prefix}/scripts/main.js`]: [
       "import { nestedMarker } from './nested.js';",
       "globalThis.entryMarker = 'entry-module-ok';",
@@ -239,10 +241,13 @@ async function runContract() {
   try {
     const port = await readServerPort(child);
     const origin = `http://127.0.0.1:${port}`;
-    const page = await expectResponse(await fetch(`${origin}/preview/${PROJECT_ID}/index.html?v=42`, {
+    const page = await expectResponse(await fetch(`${origin}/preview/${PROJECT_ID}/index.html?v=42&ready=42`, {
       headers: { "X-Boundary-Owner": OWNER_ID }
     }), 200, "preview page");
     const pageToken = requireMatch(page, /scripts\/main\.js\?v=42&pt=([0-9a-f]{64})/, "page token");
+    if (!page.includes('parent.postMessage({"type":"site-studio-preview-ready","token":"42"},"*")')) {
+      throw new Error("Resolved preview page omitted the child readiness signal");
+    }
     if (!page.includes(`images/large.png?v=42&pt=${pageToken} 2x`)) {
       throw new Error("Preview page did not rewrite every srcset candidate");
     }
@@ -295,6 +300,31 @@ async function runContract() {
       200,
       "responsive image"
     );
+    const style = await expectResponse(
+      await fetch(`${origin}/preview/${PROJECT_ID}/styles/main.css?v=42&pt=${pageToken}`),
+      200,
+      "preview stylesheet"
+    );
+    const fontToken = requireMatch(style, /fonts\/body\.woff2\?v=42&pt=([0-9a-f]{64})/, "font token");
+    const font = await fetch(`${origin}/preview/${PROJECT_ID}/fonts/body.woff2?pt=${fontToken}`);
+    await expectResponse(font.clone(), 200, "preview font");
+    if (font.headers.get("Access-Control-Allow-Origin") !== "*") {
+      throw new Error("Resolved authored font omitted opaque-origin CORS");
+    }
+    const missingPage = await fetch(`${origin}/preview/${PROJECT_ID}/missing.html?ready=42`, {
+      headers: { "X-Boundary-Owner": OWNER_ID, Accept: "text/html" }
+    });
+    const missingPageBody = await expectResponse(missingPage, 404, "missing preview page");
+    if (missingPageBody.includes("site-studio-preview-ready")) {
+      throw new Error("Missing preview page emitted a false readiness signal");
+    }
+    const missingFont = await fetch(`${origin}/u/${HANDLE}/${PROJECT_ID}/fonts/missing.woff2`, {
+      headers: { Host: "site-studio.test" }
+    });
+    await expectResponse(missingFont.clone(), 404, "missing published font");
+    if (missingFont.headers.has("Access-Control-Allow-Origin")) {
+      throw new Error("Missing authored font received a success-only CORS header");
+    }
     await expectResponse(
       await fetch(`${origin}/preview/${PROJECT_ID}/unlinked.txt?pt=${pageToken}`),
       401,
@@ -343,7 +373,7 @@ async function runContract() {
       "published dynamic module"
     );
 
-    console.log("preview route contract: opaque-origin modules, nested capabilities, and public mounts crossed child HTTP/process boundaries");
+    console.log("preview route contract: readiness, opaque-origin modules/fonts, nested capabilities, and public mounts crossed child HTTP/process boundaries");
   } finally {
     child.kill();
     await child.exited;

--- a/packages/app/src/lib/preview-ready.ts
+++ b/packages/app/src/lib/preview-ready.ts
@@ -1,0 +1,19 @@
+const PREVIEW_READY_TOKEN = /^\d+$/;
+
+/**
+ * Append a parent notification only to a successfully resolved preview page.
+ * The opaque sandbox prevents the parent from inspecting the child document,
+ * while an iframe `load` event also fires for browser-generated error pages.
+ */
+export async function addPreviewReadySignal(html: string, token: string | undefined): Promise<string> {
+  if (!token || !PREVIEW_READY_TOKEN.test(token)) return html;
+
+  const payload = JSON.stringify({ type: "site-studio-preview-ready", token });
+  const signal = `<script>addEventListener("load",()=>parent.postMessage(${payload},"*"),{once:true})</script>`;
+  const rewriter = new HTMLRewriter().onDocument({
+    end(end) {
+      end.append(signal, { html: true });
+    }
+  });
+  return rewriter.transform(new Response(html)).text();
+}

--- a/packages/app/src/lib/serving-headers.ts
+++ b/packages/app/src/lib/serving-headers.ts
@@ -13,11 +13,15 @@ export function servedContentHeaders(contentType: string) {
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "no-referrer"
   } satisfies Record<string, string>;
-  if (contentType.includes("javascript")) {
+  const needsOpaqueOriginCors = contentType.includes("javascript")
+    || contentType.startsWith("font/")
+    || contentType === "application/vnd.ms-fontobject";
+  if (needsOpaqueOriginCors) {
     // A sandboxed authored document has an opaque origin, so its module graph
-    // is a cross-origin CORS fetch even when the URLs share the app host. The
-    // preview capability in the URL remains the authorization boundary; the
-    // wildcard permits only the resulting uncredentialed response to be read.
+    // and authored fonts are cross-origin CORS fetches even when their URLs
+    // share the app host. The preview capability in the URL remains the
+    // authorization boundary; the wildcard permits only the resulting
+    // uncredentialed response to be read.
     return { ...headers, "Access-Control-Allow-Origin": "*" };
   }
   return headers;

--- a/packages/app/src/lib/serving.test.ts
+++ b/packages/app/src/lib/serving.test.ts
@@ -81,6 +81,18 @@ describe("app serving security headers", () => {
     expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
   });
 
+  it.each([
+    "font/woff",
+    "font/woff2",
+    "font/ttf",
+    "font/otf",
+    "application/vnd.ms-fontobject"
+  ])("allows a successfully resolved authored %s font to load from the opaque origin", (contentType) => {
+    const headers = servedContentHeaders(contentType);
+    expect(headers).toMatchObject({ "Access-Control-Allow-Origin": "*" });
+    expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
+  });
+
   it("keeps generated public 404s revalidated and non-embeddable", () => {
     const headers = servedNotFoundHeaders("public, max-age=0, must-revalidate");
     expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -160,6 +160,20 @@ describe("preview file resolution", () => {
     expect(await res.text()).toContain("Home");
   });
 
+  it("adds a successful child readiness signal only to resolved preview HTML", async () => {
+    const resolved = await get("index.html?ready=7", "text/html");
+    const missing = await get("missing.html?ready=7", "text/html");
+    const invalid = await get("index.html?ready=not-a-token", "text/html");
+
+    expect(resolved.status).toBe(200);
+    expect(await resolved.text()).toContain(
+      'parent.postMessage({"type":"site-studio-preview-ready","token":"7"},"*")'
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).not.toContain("site-studio-preview-ready");
+    expect(await invalid.text()).not.toContain("site-studio-preview-ready");
+  });
+
   it("serves a directory's index.html for a trailing-slash path", async () => {
     await storage.writeFile(userId, "proj", "docs/index.html", '<a href="./?x">Directory</a><h1>Docs</h1>');
     const res = await get("docs/");
@@ -810,6 +824,15 @@ describe("preview token authentication", () => {
     );
     expect(asset.status).toBe(200);
     expect(await asset.text()).toBe("hero");
+
+    const font = await app.request(
+      `http://site-studio.test/preview/proj/fonts/body.woff2?pt=${child}`,
+      {},
+      createEnv(bucket, kv)
+    );
+    expect(font.status).toBe(200);
+    expect(font.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(font.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
   it("rewrites standalone SVG URLs with a scoped child preview grant", async () => {
@@ -959,6 +982,7 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     await storage.writeFile(userId, slug, "scripts/nested.js", "export const nested = true;");
     await storage.writeFile(userId, slug, "scripts/relative.js", "export const relative = true;");
+    await storage.writeFile(userId, slug, "fonts/body.woff2", "font");
     const env = createEnv(bucket, createMockKV(), {
       PUBLISHED_BASE_URL: "https://tools.ailab.gc.cuny.edu/site-studio"
     });
@@ -994,6 +1018,23 @@ describe("preview ↔ publish extensionless parity", () => {
     );
     expect(nested.status).toBe(200);
     expect(await nested.text()).toContain("nested = true");
+
+    const font = await app.request(
+      "https://site-studio.test/u/janedoe/site/fonts/body.woff2",
+      {},
+      env
+    );
+    expect(font.status).toBe(200);
+    expect(font.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(font.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+
+    const missingFont = await app.request(
+      "https://site-studio.test/u/janedoe/site/fonts/missing.woff2",
+      {},
+      env
+    );
+    expect(missingFont.status).toBe(404);
+    expect(missingFont.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   it("preserves an external base and its governed URLs on published HTML", async () => {

--- a/packages/app/src/routes/preview.ts
+++ b/packages/app/src/routes/preview.ts
@@ -21,6 +21,7 @@ import { isLoopbackOrigin } from "../lib/csrf";
 import { mintPreviewToken } from "../lib/preview-token";
 import { FileNotFoundError, R2ProjectStorage } from "../storage/r2";
 import { getLoggingContext, type LoggingVariables } from "../lib/logging";
+import { addPreviewReadySignal } from "../lib/preview-ready";
 
 type AppContext = Context<{
   Bindings: Env;
@@ -162,7 +163,10 @@ async function servePreviewFile(
       siteRootPath,
       requestedPath
     );
-    if (rewritten !== html) content = new TextEncoder().encode(rewritten);
+    const signaled = contentType.startsWith("text/html")
+      ? await addPreviewReadySignal(rewritten, c.req.query("ready") || undefined)
+      : rewritten;
+    if (signaled !== html) content = new TextEncoder().encode(signaled);
   } else if (contentType.startsWith("text/css")) {
     const version = c.req.query("v") || undefined;
     const css = new TextDecoder().decode(content);

--- a/packages/frontend/src/lib/api/projects.ts
+++ b/packages/frontend/src/lib/api/projects.ts
@@ -2,6 +2,7 @@ import { resolvePath } from '$lib/utils/paths';
 import { apiFetch, handleApiError } from './errors';
 import { csrfFetch } from './csrf';
 import { z } from 'zod';
+import { downloadBlob } from '$lib/browser/download';
 
 const API_BASE = resolvePath('/api');
 
@@ -160,14 +161,7 @@ export async function downloadFile(projectId: string, filePath: string): Promise
 	}
 
 	const blob = await response.blob();
-	const url = window.URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = filePath.split('/').pop() || 'download';
-	document.body.appendChild(a);
-	a.click();
-	document.body.removeChild(a);
-	window.URL.revokeObjectURL(url);
+	downloadBlob(blob, filePath.split('/').pop() || 'download');
 }
 
 /**

--- a/packages/frontend/src/lib/browser/download.test.ts
+++ b/packages/frontend/src/lib/browser/download.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { downloadBlob } from './download';
+
+describe('downloadBlob', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('keeps the object URL alive until after the browser has committed the download', () => {
+		vi.useFakeTimers();
+		const createObjectURL = vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:download');
+		const revokeObjectURL = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => undefined);
+		const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+		downloadBlob(new Blob(['content']), 'notes.txt');
+
+		expect(createObjectURL).toHaveBeenCalledOnce();
+		expect(click).toHaveBeenCalledOnce();
+		expect(revokeObjectURL).not.toHaveBeenCalled();
+		expect(document.querySelector('a[download="notes.txt"]')).toBeNull();
+
+		vi.advanceTimersByTime(999);
+		expect(revokeObjectURL).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
+	});
+});

--- a/packages/frontend/src/lib/browser/download.ts
+++ b/packages/frontend/src/lib/browser/download.ts
@@ -1,0 +1,14 @@
+const OBJECT_URL_REVOCATION_DELAY_MS = 1_000;
+
+/** Start a browser download and keep the Blob URL alive until navigation commits. */
+export function downloadBlob(blob: Blob, fileName: string): void {
+	const objectUrl = window.URL.createObjectURL(blob);
+	const anchor = document.createElement('a');
+	anchor.href = objectUrl;
+	anchor.download = fileName;
+	anchor.hidden = true;
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), OBJECT_URL_REVOCATION_DELAY_MS);
+}

--- a/packages/frontend/src/lib/components/FileTree.svelte
+++ b/packages/frontend/src/lib/components/FileTree.svelte
@@ -15,6 +15,7 @@
 	import { csrfFetch } from '$lib/api/csrf';
 	import { apiResponseFetch, getErrorMessage, handleApiError } from '$lib/api/errors';
 	import { toast } from '$lib/toast.svelte';
+	import { downloadBlob } from '$lib/browser/download';
 
 	let {
 		files = [],
@@ -72,14 +73,7 @@
 			if (!response.ok) throw new Error('Download failed');
 
 			const blob = await response.blob();
-			const url = window.URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = filePath.split('/').pop() || 'download';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-			window.URL.revokeObjectURL(url);
+			downloadBlob(blob, filePath.split('/').pop() || 'download');
 		} catch (error) {
 			console.error('Error downloading file:', error);
 			toast.error('Failed to download file. Please try again.');

--- a/packages/frontend/src/lib/components/Preview.svelte
+++ b/packages/frontend/src/lib/components/Preview.svelte
@@ -2,15 +2,22 @@
 	import { resolvePath } from '$lib/utils/paths';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { RefreshCw } from 'lucide-svelte';
+	import { z } from 'zod';
 
 	let { projectId }: { projectId: string } = $props();
 
 	const PREVIEW_NAVIGATION_TIMEOUT_MS = 15_000;
+	const previewReadyMessageSchema = z.object({
+		type: z.literal('site-studio-preview-ready'),
+		token: z.string()
+	});
 
 	let previewUrl = $derived(resolvePath(`/preview/${projectId}/index.html`));
 	let previewVersion = $state(0);
-	let previewSource = $derived(`${previewUrl}?v=${previewVersion}`);
+	let previewReadyToken = $derived(String(previewVersion));
+	let previewSource = $derived(`${previewUrl}?v=${previewVersion}&ready=${previewReadyToken}`);
 	let navigationState = $state<'loading' | 'ready' | 'failed'>('loading');
+	let previewFrame = $state<HTMLIFrameElement>();
 
 	$effect(() => {
 		const activeSource = previewSource;
@@ -24,12 +31,21 @@
 		return () => clearTimeout(timeout);
 	});
 
+	$effect(() => {
+		const activeToken = previewReadyToken;
+		function handlePreviewReady(event: MessageEvent): void {
+			if (event.source !== previewFrame?.contentWindow) return;
+			const message = previewReadyMessageSchema.safeParse(event.data);
+			if (!message.success || message.data.token !== activeToken) return;
+			navigationState = 'ready';
+		}
+
+		window.addEventListener('message', handlePreviewReady);
+		return () => window.removeEventListener('message', handlePreviewReady);
+	});
+
 	export function refresh() {
 		previewVersion += 1;
-	}
-
-	function handleIframeLoad(): void {
-		navigationState = 'ready';
 	}
 
 	function handleIframeError(): void {
@@ -63,11 +79,11 @@
 		longer read `contentDocument` (it is cross-origin once opaque).
 	-->
 	<iframe
+		bind:this={previewFrame}
 		src={previewSource}
 		title="Site Preview"
 		sandbox="allow-scripts"
 		style="width: 100%; height: 100%; border: none;"
-		onload={handleIframeLoad}
 		onerror={handleIframeError}
 	></iframe>
 </div>

--- a/packages/frontend/src/lib/components/Preview.test.ts
+++ b/packages/frontend/src/lib/components/Preview.test.ts
@@ -14,27 +14,48 @@ describe('Preview lifecycle', () => {
 		return frame;
 	}
 
-	it('owns the loading state with the active iframe load', async () => {
+	it('becomes ready only after the active successful child reports its HTTP-backed token', async () => {
 		const rendered = render(Preview, { props: { projectId: 'project-a' } });
 		const frame = previewFrame(rendered.container);
 		expect(rendered.container.querySelectorAll('iframe')).toHaveLength(1);
+		expect(frame.src).toContain('?v=0&ready=0');
 
 		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
 		await fireEvent.load(frame);
+		flushSync();
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
+
+		window.dispatchEvent(new MessageEvent('message', {
+			data: { type: 'site-studio-preview-ready', token: 'wrong' },
+			source: frame.contentWindow
+		}));
+		flushSync();
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
+
+		window.dispatchEvent(new MessageEvent('message', {
+			data: { type: 'site-studio-preview-ready', token: '0' },
+			source: frame.contentWindow
+		}));
 		flushSync();
 		expect(rendered.container.querySelector('.loading-overlay')).toBeNull();
 
 		rendered.component.refresh();
 		flushSync();
-		expect(frame.src).toContain('?v=1');
+		expect(frame.src).toContain('?v=1&ready=1');
 		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
 
 		// A second refresh supersedes the first without creating a second frame
 		// whose load event could strand the overlay over the usable preview.
 		rendered.component.refresh();
 		flushSync();
-		expect(frame.src).toContain('?v=2');
+		expect(frame.src).toContain('?v=2&ready=2');
 		await fireEvent.load(frame);
+		flushSync();
+		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
+		window.dispatchEvent(new MessageEvent('message', {
+			data: { type: 'site-studio-preview-ready', token: '2' },
+			source: frame.contentWindow
+		}));
 		flushSync();
 		expect(rendered.container.querySelector('.loading-overlay')).toBeNull();
 	});
@@ -49,7 +70,7 @@ describe('Preview lifecycle', () => {
 
 		await fireEvent.click(rendered.getByRole('button', { name: 'Retry preview' }));
 		flushSync();
-		expect(frame.src).toContain('?v=1');
+		expect(frame.src).toContain('?v=1&ready=1');
 		expect(rendered.container.querySelector('.loading-overlay')).not.toBeNull();
 		expect(rendered.queryByRole('alert')).toBeNull();
 	});

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
@@ -101,22 +101,21 @@
 			isLoading = false;
 			snapshotLabel = '';
 			errorMessage = '';
-			restoringSnapshotId = null;
 		}
 	});
 
 	async function handleCreateSnapshot() {
-		if (!projectId || isCreating) {
+		if (!projectId || isCreating || restoringSnapshotId !== null) {
 			return;
 		}
 
+		isCreating = true;
 		try {
 			const canCreate = onBeforeCreateSnapshot ? await onBeforeCreateSnapshot() : true;
 			if (!canCreate) {
 				return;
 			}
 
-			isCreating = true;
 			errorMessage = '';
 			const snapshot = await createProjectSnapshot(projectId, snapshotLabel.trim() || undefined);
 			snapshots = [snapshot, ...snapshots];
@@ -129,17 +128,17 @@
 	}
 
 	async function handleRestore(snapshotId: string) {
-		if (!projectId || restoringSnapshotId) {
+		if (!projectId || isCreating || restoringSnapshotId !== null) {
 			return;
 		}
 
+		restoringSnapshotId = snapshotId;
 		try {
 			const canRestore = onBeforeRestore ? await onBeforeRestore() : true;
 			if (!canRestore) {
 				return;
 			}
 
-			restoringSnapshotId = snapshotId;
 			errorMessage = '';
 			await restoreProjectSnapshot(projectId, snapshotId);
 			await loadSnapshots();

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.svelte
@@ -169,10 +169,10 @@
 					id="snapshot-label"
 					bind:value={snapshotLabel}
 					placeholder="Optional note for this checkpoint"
-					disabled={isCreating}
+					disabled={isCreating || restoringSnapshotId !== null}
 				/>
 			</div>
-			<Button onclick={handleCreateSnapshot} disabled={isCreating}>
+			<Button onclick={handleCreateSnapshot} disabled={isCreating || restoringSnapshotId !== null}>
 				{#if isCreating}
 					<Loader2 size={14} class="animate-spin" />
 					Creating...
@@ -215,7 +215,7 @@
 							variant="outline"
 							size="sm"
 							onclick={() => handleRestore(snapshot.id)}
-							disabled={restoringSnapshotId !== null}
+							disabled={isCreating || restoringSnapshotId !== null}
 						>
 							{#if restoringSnapshotId === snapshot.id}
 								<Loader2 size={14} class="animate-spin" />

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
@@ -1,7 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import ProjectHistoryDialog from './ProjectHistoryDialog.svelte';
 import type { ProjectSnapshot } from '$lib/api/projects';
+import { invalidateCsrfToken } from '$lib/api/csrf';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
 
 const firstSnapshot: ProjectSnapshot = {
 	id: 'snapshot-1',
@@ -22,11 +31,17 @@ const agentSnapshot: ProjectSnapshot = {
 };
 
 describe('ProjectHistoryDialog', () => {
-	let fetchMock: ReturnType<typeof vi.spyOn>;
+	type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+	let fetchMock: Mock<FetchFunction>;
 
 	beforeEach(() => {
-		fetchMock = vi.spyOn(globalThis, 'fetch');
+		document.cookie = 'cail_csrf_sitestudio=test-csrf-token';
+		invalidateCsrfToken();
+		fetchMock = vi.fn<FetchFunction>();
+		vi.stubGlobal('fetch', fetchMock);
 	});
+
+	afterEach(() => vi.unstubAllGlobals());
 
 	it('reloads snapshots whenever the dialog opens', async () => {
 		fetchMock
@@ -50,5 +65,104 @@ describe('ProjectHistoryDialog', () => {
 
 		await screen.findByText('Agent changes');
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+	});
+
+	it('owns snapshot creation before awaiting the pending-save flush', async () => {
+		const flush = deferred<boolean>();
+		const onBeforeCreateSnapshot = vi.fn(() => flush.promise);
+		fetchMock.mockImplementation(async (_input, init) => {
+			if ((init?.method || 'GET') === 'POST') {
+				return new Response(JSON.stringify({ snapshot: agentSnapshot }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ snapshots: [firstSnapshot] }), { status: 200 });
+		});
+		render(ProjectHistoryDialog, {
+			props: {
+				open: true,
+				projectId: 'project-a',
+				onOpenChange: vi.fn(),
+				onBeforeCreateSnapshot
+			}
+		});
+
+		await screen.findByText('Before the agent run');
+		const save = screen.getByRole('button', { name: 'Save version' });
+		await Promise.all([fireEvent.click(save), fireEvent.click(save)]);
+
+		expect(onBeforeCreateSnapshot).toHaveBeenCalledOnce();
+		expect(screen.getByRole('button', { name: 'Creating...' })).toBeDisabled();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		flush.resolve(true);
+		await screen.findByText('Agent changes');
+		const posts = fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST');
+		expect(posts).toHaveLength(1);
+	});
+
+	it('owns restore before awaiting the pending-save flush', async () => {
+		const flush = deferred<boolean>();
+		const onBeforeRestore = vi.fn(() => flush.promise);
+		const onRestoreSuccess = vi.fn();
+		fetchMock.mockImplementation(async (_input, init) => {
+			if ((init?.method || 'GET') === 'POST') {
+				return new Response(JSON.stringify({
+					restoredSnapshot: firstSnapshot,
+					restorePoint: agentSnapshot
+				}), { status: 200 });
+			}
+			return new Response(JSON.stringify({ snapshots: [firstSnapshot] }), { status: 200 });
+		});
+		render(ProjectHistoryDialog, {
+			props: {
+				open: true,
+				projectId: 'project-a',
+				onOpenChange: vi.fn(),
+				onBeforeRestore,
+				onRestoreSuccess
+			}
+		});
+
+		await screen.findByText('Before the agent run');
+		const restore = screen.getByRole('button', { name: 'Restore' });
+		await Promise.all([fireEvent.click(restore), fireEvent.click(restore)]);
+
+		expect(onBeforeRestore).toHaveBeenCalledOnce();
+		expect(screen.getByRole('button', { name: 'Restoring...' })).toBeDisabled();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		flush.resolve(true);
+		await waitFor(() => expect(onRestoreSuccess).toHaveBeenCalledOnce());
+		const posts = fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST');
+		expect(posts).toHaveLength(1);
+	});
+
+	it('releases creation ownership when the save flush fails so retry works', async () => {
+		const onBeforeCreateSnapshot = vi.fn()
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		fetchMock.mockImplementation(async (_input, init) => {
+			if ((init?.method || 'GET') === 'POST') {
+				return new Response(JSON.stringify({ snapshot: agentSnapshot }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ snapshots: [firstSnapshot] }), { status: 200 });
+		});
+		render(ProjectHistoryDialog, {
+			props: {
+				open: true,
+				projectId: 'project-a',
+				onOpenChange: vi.fn(),
+				onBeforeCreateSnapshot
+			}
+		});
+
+		await screen.findByText('Before the agent run');
+		await fireEvent.click(screen.getByRole('button', { name: 'Save version' }));
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Save version' })).toBeEnabled());
+		expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(0);
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Save version' }));
+		await screen.findByText('Agent changes');
+		expect(onBeforeCreateSnapshot).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1);
 	});
 });

--- a/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
+++ b/packages/frontend/src/lib/components/ProjectHistoryDialog.test.ts
@@ -91,6 +91,7 @@ describe('ProjectHistoryDialog', () => {
 
 		expect(onBeforeCreateSnapshot).toHaveBeenCalledOnce();
 		expect(screen.getByRole('button', { name: 'Creating...' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Restore' })).toBeDisabled();
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
 		flush.resolve(true);
@@ -128,6 +129,7 @@ describe('ProjectHistoryDialog', () => {
 
 		expect(onBeforeRestore).toHaveBeenCalledOnce();
 		expect(screen.getByRole('button', { name: 'Restoring...' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save version' })).toBeDisabled();
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
 		flush.resolve(true);

--- a/packages/frontend/src/routes/editor/[projectId]/+page.svelte
+++ b/packages/frontend/src/routes/editor/[projectId]/+page.svelte
@@ -16,6 +16,7 @@
 	import Button from '$lib/components/ui/button/button.svelte';
     import { ChevronDown, LayoutDashboard, Code2, PanelLeftClose, PanelRightClose, MoreVertical, Globe, GlobeLock, ExternalLink, Download, Check, Loader2, RotateCcw, Image as ImageIcon } from 'lucide-svelte';
 	import { downloadFile as downloadProjectFile, fetchProjects, publishProject, unpublishProject, type A11yFinding, type Project, type ProjectFile } from '$lib/api/projects';
+	import { downloadBlob } from '$lib/browser/download';
 	import { csrfFetch, getCsrfToken, getCsrfTokenFromCookie } from '$lib/api/csrf';
 	import { apiFetch, apiResponseFetch } from '$lib/api/errors';
 	import ProjectDialogs from '$lib/components/ProjectDialogs.svelte';
@@ -812,17 +813,7 @@
 			// Create a blob from the response
 			const blob = await response.blob();
 
-			// Create a temporary download link
-			const url = window.URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = `${currentProject.id}.zip`;
-			document.body.appendChild(a);
-			a.click();
-
-			// Cleanup
-			window.URL.revokeObjectURL(url);
-			document.body.removeChild(a);
+			downloadBlob(blob, `${currentProject.id}.zip`);
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to export project.');
 		}


### PR DESCRIPTION
## What changed

- require a token-bound child signal before Preview reports ready
- allow successfully resolved authored fonts in the existing opaque sandbox
- share delayed Blob-download cleanup across all three product controls
- acquire History create/restore ownership before save flushes

Authentication, preview capabilities, sandbox, CSP, and non-authored response behavior remain unchanged.

## Verification

- full check: 765 app tests, 186 frontend tests, lint, types, diagnostics, production build, HTTP/process boundaries
- real local browser: valid WOFF2 load, success-vs-404 readiness signal, delayed download lifecycle
- independent review accepted
- exact live project/browser rerun follows production deploy