### PR TITLE
Align Site Studio runtime contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ site-studio/
 
 - Cloudflare Worker + Hono
 - Native R2, KV, and Durable Object bindings
-- Same-origin preview and public-site serving
+- Preview and public-site bytes served by the app Worker; authored documents
+  execute in an opaque-origin sandbox and cannot rely on app-origin authority
 - Verified CAIL identity on every product route
 - One-time first-login import from a resolvable legacy R2 session
 
@@ -57,6 +58,8 @@ site-studio/
 - Project-scoped instance identity: `userId:projectId`
 - `codemode` wraps project operations so the model can write JavaScript that orchestrates multi-step work in a Dynamic Worker sandbox
 - `ask_user_question` remains available for structured clarification
+- The active default model is the Workers AI catalog id
+  `@cf/zai-org/glm-5.2`; any `CAIL_MODEL` override must remain a `@cf/...` id
 
 ## Frontend Transport
 
@@ -136,6 +139,10 @@ Local ports:
   root, and unauthenticated no-store-401 probes are release gates. There is no
   checked-in staging Worker/storage topology, so there is no PR production
   preview.
-- Preserve same-origin assumptions for preview and thumbnail capture unless deliberately redesigned
+- Preserve the opaque-origin preview boundary. Authored documents never receive
+  `allow-same-origin`; linked preview resources use short-lived,
+  project-and-path-scoped capabilities, and successful authored JavaScript and
+  font responses use uncredentialed wildcard CORS so they can load from that
+  opaque origin.
 - Use Svelte 5 runes patterns in frontend code
 - Default to execute-plus-clarify, not approval-first UX

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Model traffic goes directly from the app Worker to the CAIL Gateway through
 `@cuny-ai-lab/cail-client` and `@ai-sdk/openai-compatible` at
 the canonical `https://tools.ailab.gc.cuny.edu/v1` API. The checked-in
 `CAIL_API_BASE` is the canonical origin; the shared client owns the `/v1`
-model and quota paths. The app forwards only the separately verified,
+model and quota paths. The active default is the Workers AI catalog model
+`@cf/zai-org/glm-5.2`; any configured override must also be a `@cf/...` model.
+The app forwards only the separately verified,
 subject-bound gateway identity and stamps `X-CAIL-App: site-studio`. Site Studio
 has no provider keys and does not impose an output-token or model-step cap.
 Billed model POSTs use `maxRetries: 0` because an uncertain automatic retry can
@@ -94,6 +96,38 @@ Slashless public roots redirect to the trailing-slash form so relative assets
 resolve beneath the site root. When public ingress mounts the Worker under the
 path in `PUBLISHED_BASE_URL`, redirects and styled 404 home links retain that
 path; loopback development remains rooted at `/`.
+
+## Browser lifecycle ownership
+
+The preview component owns one iframe navigation at a time. Authored pages run
+under `Content-Security-Policy: sandbox allow-scripts` without
+`allow-same-origin`, so they have an opaque origin even though the app Worker
+serves their bytes. The Worker rewrites linked project resources with
+short-lived, project-and-path-scoped preview capabilities; successful authored
+JavaScript and font responses allow uncredentialed wildcard CORS so those
+resources can load from the opaque document. A preview becomes ready only when
+the active resolved child reports its matching navigation token. A failed or
+stalled navigation remains retryable.
+
+The browser download helper owns Blob URL cleanup. It removes the temporary
+anchor immediately but delays URL revocation until the browser has had time to
+commit the download; do not replace that with same-stack revocation.
+
+The chat component and the maintained WebSocket transport jointly own a model
+turn. Stop cancels the full server turn, suppresses its late frames and queued
+continuations, and leaves a later request independent. An unexpected disconnect
+reconnects with bounded backoff while the project remains active, refreshes the
+CSRF token once per reconnect cycle, and resumes only a request still
+owned by the same authenticated subject. A post-persistence commit or an
+authenticated history read repairs a stream that ended before the saved turn
+arrived. Responses from an older project, request generation, or superseded
+history read cannot overwrite newer visible work.
+
+Version-history create and restore are single-flight operations owned by the
+history dialog. Ownership is taken before any pending editor save is awaited;
+while one operation is pending, its create and restore controls stay disabled.
+Snapshot-list responses are latest-wins so a slow response from an earlier open
+or project cannot replace the current list.
 
 ## Local development
 

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -80,6 +80,23 @@ rendered document. Resolved preview HTML reports its navigation token after the
 child load completes, so a browser-generated error document cannot clear the
 preview failure state. Chat Markdown strips images and sanitizes links.
 
+The frontend keeps one preview iframe and accepts readiness only from the
+active child with the matching navigation token. It turns failed or stalled
+navigations into the same retryable state. Browser downloads use a temporary
+Blob URL whose revocation is deliberately delayed until after the download
+navigation can commit.
+
+Stop resets the whole agent turn, not only the current response id. The client
+and agent retain cancellation identity long enough to reject late stream frames
+and successor continuations. Unexpected socket loss reconnects with bounded
+backoff while the project is mounted; a reconnect refreshes the CSRF token once
+per cycle and may resume only the same subject's owned request. Successful
+persisted turns emit a targeted commit frame. That frame or an authenticated
+history read repairs the visible transcript, while project epochs and request
+generations prevent stale reads and frames from overwriting newer work. A
+history load failure is shown as a retryable loading problem rather than an
+empty conversation.
+
 ## Storage admission and mutation recovery
 
 Uploads enforce content signatures, per-file platform limits, and configured
@@ -98,6 +115,11 @@ of overwriting remote content. Drafts are encrypted with the per-owner CSRF
 token before origin-wide browser storage and clear only after the exact content
 is acknowledged. This protects against another later owner reading a leftover
 draft, not against XSS.
+
+The version-history dialog owns create and restore as single-flight operations.
+It takes ownership before awaiting an editor-save flush, blocks another history
+mutation until the first settles, and ignores snapshot-list responses that no
+longer belong to the active load.
 
 ## Publishing and rollback
 

--- a/packages/app/src/prompts/site-builder.ts
+++ b/packages/app/src/prompts/site-builder.ts
@@ -1,4 +1,3 @@
-// TODO(policy-wording): generation content-policy line from Stephen pending
 export const SITE_BUILDER_PROMPT = `You are Site Studio's site-building agent.
 
 You help academics and researchers create clean, professional static websites by editing project files directly.
@@ -31,7 +30,7 @@ Workflow:
 Available tools:
 - extract_document_text: extract readable text from supported uploaded documents such as PDFs
 - codemode: run sandboxed JavaScript that uses typed project APIs to inspect and modify the site
-- generate_image: create imagery when the user wants visuals they do not already have (saves to images/); always agree on descriptive alt text in conversation before or right after inserting it, and if a generation is rejected by the content check, rephrase the request rather than retrying it verbatim
+- generate_image: create imagery when the user wants visuals they do not already have (saves to images/); always agree on descriptive alt text in conversation before or right after inserting it. Every generated image must pass the content check before it is saved. If one is rejected, tell the user it could not be used and ask for a different description; do not retry the same request or speculate about the check.
 - ask_user_question: ask the user a focused follow-up when required
 
 Design standard:


### PR DESCRIPTION
## Summary
- replace the stale same-origin instruction with the actual opaque-origin sandbox contract
- document the active model and browser lifecycle ownership
- resolve the generated-image policy TODO with the current fail-closed behavior

## Verification
- `bun run check` (765 app tests, 186 frontend tests, real preview/chat boundaries, lint, types, Svelte diagnostics, production build)
- independent exact-commit review: accepted
- `git diff --check`