### PR TITLE
Align Site Studio quota authority

### DIFF
--- a/docs/cail-log-alignment.md
+++ b/docs/cail-log-alignment.md
@@ -14,9 +14,9 @@ shared observability workspace package.
   `cail-v1-<32 lowercase hex>`. This is a log representation only; storage,
   Durable Object and handle keys remain the exact identity `sub`.
   Legacy and anonymous owner identifiers remain anonymous.
-- The CAIL model gateway remains the owner of model-call success, token, quota,
-  latency, and spend records. Site Studio does not duplicate those events or use
-  application logs as a spend ledger.
+- The CAIL Gateway/Cloudflare AI Gateway boundary remains authoritative for
+  model-call success, token, quota, latency, and spend records. Site Studio does
+  not duplicate those events or use application logs as a spend ledger.
 
 ## Event and acknowledgement map
 
@@ -88,8 +88,8 @@ export window. It evaluates the diagnostic projection, never product state.
 Contract version 2 defines the initial operating posture: full-sampled
 bounded custom events, invocation logs off, no v1 external exporter, default-
 deny `kale-admin` access, a one-minute `ENAM` synthetic profile, rolling 24-hour
-SLOs, latency and reliability thresholds, and month-to-date gateway-ledger spend
-bands. Its action SLI sub-contract versions admission-window assignment, a
+SLOs and latency/reliability thresholds. Its action SLI sub-contract versions
+admission-window assignment, a
 15-minute terminal grace period, exact terminal matching, durable-success
 semantics, and separate build/publish denominators.
 
@@ -106,11 +106,13 @@ minutes. Build/publish admissions get a 15-minute terminal grace period.
 | Build/publish terminal coverage | below 99.5% | below 98.0% | 10 actions |
 
 Request p95 latency warns above five seconds for the app. Action p95 warns above ten minutes for build and 30 seconds for
-publish; critical latency is twice the warning threshold. Spend is
-calendar-month-to-date UTC from the gateway ledger, with bands at 80%, 95%, and
-100% of the externally approved product budget.
+publish; critical latency is twice the warning threshold. Site Studio has no
+spend SLO or threshold ledger. Its authenticated quota endpoint relays the
+verified user's current Cloudflare Gateway estimate and returned accounting
+window as a display-only value; Site Studio does not create a local spend ledger
+or infer a budget from model prices.
 
-Contract version 3 adds the fleet projection without changing that privacy
+Contract version 4 retains the fleet projection without changing that privacy
 posture. At each trusted Worker boundary, the logger uses
 `fanoutSinks(workersStructuredSink, createAnalyticsEngineSink(...))`. The
 library owns the ordered Analytics Engine columns and the
@@ -121,9 +123,11 @@ facts, and Kale project identity.
 
 Analytics Engine counts, rates, and percentiles are weighted cohort diagnostics
 using `_sample_interval`; they are never exact lifecycle or accounting facts.
-Model spend and the native $10 model limit come from CAIL gateway/key-service
-accounting. Sandbox settlement and cost come from Sandbox accounting. Site
-Studio does not reproduce either ledger.
+Model spend, enforcement, and the authenticated quota estimate remain at the
+Cloudflare AI Gateway boundary for the verified user. The estimate is
+display-only and may lag analytics; Site Studio does not reproduce that
+accounting or invent model limits. Sandbox settlement and cost are outside this
+Site Studio observability contract.
 
 ## Decisive sources
 

--- a/packages/app/src/observability-contract.test.ts
+++ b/packages/app/src/observability-contract.test.ts
@@ -67,7 +67,7 @@ describe("observability source contract", () => {
   });
 
   it("defines queryable build and publish action seams", () => {
-    expect(OBSERVABILITY_CONTRACT_VERSION).toBe(3);
+    expect(OBSERVABILITY_CONTRACT_VERSION).toBe(4);
     expect(OBSERVABILITY_CONTRACT.actions).toEqual({
       build: {
         route: "/api/agents/site-builder/{project_id}",
@@ -161,15 +161,6 @@ describe("observability source contract", () => {
           route: "/api/projects/{id}/observability",
           schemaVersion: "site-studio.action-attempt-admin.v1",
         },
-        modelCostAndLimit: {
-          source: "cail-gateway-key-service-accounting",
-          nativeLimitUsd: 10,
-          applicationLogsAreLedger: false,
-        },
-        sandboxSettlementAndCost: {
-          source: "cail-sandbox-accounting",
-          applicationLogsAreLedger: false,
-        },
       },
     });
     expect(OBSERVABILITY_CONTRACT.access).toEqual({
@@ -179,7 +170,6 @@ describe("observability source contract", () => {
         "dashboards",
         "saved_queries",
         "monitor_configuration",
-        "spend_views",
       ],
     });
     expect(OBSERVABILITY_CONTRACT.syntheticMonitor).toMatchObject({
@@ -221,7 +211,7 @@ describe("observability source contract", () => {
     }
   });
 
-  it("versions the 24-hour SLO, action denominator, coverage, latency, and MTD spend rules", () => {
+  it("versions the 24-hour SLO, action denominator, coverage, and latency rules", () => {
     const levels = OBSERVABILITY_CONTRACT.serviceLevels;
     expect(levels.evaluation).toEqual({
       reliabilityWindowHours: 24,
@@ -317,16 +307,7 @@ describe("observability source contract", () => {
       criticalMultiplier: 2,
       minimumEligibleActions: 10,
     });
-    expect(levels.spend).toEqual({
-      source: "cail-gateway-usage-ledger",
-      productId: "site-studio",
-      window: "calendar_month_to_date_utc",
-      measure: "sum_cost_micro_usd",
-      budgetInput: "monthly_budget_micro_usd",
-      warningPercent: 80,
-      criticalPercent: 95,
-      exhaustedPercent: 100,
-    });
+    expect(levels).not.toHaveProperty("spend");
   });
 
   it("returns a stable, no-store app liveness response with null local metadata", async () => {

--- a/packages/observability-core/src/contract.ts
+++ b/packages/observability-core/src/contract.ts
@@ -15,7 +15,7 @@ import {
 import { SITE_STUDIO_MAX_FLEET_POINTS_PER_INVOCATION } from "./fleet-projection";
 import { z } from "zod";
 
-export const OBSERVABILITY_CONTRACT_VERSION = 3;
+export const OBSERVABILITY_CONTRACT_VERSION = 4;
 export const PRODUCT_ID = "site-studio";
 export const SERVICE_VERSION = "0.1.0";
 
@@ -106,15 +106,6 @@ export const OBSERVABILITY_CONTRACT = {
         route: "/api/projects/{id}/observability",
         schemaVersion: ACTION_ATTEMPT_ADMIN_SCHEMA_VERSION,
       },
-      modelCostAndLimit: {
-        source: "cail-gateway-key-service-accounting",
-        nativeLimitUsd: 10,
-        applicationLogsAreLedger: false,
-      },
-      sandboxSettlementAndCost: {
-        source: "cail-sandbox-accounting",
-        applicationLogsAreLedger: false,
-      },
     },
   },
   access: {
@@ -124,7 +115,6 @@ export const OBSERVABILITY_CONTRACT = {
       "dashboards",
       "saved_queries",
       "monitor_configuration",
-      "spend_views",
     ],
   },
   syntheticMonitor: {
@@ -237,16 +227,6 @@ export const OBSERVABILITY_CONTRACT = {
         criticalMultiplier: 2,
         minimumEligibleActions: 10,
       },
-    },
-    spend: {
-      source: "cail-gateway-usage-ledger",
-      productId: PRODUCT_ID,
-      window: "calendar_month_to_date_utc",
-      measure: "sum_cost_micro_usd",
-      budgetInput: "monthly_budget_micro_usd",
-      warningPercent: 80,
-      criticalPercent: 95,
-      exhaustedPercent: 100,
     },
   },
   dashboardViews: {


### PR DESCRIPTION
## Summary\n- remove the obsolete native $10/local spend-ledger assumptions from the exported observability contract\n- retain Site Studio's authenticated display-only Gateway quota estimate and operational diagnostics\n- update contract tests and end-state documentation\n\n## Verification\n- independent review accepted exact head b2ecc2a041ca367f0814247efe42b2994a3ce5a9\n- bun run check\n- git diff --check\n