### PR TITLE
Make published project addresses portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,9 @@ site-studio/
 ## Compatibility Position
 
 This is a greenfield product with one narrow data-preservation exception.
-Canonical published URLs are `/u/:handle/:slug/*`; the handle and slug are the
-durable public identity while `PUBLISHED_BASE_URL` is the deployment mount.
+Canonical published URLs are `/u/:handle/:slug/*`; the user's separate handle
+mapping and project slug are the durable public identity while
+`PUBLISHED_BASE_URL` is the deployment mount.
 API links derive that current base at read time, so moving the mount does not
 rewrite or republish projects. There is no `/sites` route, forwarding pointer,
 migration window, dual-read, or compatibility API. Any DNS or redirect work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,12 @@ site-studio/
 ## Compatibility Position
 
 This is a greenfield product with one narrow data-preservation exception.
-Canonical published URLs are `/u/:handle/:slug/*`; there is no `/sites` route,
-forwarding pointer, migration window, dual-read, or compatibility API.
+Canonical published URLs are `/u/:handle/:slug/*`; the handle and slug are the
+durable public identity while `PUBLISHED_BASE_URL` is the deployment mount.
+API links derive that current base at read time, so moving the mount does not
+rewrite or republish projects. There is no `/sites` route, forwarding pointer,
+migration window, dual-read, or compatibility API. Any DNS or redirect work
+for an old mount belongs to deployment configuration, not project storage.
 
 On a user's first verified CAIL login only, an old `site-studio-session` cookie
 may resolve an unexpired R2 legacy session. Its server-stored anonymous owner is

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ deployment matrix, or compatibility routing layer.
 Publishing sets live project metadata to `published: true` and reserves the
 project's durable `slug`. The single public shape is `/u/:handle/:slug/*`, where
 the handle is chosen by the user. Internal CAIL subjects never appear in public
-URLs. Project metadata stores the handle/slug identity, not a full host URL;
-the API derives the current link from `PUBLISHED_BASE_URL` at read time. Moving
+URLs. A separate owner mapping stores the handle while project metadata stores
+the slug and publication state, not a full host URL; the API derives the
+current link from `PUBLISHED_BASE_URL` at read time. Moving
 the public mount therefore changes links without rewriting or republishing
 projects. DNS and any redirects from the former mount remain deployment
 responsibilities. Editing a published project changes its public bytes;

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ sandboxed Dynamic Worker. Preview and published content are served by the app
 itself. There is no publisher service, release manifest, copied publish tree,
 deployment matrix, or compatibility routing layer.
 
-Publishing sets live project metadata to `published: true`. The single public
-shape is `/u/:handle/:slug/*`, where the handle is chosen by the user. Internal
-CAIL subjects never appear in public URLs. Editing a published project changes
-its public bytes; snapshots, not publish artifacts, provide content recovery.
+Publishing sets live project metadata to `published: true` and reserves the
+project's durable `slug`. The single public shape is `/u/:handle/:slug/*`, where
+the handle is chosen by the user. Internal CAIL subjects never appear in public
+URLs. Project metadata stores the handle/slug identity, not a full host URL;
+the API derives the current link from `PUBLISHED_BASE_URL` at read time. Moving
+the public mount therefore changes links without rewriting or republishing
+projects. DNS and any redirects from the former mount remain deployment
+responsibilities. Editing a published project changes its public bytes;
+snapshots, not publish artifacts, provide content recovery.
 
 ## Identity and model access
 

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -124,9 +124,14 @@ longer belong to the active load.
 ## Publishing and rollback
 
 Publishing reserves an owner-local slug and makes current project objects
-public at `/u/:handle/:slug/*`. There is no release generation, copied publish
-directory, manifest, publisher Worker, or publish-specific rollback. Edits and
-restores immediately change a published site's bytes.
+public at `/u/:handle/:slug/*`. The durable public identity is the verified
+handle plus project slug; project metadata does not treat a full host URL as
+authoritative. API links are derived from the current `PUBLISHED_BASE_URL`, so
+moving the public mount does not require rewriting or republishing records.
+DNS and redirects from an old mount are deployment responsibilities. There is
+no release generation, copied publish directory, manifest, publisher Worker,
+or publish-specific rollback. Edits and restores immediately change a
+published site's bytes.
 
 Published responses revalidate mutable paths with ETag and Last-Modified.
 Unpublish removes visibility but cannot revoke bytes already downloaded.

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -125,8 +125,9 @@ longer belong to the active load.
 
 Publishing reserves an owner-local slug and makes current project objects
 public at `/u/:handle/:slug/*`. The durable public identity is the verified
-handle plus project slug; project metadata does not treat a full host URL as
-authoritative. API links are derived from the current `PUBLISHED_BASE_URL`, so
+handle mapping plus project slug; project metadata does not treat a full host
+URL as authoritative. API links are derived from the current
+`PUBLISHED_BASE_URL`, so
 moving the public mount does not require rewriting or republishing records.
 DNS and redirects from an old mount are deployment responsibilities. There is
 no release generation, copied publish directory, manifest, publisher Worker,

--- a/packages/app/src/agents/mutation-coordinator.ts
+++ b/packages/app/src/agents/mutation-coordinator.ts
@@ -62,15 +62,11 @@ export class MutationCoordinator extends DurableObject<Env> {
         logging ? createSiteStudioBoundaryContext(this.env, logging) : undefined,
         createProjectHistoryLifecycle(this.env),
       ).recover(anonUserId);
-      if (!this.env.PUBLISHED_BASE_URL) {
-        throw new Error("PUBLISHED_BASE_URL is not configured");
-      }
       return migrateAnonymousData({
         bucket: this.env.SITE_STUDIO_BUCKET,
         kv: this.env.SESSION_KV,
         anonUserId,
         subject,
-        publishedBaseUrl: this.env.PUBLISHED_BASE_URL,
         anonSessionId,
         porter: createAgentHistoryPorter(this.env),
         logging: logging ? createSiteStudioBoundaryContext(this.env, logging) : undefined,

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -906,7 +906,7 @@ export function createProjectTools(
 
         // SS-18: protected system files (.metadata.json, .thumbnail.png) are
         // guarded on delete/rename; guard writes too so the agent can't overwrite
-        // .metadata.json and flip published/slug/publishedUrl.
+        // .metadata.json and flip published/slug.
         if (PROTECTED_FILE_NAMES.has(filePath.split("/").pop() || "")) {
           return {
             ok: false,

--- a/packages/app/src/lib/handles.ts
+++ b/packages/app/src/lib/handles.ts
@@ -274,28 +274,6 @@ export async function getUserHandle(bucket: R2Bucket, ownerId: string): Promise<
   return (await resolveHandleOwner(bucket, handle)) === ownerId ? handle : null;
 }
 
-/**
- * Resolve the effective public handle while an anonymous migration is being
- * retried. A crash can commit the forward `handles/{handle}` update before the
- * subject reverse record, leaving the anonymous reverse record as the only
- * durable clue. `getUserHandle` intentionally rejects that stale reverse
- * record, so migration planning needs this narrowly-scoped recovery read.
- */
-export async function getMigrationHandle(
-  bucket: R2Bucket,
-  anonUserId: string,
-  subject: string
-): Promise<string | null> {
-  const subjectHandle = await getUserHandle(bucket, subject);
-  if (subjectHandle) return subjectHandle;
-
-  const anonRecord = await readRecordedUserHandle(bucket, anonUserId);
-  if (!anonRecord) return null;
-  const anonHandle = anonRecord.record.handle;
-  const owner = await resolveHandleOwner(bucket, anonHandle);
-  return owner === anonUserId || owner === subject ? anonHandle : null;
-}
-
 export type CheckHandleResult = {
   handle: string;
   valid: boolean;

--- a/packages/app/src/lib/migration.test.ts
+++ b/packages/app/src/lib/migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { canonicalTestSubject } from "@cuny-ai-lab/cail-identity/testing";
+import { z } from "zod";
 import type { ProjectMetadata } from "../types";
 import {
   migrateAnonymousData,
@@ -110,7 +111,6 @@ function createMockKV() {
 
 const ANON = "user_anon123";
 const SUBJECT = canonicalTestSubject("migration-owner");
-const PUBLISHED_BASE_URL = "https://tools.ailab.gc.cuny.edu/site-studio";
 
 /** Copied objects are stored as strings by the mock. */
 function textOf(entry: { data: string } | undefined): string | undefined {
@@ -167,7 +167,6 @@ describe("migrateAnonymousData", () => {
       kv,
       anonUserId: ANON,
       subject: SUBJECT,
-      publishedBaseUrl: PUBLISHED_BASE_URL,
       anonSessionId: "anon-session-id",
       ...overrides
     });
@@ -473,7 +472,6 @@ describe("migrateAnonymousData", () => {
     seedAnonProject(bucket, "portfolio", {
       published: true,
       slug: "portfolio",
-      publishedUrl: "https://tools.cuny.qzz.io/u/jane-rivera/portfolio/"
     });
     kv.store.set("session:anon-session-id", JSON.stringify({ id: ANON }));
     const porter: ChatHistoryPorter = {
@@ -531,7 +529,6 @@ describe("migrateAnonymousData", () => {
     seedAnonProject(bucket, "portfolio", {
       published: true,
       slug: "portfolio",
-      publishedUrl: "https://tools.cuny.qzz.io/u/jane-rivera/portfolio/"
     });
     let attempts = 0;
     const porter: ChatHistoryPorter = {
@@ -577,7 +574,6 @@ describe("migrateAnonymousData", () => {
     seedAnonProject(bucket, "portfolio", {
       published: true,
       slug: "portfolio",
-      publishedUrl: "https://tools.cuny.qzz.io/u/jane-rivera/portfolio/"
     });
 
     const originalPut = bucket.put;
@@ -655,7 +651,7 @@ describe("handle re-homing through migration", () => {
     bucket.store.set(`userhandles/${ownerId}.json`, { data: JSON.stringify({ handle, claimedAt }) });
   }
 
-  it("moves the anon handle to a subject with none, and canonicalizes publishedUrl", async () => {
+  it("moves the anon handle to a subject with none without storing a publication URL", async () => {
     seedHandle(ANON, "jane-rivera");
     seedAnonProject(
       bucket,
@@ -663,18 +659,29 @@ describe("handle re-homing through migration", () => {
       {
         published: true,
         slug: "portfolio",
-        publishedAt: "2026-01-02T00:00:00.000Z",
-        publishedUrl: "https://tools.cuny.qzz.io/u/jane-rivera/portfolio/"
+        publishedAt: "2026-01-02T00:00:00.000Z"
       },
       "<h1>site</h1>"
     );
+    const legacyMetadataKey = `projects/${ANON}/portfolio/.metadata.json`;
+    const legacyMetadata = z.object({
+      id: z.string(),
+      name: z.string(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      published: z.boolean(),
+      publishedAt: z.string().optional(),
+      slug: z.string().optional(),
+      publishedUrl: z.string().optional(),
+    }).parse(JSON.parse(bucket.store.get(legacyMetadataKey)!.data));
+    legacyMetadata.publishedUrl = "https://old.example/u/jane-rivera/portfolio/";
+    bucket.store.set(legacyMetadataKey, { data: JSON.stringify(legacyMetadata) });
 
     await migrateAnonymousData({
       bucket,
       kv,
       anonUserId: ANON,
       subject: SUBJECT,
-      publishedBaseUrl: PUBLISHED_BASE_URL,
     });
 
     // Handle re-homed: record points at subject, reverse record moved.
@@ -685,10 +692,11 @@ describe("handle re-homing through migration", () => {
       claimedAt: "1970-01-01T00:00:00.000Z",
     });
 
-    // Migrated project's publishedUrl uses the handle, never the subject id.
+    // Publication addresses are derived from the current base and are not
+    // copied into project metadata during migration.
     const meta = JSON.parse(bucket.store.get(`projects/${SUBJECT}/portfolio/.metadata.json`)!.data);
-    expect(meta.publishedUrl).toBe(`${PUBLISHED_BASE_URL}/u/jane-rivera/portfolio/`);
-    expect(meta.publishedUrl).not.toContain(SUBJECT);
+    expect(meta.publishedUrl).toBeUndefined();
+    expect(JSON.stringify(meta)).not.toContain("old.example");
   });
 
   it("keeps the subject's primary handle but re-points the anon handle as an alias", async () => {
@@ -701,7 +709,6 @@ describe("handle re-homing through migration", () => {
       kv,
       anonUserId: ANON,
       subject: SUBJECT,
-      publishedBaseUrl: PUBLISHED_BASE_URL,
     });
 
     // Subject keeps its own primary.

--- a/packages/app/src/lib/migration.test.ts
+++ b/packages/app/src/lib/migration.test.ts
@@ -7,10 +7,13 @@ import {
   migrationClaimKey,
   migrationPendingKey,
   type ChatHistoryPorter,
-  type MigrationClaim
+  type MigrationClaim,
 } from "./migration";
 import { getUserHandle } from "./handles";
-import { createMockKV as createSharedMockKV, createTestR2Object } from "./test-utils";
+import {
+  createMockKV as createSharedMockKV,
+  createTestR2Object,
+} from "./test-utils";
 
 function testConditional(options?: R2PutOptions): R2Conditional | undefined {
   const conditional = options?.onlyIf;
@@ -25,7 +28,10 @@ function testMetadata(options?: R2PutOptions): R2HTTPMetadata | undefined {
 // Mock R2 bucket (same shape as storage/r2.test.ts).
 function createMockBucket() {
   let revision = 0;
-  const store = new Map<string, { data: string; httpMetadata?: R2HTTPMetadata; etag?: string }>();
+  const store = new Map<
+    string,
+    { data: string; httpMetadata?: R2HTTPMetadata; etag?: string }
+  >();
 
   function textData(data: string | ArrayBuffer | Uint8Array): string {
     if (data instanceof ArrayBuffer) return new TextDecoder().decode(data);
@@ -50,25 +56,38 @@ function createMockBucket() {
         size: entry.data.length,
         httpMetadata: entry.httpMetadata || {},
         text: async () => entry.data,
-        arrayBuffer: async () => new TextEncoder().encode(entry.data).buffer
+        arrayBuffer: async () => new TextEncoder().encode(entry.data).buffer,
       };
     }),
-    put: vi.fn(async (key: string, data: string | ArrayBuffer | Uint8Array, options?: R2PutOptions) => {
-      // Honor R2 put-if-absent: onlyIf.etagDoesNotMatch:"*" writes only when
-      // the key is empty; a failed condition returns null (no write, no throw).
-      // migrateHandle's promotion (SS-52) relies on this contract.
-      const conditional = testConditional(options);
-      if (conditional?.etagDoesNotMatch === "*" && store.has(key)) {
-        return null;
-      }
-      if (conditional?.etagMatches && store.get(key)?.etag !== conditional.etagMatches) {
-        return null;
-      }
-      const text = textData(data);
-      const etag = `etag-${++revision}`;
-      store.set(key, { data: text, httpMetadata: testMetadata(options), etag });
-      return createTestR2Object(key, etag, text.length);
-    }),
+    put: vi.fn(
+      async (
+        key: string,
+        data: string | ArrayBuffer | Uint8Array,
+        options?: R2PutOptions,
+      ) => {
+        // Honor R2 put-if-absent: onlyIf.etagDoesNotMatch:"*" writes only when
+        // the key is empty; a failed condition returns null (no write, no throw).
+        // migrateHandle's promotion (SS-52) relies on this contract.
+        const conditional = testConditional(options);
+        if (conditional?.etagDoesNotMatch === "*" && store.has(key)) {
+          return null;
+        }
+        if (
+          conditional?.etagMatches &&
+          store.get(key)?.etag !== conditional.etagMatches
+        ) {
+          return null;
+        }
+        const text = textData(data);
+        const etag = `etag-${++revision}`;
+        store.set(key, {
+          data: text,
+          httpMetadata: testMetadata(options),
+          etag,
+        });
+        return createTestR2Object(key, etag, text.length);
+      },
+    ),
     delete: vi.fn(async (key: string) => {
       store.delete(key);
     }),
@@ -83,7 +102,8 @@ function createMockBucket() {
           const rest = key.slice(prefix?.length || 0);
           const delimIndex = rest.indexOf(delimiter);
           if (delimIndex >= 0) {
-            const delimitedPrefix = (prefix || "") + rest.slice(0, delimIndex + 1);
+            const delimitedPrefix =
+              (prefix || "") + rest.slice(0, delimIndex + 1);
             if (!delimitedPrefixes.includes(delimitedPrefix)) {
               delimitedPrefixes.push(delimitedPrefix);
             }
@@ -97,12 +117,21 @@ function createMockBucket() {
       return {
         objects: limit ? objects.slice(0, limit) : objects,
         truncated: false,
-        delimitedPrefixes
+        delimitedPrefixes,
       };
     }),
-    createMultipartUpload: vi.fn(async () => { throw new Error("multipart upload is not part of this fixture"); }),
-    resumeMultipartUpload: vi.fn(() => { throw new Error("multipart upload is not part of this fixture"); })
-  } as R2Bucket & { store: Map<string, { data: string; httpMetadata?: R2HTTPMetadata; etag?: string }> };
+    createMultipartUpload: vi.fn(async () => {
+      throw new Error("multipart upload is not part of this fixture");
+    }),
+    resumeMultipartUpload: vi.fn(() => {
+      throw new Error("multipart upload is not part of this fixture");
+    }),
+  } as R2Bucket & {
+    store: Map<
+      string,
+      { data: string; httpMetadata?: R2HTTPMetadata; etag?: string }
+    >;
+  };
 }
 
 function createMockKV() {
@@ -125,7 +154,7 @@ function metadataFor(id: string, extra: Partial<ProjectMetadata> = {}): string {
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     published: false,
-    ...extra
+    ...extra,
   } satisfies ProjectMetadata);
 }
 
@@ -133,10 +162,14 @@ function seedAnonProject(
   bucket: ReturnType<typeof createMockBucket>,
   projectId: string,
   extra: Partial<ProjectMetadata> = {},
-  content = `<h1>${projectId} (anon)</h1>`
+  content = `<h1>${projectId} (anon)</h1>`,
 ) {
-  bucket.store.set(`projects/${ANON}/${projectId}/.metadata.json`, { data: metadataFor(projectId, extra) });
-  bucket.store.set(`projects/${ANON}/${projectId}/index.html`, { data: content });
+  bucket.store.set(`projects/${ANON}/${projectId}/.metadata.json`, {
+    data: metadataFor(projectId, extra),
+  });
+  bucket.store.set(`projects/${ANON}/${projectId}/index.html`, {
+    data: content,
+  });
 }
 
 function seedAnonHandle(
@@ -145,10 +178,10 @@ function seedAnonHandle(
 ) {
   const claimedAt = "2026-01-01T00:00:00.000Z";
   bucket.store.set(`handles/${handle}.json`, {
-    data: JSON.stringify({ ownerId: ANON, claimedAt })
+    data: JSON.stringify({ ownerId: ANON, claimedAt }),
   });
   bucket.store.set(`userhandles/${ANON}.json`, {
-    data: JSON.stringify({ handle, claimedAt })
+    data: JSON.stringify({ handle, claimedAt }),
   });
 }
 
@@ -161,31 +194,46 @@ describe("migrateAnonymousData", () => {
     kv = createMockKV();
   });
 
-  const run = (overrides: Partial<Parameters<typeof migrateAnonymousData>[0]> = {}) =>
+  const run = (
+    overrides: Partial<Parameters<typeof migrateAnonymousData>[0]> = {},
+  ) =>
     migrateAnonymousData({
       bucket,
       kv,
       anonUserId: ANON,
       subject: SUBJECT,
       anonSessionId: "anon-session-id",
-      ...overrides
+      ...overrides,
     });
 
   it("migrates projects, snapshots, and uploads into the subject namespace (happy path)", async () => {
     seedAnonProject(bucket, "portfolio");
-    bucket.store.set(`projects/${ANON}/portfolio/styles.css`, { data: "body{}" });
-    bucket.store.set(`snapshots/${ANON}/portfolio/snap1.zip`, { data: "zipbytes" });
+    bucket.store.set(`projects/${ANON}/portfolio/styles.css`, {
+      data: "body{}",
+    });
+    bucket.store.set(`snapshots/${ANON}/portfolio/snap1.zip`, {
+      data: "zipbytes",
+    });
     bucket.store.set(`snapshots/${ANON}/portfolio/snap1.json`, {
-      data: JSON.stringify({ id: "snap1", createdAt: "2026-01-02T00:00:00.000Z", projectId: "portfolio", trigger: "manual", fileCount: 2 })
+      data: JSON.stringify({
+        id: "snap1",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        projectId: "portfolio",
+        trigger: "manual",
+        fileCount: 2,
+      }),
     });
     bucket.store.set(`uploads/${ANON}/paper.pdf`, { data: "pdfbytes" });
-    kv.store.set("session:anon-session-id", JSON.stringify({ id: ANON, createdAt: "2026-01-01T00:00:00.000Z" }));
+    kv.store.set(
+      "session:anon-session-id",
+      JSON.stringify({ id: ANON, createdAt: "2026-01-01T00:00:00.000Z" }),
+    );
 
     const ported: string[] = [];
     const porter: ChatHistoryPorter = {
       port: async (fromOwner, fromId, toOwner, toId) => {
         ported.push(`${fromOwner}:${fromId}->${toOwner}:${toId}`);
-      }
+      },
     };
 
     const result = await run({ porter });
@@ -193,14 +241,24 @@ describe("migrateAnonymousData", () => {
     expect(result.projects).toEqual({ portfolio: "portfolio" });
 
     // Subject now owns the data.
-    const meta = JSON.parse(bucket.store.get(`projects/${SUBJECT}/portfolio/.metadata.json`)!.data);
+    const meta = JSON.parse(
+      bucket.store.get(`projects/${SUBJECT}/portfolio/.metadata.json`)!.data,
+    );
     expect(meta.id).toBe("portfolio");
     expect(meta.importedFrom).toBe(ANON);
     expect(meta.importedOriginalId).toBe("portfolio");
-    expect(textOf(bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`))).toContain("(anon)");
-    expect(bucket.store.get(`projects/${SUBJECT}/portfolio/styles.css`)).toBeTruthy();
-    expect(bucket.store.get(`snapshots/${SUBJECT}/portfolio/snap1.zip`)).toBeTruthy();
-    const snapRecord = JSON.parse(bucket.store.get(`snapshots/${SUBJECT}/portfolio/snap1.json`)!.data);
+    expect(
+      textOf(bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`)),
+    ).toContain("(anon)");
+    expect(
+      bucket.store.get(`projects/${SUBJECT}/portfolio/styles.css`),
+    ).toBeTruthy();
+    expect(
+      bucket.store.get(`snapshots/${SUBJECT}/portfolio/snap1.zip`),
+    ).toBeTruthy();
+    const snapRecord = JSON.parse(
+      bucket.store.get(`snapshots/${SUBJECT}/portfolio/snap1.json`)!.data,
+    );
     expect(snapRecord.projectId).toBe("portfolio");
     expect(bucket.store.get(`uploads/${SUBJECT}/paper.pdf`)).toBeTruthy();
 
@@ -208,14 +266,24 @@ describe("migrateAnonymousData", () => {
     expect(ported).toEqual([`${ANON}:portfolio->${SUBJECT}:portfolio`]);
 
     // Originals are retired after the complete copy.
-    expect(bucket.store.get(`projects/${ANON}/portfolio/index.html`)).toBeUndefined();
-    expect(bucket.store.get(`snapshots/${ANON}/portfolio/snap1.zip`)).toBeUndefined();
+    expect(
+      bucket.store.get(`projects/${ANON}/portfolio/index.html`),
+    ).toBeUndefined();
+    expect(
+      bucket.store.get(`snapshots/${ANON}/portfolio/snap1.zip`),
+    ).toBeUndefined();
     expect(bucket.store.get(`uploads/${ANON}/paper.pdf`)).toBeUndefined();
-    expect([...bucket.store.keys()].some((key) => key.startsWith(`projects/${ANON}/`))).toBe(false);
+    expect(
+      [...bucket.store.keys()].some((key) =>
+        key.startsWith(`projects/${ANON}/`),
+      ),
+    ).toBe(false);
 
     // Claim recorded complete; anon session and pending marker cleared.
     // SAFETY: The migration service writes this KV value from the MigrationClaim schema.
-    const claim = JSON.parse(kv.store.get(migrationClaimKey(ANON))!) as MigrationClaim;
+    const claim = JSON.parse(
+      kv.store.get(migrationClaimKey(ANON))!,
+    ) as MigrationClaim;
     expect(claim).toMatchObject({ subject: SUBJECT, status: "complete" });
     expect(kv.store.has("session:anon-session-id")).toBe(false);
     expect(kv.store.has(migrationPendingKey(SUBJECT))).toBe(false);
@@ -226,7 +294,7 @@ describe("migrateAnonymousData", () => {
     await run();
 
     const snapshotBefore = new Map(
-      [...bucket.store.entries()].map(([k, v]) => [k, v.data])
+      [...bucket.store.entries()].map(([k, v]) => [k, v.data]),
     );
     const second = await run();
 
@@ -239,8 +307,12 @@ describe("migrateAnonymousData", () => {
 
   it("merges without overwriting: colliding project ids are suffixed, subject data untouched", async () => {
     // Subject already owns "site" with its own content.
-    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, { data: metadataFor("site") });
-    bucket.store.set(`projects/${SUBJECT}/site/index.html`, { data: "<h1>subject original</h1>" });
+    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, {
+      data: metadataFor("site", { published: true, slug: "site" }),
+    });
+    bucket.store.set(`projects/${SUBJECT}/site/index.html`, {
+      data: "<h1>subject original</h1>",
+    });
 
     // Anonymous namespace has a colliding "site" and a non-colliding "blog".
     seedAnonProject(bucket, "site");
@@ -251,14 +323,23 @@ describe("migrateAnonymousData", () => {
     expect(result.projects).toEqual({ site: "site-imported", blog: "blog" });
 
     // Subject's original is byte-identical.
-    expect(bucket.store.get(`projects/${SUBJECT}/site/index.html`)!.data).toBe("<h1>subject original</h1>");
+    expect(bucket.store.get(`projects/${SUBJECT}/site/index.html`)!.data).toBe(
+      "<h1>subject original</h1>",
+    );
     // Incoming copy lives under the suffixed id with its own content.
-    const imported = JSON.parse(bucket.store.get(`projects/${SUBJECT}/site-imported/.metadata.json`)!.data);
+    const imported = JSON.parse(
+      bucket.store.get(`projects/${SUBJECT}/site-imported/.metadata.json`)!
+        .data,
+    );
     expect(imported.id).toBe("site-imported");
     expect(imported.importedOriginalId).toBe("site");
-    expect(textOf(bucket.store.get(`projects/${SUBJECT}/site-imported/index.html`))).toContain("(anon)");
+    expect(
+      textOf(bucket.store.get(`projects/${SUBJECT}/site-imported/index.html`)),
+    ).toContain("(anon)");
     // Non-colliding project keeps its id.
-    expect(bucket.store.get(`projects/${SUBJECT}/blog/index.html`)).toBeTruthy();
+    expect(
+      bucket.store.get(`projects/${SUBJECT}/blog/index.html`),
+    ).toBeTruthy();
   });
 
   it("preserves both namespaces when a subject write wins the copy-if-absent race", async () => {
@@ -268,21 +349,27 @@ describe("migrateAnonymousData", () => {
     let injected = false;
     // SAFETY: This replacement preserves the R2 put signature while injecting
     // a subject-side writer for the copy-if-absent race.
-    bucket.put = vi.fn(async (key: string, data: string, options?: R2PutOptions) => {
-      if (key === destination && !injected) {
-        injected = true;
-        await originalPut(destination, "<h1>subject concurrent edit</h1>");
-      }
-      return originalPut(key, data, options);
-    });
+    bucket.put = vi.fn(
+      async (key: string, data: string, options?: R2PutOptions) => {
+        if (key === destination && !injected) {
+          injected = true;
+          await originalPut(destination, "<h1>subject concurrent edit</h1>");
+        }
+        return originalPut(key, data, options);
+      },
+    );
 
     await expect(run()).rejects.toThrow("destination changed");
-    expect(textOf(bucket.store.get(destination))).toBe("<h1>subject concurrent edit</h1>");
-    expect(textOf(bucket.store.get(`projects/${ANON}/portfolio/index.html`))).toBe(
-      "<h1>anonymous source</h1>"
+    expect(textOf(bucket.store.get(destination))).toBe(
+      "<h1>subject concurrent edit</h1>",
     );
+    expect(
+      textOf(bucket.store.get(`projects/${ANON}/portfolio/index.html`)),
+    ).toBe("<h1>anonymous source</h1>");
     // SAFETY: The failed migration leaves the claim in its documented pending shape.
-    const claim = JSON.parse(kv.store.get(migrationClaimKey(ANON))!) as MigrationClaim;
+    const claim = JSON.parse(
+      kv.store.get(migrationClaimKey(ANON))!,
+    ) as MigrationClaim;
     expect(claim.status).toBe("pending");
   });
 
@@ -291,13 +378,20 @@ describe("migrateAnonymousData", () => {
     await run(); // SUBJECT claims and completes
 
     const otherSubject = canonicalTestSubject("other-owner");
-    const result = await run({ subject: otherSubject, anonSessionId: undefined });
+    const result = await run({
+      subject: otherSubject,
+      anonSessionId: undefined,
+    });
 
     expect(result.status).toBe("refused");
     // SAFETY: The completed first claim is stored using the MigrationClaim schema.
-    const claim = JSON.parse(kv.store.get(migrationClaimKey(ANON))!) as MigrationClaim;
+    const claim = JSON.parse(
+      kv.store.get(migrationClaimKey(ANON))!,
+    ) as MigrationClaim;
     expect(claim.subject).toBe(SUBJECT); // original claim untouched
-    const otherKeys = [...bucket.store.keys()].filter((k) => k.includes(otherSubject));
+    const otherKeys = [...bucket.store.keys()].filter((k) =>
+      k.includes(otherSubject),
+    );
     expect(otherKeys).toEqual([]);
   });
 
@@ -318,23 +412,32 @@ describe("migrateAnonymousData", () => {
     await expect(run()).rejects.toThrow("KV read failed");
 
     // The guard was NOT bypassed: nothing was copied into the subject namespace.
-    const subjectKeys = [...bucket.store.keys()].filter((k) => k.includes(SUBJECT));
+    const subjectKeys = [...bucket.store.keys()].filter((k) =>
+      k.includes(SUBJECT),
+    );
     expect(subjectKeys).toEqual([]);
   });
 
   it("refuses non-anonymous ids (never migrates a subject namespace)", async () => {
-    const result = await run({ anonUserId: canonicalTestSubject("non-anonymous-id") });
+    const result = await run({
+      anonUserId: canonicalTestSubject("non-anonymous-id"),
+    });
     expect(result.status).toBe("refused");
     expect(kv.store.size).toBe(0);
   });
 
   it("completes with nothing-to-migrate when the anonymous namespace is empty", async () => {
-    kv.store.set("session:anon-session-id", JSON.stringify({ id: ANON, createdAt: "2026-01-01T00:00:00.000Z" }));
+    kv.store.set(
+      "session:anon-session-id",
+      JSON.stringify({ id: ANON, createdAt: "2026-01-01T00:00:00.000Z" }),
+    );
     const result = await run();
 
     expect(result.status).toBe("nothing-to-migrate");
     // SAFETY: The empty migration records completion using the MigrationClaim schema.
-    const claim = JSON.parse(kv.store.get(migrationClaimKey(ANON))!) as MigrationClaim;
+    const claim = JSON.parse(
+      kv.store.get(migrationClaimKey(ANON))!,
+    ) as MigrationClaim;
     expect(claim.status).toBe("complete");
     expect(kv.store.has("session:anon-session-id")).toBe(false);
   });
@@ -345,7 +448,11 @@ describe("migrateAnonymousData", () => {
    * result is computed, so the listing that triggered the injection does not
    * see them — simulating a direct file-API write racing the migration.
    */
-  function injectAfterList(triggerPrefix: string, nth: number, inject: () => void) {
+  function injectAfterList(
+    triggerPrefix: string,
+    nth: number,
+    inject: () => void,
+  ) {
     const original = bucket.list.bind(bucket);
     let count = 0;
     bucket.list = vi.fn(async (options: R2ListOptions = {}) => {
@@ -366,7 +473,7 @@ describe("migrateAnonymousData", () => {
     // caught by the delete pass — silently lost.
     injectAfterList(`projects/${ANON}/portfolio/`, 1, () => {
       bucket.store.set(`projects/${ANON}/portfolio/late-edit.html`, {
-        data: "<h1>written mid-migration</h1>"
+        data: "<h1>written mid-migration</h1>",
       });
     });
 
@@ -374,11 +481,13 @@ describe("migrateAnonymousData", () => {
     expect(result.status).toBe("migrated");
 
     // The mid-run write survived into the subject namespace...
-    expect(textOf(bucket.store.get(`projects/${SUBJECT}/portfolio/late-edit.html`))).toContain(
-      "written mid-migration"
-    );
+    expect(
+      textOf(bucket.store.get(`projects/${SUBJECT}/portfolio/late-edit.html`)),
+    ).toContain("written mid-migration");
     // ...and the anon original is gone.
-    const anonKeys = [...bucket.store.keys()].filter((k) => k.startsWith(`projects/${ANON}/`));
+    const anonKeys = [...bucket.store.keys()].filter((k) =>
+      k.startsWith(`projects/${ANON}/`),
+    );
     expect(anonKeys).toEqual([]);
   });
 
@@ -389,20 +498,33 @@ describe("migrateAnonymousData", () => {
     // the first sweep's plan listing. A project created right after #2 was,
     // before this fix, never planned or copied yet still deleted.
     injectAfterList(`projects/${ANON}/`, 2, () => {
-      bucket.store.set(`projects/${ANON}/newproj/.metadata.json`, { data: metadataFor("newproj") });
-      bucket.store.set(`projects/${ANON}/newproj/index.html`, { data: "<h1>newproj (anon)</h1>" });
+      bucket.store.set(`projects/${ANON}/newproj/.metadata.json`, {
+        data: metadataFor("newproj"),
+      });
+      bucket.store.set(`projects/${ANON}/newproj/index.html`, {
+        data: "<h1>newproj (anon)</h1>",
+      });
     });
 
     const result = await run();
     expect(result.status).toBe("migrated");
-    expect(result.projects).toEqual({ portfolio: "portfolio", newproj: "newproj" });
+    expect(result.projects).toEqual({
+      portfolio: "portfolio",
+      newproj: "newproj",
+    });
 
     // The mid-run project survived into the subject namespace...
-    const meta = JSON.parse(bucket.store.get(`projects/${SUBJECT}/newproj/.metadata.json`)!.data);
+    const meta = JSON.parse(
+      bucket.store.get(`projects/${SUBJECT}/newproj/.metadata.json`)!.data,
+    );
     expect(meta.importedFrom).toBe(ANON);
-    expect(textOf(bucket.store.get(`projects/${SUBJECT}/newproj/index.html`))).toContain("newproj (anon)");
+    expect(
+      textOf(bucket.store.get(`projects/${SUBJECT}/newproj/index.html`)),
+    ).toContain("newproj (anon)");
     // ...and the anon originals are gone.
-    const anonKeys = [...bucket.store.keys()].filter((k) => k.startsWith(`projects/${ANON}/`));
+    const anonKeys = [...bucket.store.keys()].filter((k) =>
+      k.startsWith(`projects/${ANON}/`),
+    );
     expect(anonKeys).toEqual([]);
   });
 
@@ -411,8 +533,12 @@ describe("migrateAnonymousData", () => {
     // second sweep must resolve the SAME anon project to the SAME subject id
     // (via the importedFrom stamp) instead of re-suffixing, and must not
     // overwrite the metadata or files the first sweep wrote.
-    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, { data: metadataFor("site") });
-    bucket.store.set(`projects/${SUBJECT}/site/index.html`, { data: "<h1>subject original</h1>" });
+    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, {
+      data: metadataFor("site"),
+    });
+    bucket.store.set(`projects/${SUBJECT}/site/index.html`, {
+      data: "<h1>subject original</h1>",
+    });
     seedAnonProject(bucket, "site");
 
     const result = await run();
@@ -423,18 +549,164 @@ describe("migrateAnonymousData", () => {
     const importedIds = new Set(
       [...bucket.store.keys()]
         .filter((k) => k.startsWith(`projects/${SUBJECT}/`))
-        .map((k) => k.slice(`projects/${SUBJECT}/`.length).split("/")[0])
+        .map((k) => k.slice(`projects/${SUBJECT}/`.length).split("/")[0]),
     );
     expect([...importedIds].sort()).toEqual(["site", "site-imported"]);
-    expect(bucket.store.get(`projects/${SUBJECT}/site/index.html`)!.data).toBe("<h1>subject original</h1>");
+    expect(bucket.store.get(`projects/${SUBJECT}/site/index.html`)!.data).toBe(
+      "<h1>subject original</h1>",
+    );
+  });
+
+  it("repairs an older stamped metadata partial on retry without duplicating the project", async () => {
+    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, {
+      data: metadataFor("site", { published: true, slug: "site" }),
+    });
+    bucket.store.set(`projects/${SUBJECT}/site/index.html`, {
+      data: "<h1>subject original</h1>",
+    });
+    seedAnonProject(bucket, "site", { published: true, slug: "site" });
+    seedAnonHandle(bucket, "jane-rivera");
+
+    const legacyDestination = z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+        published: z.boolean(),
+        publishedAt: z.string().optional(),
+        slug: z.string().optional(),
+        importedFrom: z.string().optional(),
+        importedOriginalId: z.string().optional(),
+        publishedUrl: z.string().optional(),
+      })
+      .parse(
+        JSON.parse(metadataFor("site", { published: true, slug: "site-2" })),
+      );
+    legacyDestination.id = "site-imported";
+    legacyDestination.importedFrom = ANON;
+    legacyDestination.importedOriginalId = "site";
+    legacyDestination.publishedUrl =
+      "https://old.example/u/jane-rivera/site-2/";
+    bucket.store.set(`projects/${SUBJECT}/site-imported/.metadata.json`, {
+      data: JSON.stringify(legacyDestination),
+    });
+    bucket.store.set(`projects/${SUBJECT}/site-imported/index.html`, {
+      data: "<h1>site (anon)</h1>",
+    });
+    kv.store.set(
+      migrationClaimKey(ANON),
+      JSON.stringify({
+        subject: SUBJECT,
+        status: "pending",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      } satisfies MigrationClaim),
+    );
+    kv.store.set(migrationPendingKey(SUBJECT), ANON);
+
+    const result = await run();
+
+    expect(result).toMatchObject({
+      status: "migrated",
+      projects: { site: "site-imported" },
+    });
+    const repaired = JSON.parse(
+      bucket.store.get(`projects/${SUBJECT}/site-imported/.metadata.json`)!
+        .data,
+    );
+    expect(repaired).toMatchObject({
+      id: "site-imported",
+      published: true,
+      slug: "site-2",
+      importedFrom: ANON,
+      importedOriginalId: "site",
+    });
+    expect(repaired.publishedUrl).toBeUndefined();
+    expect(
+      textOf(bucket.store.get(`projects/${SUBJECT}/site-imported/index.html`)),
+    ).toBe("<h1>site (anon)</h1>");
+    expect(
+      [
+        ...new Set(
+          [...bucket.store.keys()]
+            .filter((key) => key.startsWith(`projects/${SUBJECT}/`))
+            .map((key) =>
+              key.slice(`projects/${SUBJECT}/`.length).split("/")[0],
+            ),
+        ),
+      ],
+    ).toEqual(["site", "site-imported"]);
+    expect(
+      [...bucket.store.keys()].some((key) =>
+        key.startsWith(`projects/${ANON}/`),
+      ),
+    ).toBe(false);
+    expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!).status).toBe(
+      "complete",
+    );
+  });
+
+  it("keeps the source when a stamped legacy destination has another change", async () => {
+    bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, {
+      data: metadataFor("site", { published: true, slug: "site" }),
+    });
+    seedAnonProject(bucket, "site", { published: true, slug: "site" });
+
+    const legacyDestination = z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+        published: z.boolean(),
+        slug: z.string().optional(),
+        importedFrom: z.string().optional(),
+        importedOriginalId: z.string().optional(),
+        publishedUrl: z.string().optional(),
+      })
+      .parse(
+        JSON.parse(metadataFor("site", { published: true, slug: "site-2" })),
+      );
+    legacyDestination.id = "site-imported";
+    legacyDestination.name = "changed after partial copy";
+    legacyDestination.importedFrom = ANON;
+    legacyDestination.importedOriginalId = "site";
+    legacyDestination.publishedUrl =
+      "https://old.example/u/jane-rivera/site-2/";
+    bucket.store.set(`projects/${SUBJECT}/site-imported/.metadata.json`, {
+      data: JSON.stringify(legacyDestination),
+    });
+    kv.store.set(
+      migrationClaimKey(ANON),
+      JSON.stringify({
+        subject: SUBJECT,
+        status: "pending",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      } satisfies MigrationClaim),
+    );
+    kv.store.set(migrationPendingKey(SUBJECT), ANON);
+
+    await expect(run()).rejects.toThrow("destination changed");
+    expect(
+      bucket.store.has(`projects/${ANON}/site/.metadata.json`),
+    ).toBe(true);
+    expect(
+      JSON.parse(
+        bucket.store.get(`projects/${SUBJECT}/site-imported/.metadata.json`)!
+          .data,
+      ).publishedUrl,
+    ).toBe("https://old.example/u/jane-rivera/site-2/");
+    expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!).status).toBe(
+      "pending",
+    );
   });
 
   it("resumes after partial source deletion without duplicating imported projects", async () => {
     bucket.store.set(`projects/${SUBJECT}/site/.metadata.json`, {
-      data: metadataFor("site", { published: true, slug: "site" })
+      data: metadataFor("site", { published: true, slug: "site" }),
     });
     bucket.store.set(`projects/${SUBJECT}/site/index.html`, {
-      data: "<h1>subject site</h1>"
+      data: "<h1>subject site</h1>",
     });
     seedAnonProject(bucket, "site", { published: true, slug: "site" });
     seedAnonProject(bucket, "notes", { published: true, slug: "notes" });
@@ -452,19 +724,35 @@ describe("migrateAnonymousData", () => {
     });
 
     await expect(run()).rejects.toThrow("injected delete interruption");
-    expect(bucket.store.has(`projects/${SUBJECT}/site-imported/.metadata.json`)).toBe(true);
-    expect(bucket.store.has(`projects/${SUBJECT}/notes/.metadata.json`)).toBe(true);
-    expect(bucket.store.has(`projects/${ANON}/site/.metadata.json`)).toBe(false);
-    expect(bucket.store.has(`projects/${ANON}/notes/.metadata.json`)).toBe(true);
+    expect(
+      bucket.store.has(`projects/${SUBJECT}/site-imported/.metadata.json`),
+    ).toBe(true);
+    expect(bucket.store.has(`projects/${SUBJECT}/notes/.metadata.json`)).toBe(
+      true,
+    );
+    expect(bucket.store.has(`projects/${ANON}/site/.metadata.json`)).toBe(
+      false,
+    );
+    expect(bucket.store.has(`projects/${ANON}/notes/.metadata.json`)).toBe(
+      true,
+    );
 
     await expect(run()).resolves.toMatchObject({ status: "migrated" });
     const subjectProjectIds = new Set(
       [...bucket.store.keys()]
         .filter((key) => key.startsWith(`projects/${SUBJECT}/`))
-        .map((key) => key.slice(`projects/${SUBJECT}/`.length).split("/")[0])
+        .map((key) => key.slice(`projects/${SUBJECT}/`.length).split("/")[0]),
     );
-    expect([...subjectProjectIds].sort()).toEqual(["notes", "site", "site-imported"]);
-    expect([...bucket.store.keys()].filter((key) => key.startsWith(`projects/${ANON}/`))).toEqual([]);
+    expect([...subjectProjectIds].sort()).toEqual([
+      "notes",
+      "site",
+      "site-imported",
+    ]);
+    expect(
+      [...bucket.store.keys()].filter((key) =>
+        key.startsWith(`projects/${ANON}/`),
+      ),
+    ).toEqual([]);
   });
 
   it("fails closed when chat history export is unavailable", async () => {
@@ -477,15 +765,21 @@ describe("migrateAnonymousData", () => {
     const porter: ChatHistoryPorter = {
       port: async () => {
         throw new Error("anonymous chat export unavailable");
-      }
+      },
     };
 
-    await expect(run({ porter })).rejects.toThrow("Chat history migration failed");
+    await expect(run({ porter })).rejects.toThrow(
+      "Chat history migration failed",
+    );
 
     // File copies may precede the chat call, but the source remains available
     // because no completion claim was written.
-    expect(bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`)).toBeTruthy();
-    expect(bucket.store.get(`projects/${ANON}/portfolio/index.html`)).toBeTruthy();
+    expect(
+      bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`),
+    ).toBeTruthy();
+    expect(
+      bucket.store.get(`projects/${ANON}/portfolio/index.html`),
+    ).toBeTruthy();
     expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!)).toMatchObject({
       subject: SUBJECT,
       status: "pending",
@@ -494,14 +788,18 @@ describe("migrateAnonymousData", () => {
     expect(kv.store.get(migrationPendingKey(SUBJECT))).toBe(ANON);
     // Handle ownership and the old published namespace remain authoritative
     // until chat history can be imported on a retry.
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(ANON);
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(ANON);
     expect(bucket.store.has(`userhandles/${ANON}.json`)).toBe(true);
     expect(bucket.store.has(`userhandles/${SUBJECT}.json`)).toBe(false);
   });
 
   it("retains the anonymous source when snapshot metadata is invalid", async () => {
     seedAnonProject(bucket, "portfolio");
-    bucket.store.set(`snapshots/${ANON}/portfolio/snap1.zip`, { data: "zipbytes" });
+    bucket.store.set(`snapshots/${ANON}/portfolio/snap1.zip`, {
+      data: "zipbytes",
+    });
     bucket.store.set(`snapshots/${ANON}/portfolio/snap1.json`, {
       data: JSON.stringify({
         id: "snap1",
@@ -516,8 +814,12 @@ describe("migrateAnonymousData", () => {
 
     // The strict snapshot schema must fail before migration reaches source
     // deletion. Both the archive and its invalid record remain recoverable.
-    expect(bucket.store.has(`snapshots/${ANON}/portfolio/snap1.zip`)).toBe(true);
-    expect(bucket.store.has(`snapshots/${ANON}/portfolio/snap1.json`)).toBe(true);
+    expect(bucket.store.has(`snapshots/${ANON}/portfolio/snap1.zip`)).toBe(
+      true,
+    );
+    expect(bucket.store.has(`snapshots/${ANON}/portfolio/snap1.json`)).toBe(
+      true,
+    );
     expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!)).toMatchObject({
       subject: SUBJECT,
       status: "pending",
@@ -537,36 +839,56 @@ describe("migrateAnonymousData", () => {
         if (attempts === 1) {
           throw new Error("subject chat import unavailable");
         }
-      }
+      },
     };
 
-    await expect(run({ porter })).rejects.toThrow("Chat history migration failed");
-    expect(bucket.store.get(`projects/${ANON}/portfolio/index.html`)).toBeTruthy();
+    await expect(run({ porter })).rejects.toThrow(
+      "Chat history migration failed",
+    );
+    expect(
+      bucket.store.get(`projects/${ANON}/portfolio/index.html`),
+    ).toBeTruthy();
     expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!)).toMatchObject({
       subject: SUBJECT,
       status: "pending",
     });
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(ANON);
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(ANON);
     expect(bucket.store.has(`userhandles/${ANON}.json`)).toBe(true);
     expect(bucket.store.has(`userhandles/${SUBJECT}.json`)).toBe(false);
 
     const retry = await run({ porter });
     expect(retry.status).toBe("migrated");
     expect(attempts).toBe(2);
-    expect(bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`)).toBeTruthy();
-    expect(bucket.store.get(`projects/${ANON}/portfolio/index.html`)).toBeUndefined();
-    expect([...bucket.store.keys()].some((key) => key.startsWith(`projects/${ANON}/`))).toBe(false);
+    expect(
+      bucket.store.get(`projects/${SUBJECT}/portfolio/index.html`),
+    ).toBeTruthy();
+    expect(
+      bucket.store.get(`projects/${ANON}/portfolio/index.html`),
+    ).toBeUndefined();
+    expect(
+      [...bucket.store.keys()].some((key) =>
+        key.startsWith(`projects/${ANON}/`),
+      ),
+    ).toBe(false);
     expect(JSON.parse(kv.store.get(migrationClaimKey(ANON))!)).toMatchObject({
       subject: SUBJECT,
       status: "complete",
     });
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(SUBJECT);
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(SUBJECT);
     expect(bucket.store.has(`userhandles/${ANON}.json`)).toBe(true);
-    expect(JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data)).toMatchObject({
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data),
+    ).toMatchObject({
       handle: "jane-rivera",
       claimedAt: "1970-01-01T00:00:00.000Z",
     });
-    expect(JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle).toBe("jane-rivera");
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle,
+    ).toBe("jane-rivera");
   });
 
   it("retries after forward handle ownership commits before the subject reverse record", async () => {
@@ -580,22 +902,30 @@ describe("migrateAnonymousData", () => {
     let failSubjectReverse = true;
     // SAFETY: This replacement preserves the R2 put signature while injecting
     // the first subject reverse-write failure.
-    bucket.put = vi.fn(async (key: string, data: string, options?: R2PutOptions) => {
-      if (key === `userhandles/${SUBJECT}.json` && failSubjectReverse) {
-        failSubjectReverse = false;
-        throw new Error("injected subject reverse failure");
-      }
-      return originalPut(key, data, options);
-    });
+    bucket.put = vi.fn(
+      async (key: string, data: string, options?: R2PutOptions) => {
+        if (key === `userhandles/${SUBJECT}.json` && failSubjectReverse) {
+          failSubjectReverse = false;
+          throw new Error("injected subject reverse failure");
+        }
+        return originalPut(key, data, options);
+      },
+    );
 
     await expect(run()).rejects.toThrow("injected subject reverse failure");
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(SUBJECT);
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(SUBJECT);
     expect(bucket.store.has(`userhandles/${ANON}.json`)).toBe(true);
     expect(bucket.store.has(`userhandles/${SUBJECT}.json`)).toBe(false);
 
     await expect(run()).resolves.toMatchObject({ status: "migrated" });
-    expect(bucket.store.has(`projects/${ANON}/portfolio/index.html`)).toBe(false);
-    expect(JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle).toBe("jane-rivera");
+    expect(bucket.store.has(`projects/${ANON}/portfolio/index.html`)).toBe(
+      false,
+    );
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle,
+    ).toBe("jane-rivera");
   });
 
   it("retries after subject reverse commit before anonymous reverse cleanup", async () => {
@@ -606,28 +936,38 @@ describe("migrateAnonymousData", () => {
     let failAnonReverseRetirement = true;
     // SAFETY: This replacement preserves the R2 put signature while injecting
     // the anonymous reverse-retirement failure.
-    bucket.put = vi.fn(async (key: string, data: string, options?: R2PutOptions) => {
-      if (
-        key === `userhandles/${ANON}.json`
-        && testConditional(options)?.etagMatches
-        && failAnonReverseRetirement
-      ) {
-        failAnonReverseRetirement = false;
-        throw new Error("injected anonymous reverse cleanup failure");
-      }
-      return originalPut(key, data, options);
-    });
+    bucket.put = vi.fn(
+      async (key: string, data: string, options?: R2PutOptions) => {
+        if (
+          key === `userhandles/${ANON}.json` &&
+          testConditional(options)?.etagMatches &&
+          failAnonReverseRetirement
+        ) {
+          failAnonReverseRetirement = false;
+          throw new Error("injected anonymous reverse cleanup failure");
+        }
+        return originalPut(key, data, options);
+      },
+    );
 
     // Cleanup is part of the migration boundary. If retiring the anonymous
     // reverse record fails, the run must stay pending so the source remains
     // available for a complete retry.
-    await expect(run()).rejects.toThrow("injected anonymous reverse cleanup failure");
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(SUBJECT);
-    expect(JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle).toBe("jane-rivera");
+    await expect(run()).rejects.toThrow(
+      "injected anonymous reverse cleanup failure",
+    );
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(SUBJECT);
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle,
+    ).toBe("jane-rivera");
     expect(bucket.store.has(`userhandles/${ANON}.json`)).toBe(true);
 
     await expect(run()).resolves.toMatchObject({ status: "migrated" });
-    expect(bucket.store.has(`projects/${ANON}/portfolio/index.html`)).toBe(false);
+    expect(bucket.store.has(`projects/${ANON}/portfolio/index.html`)).toBe(
+      false,
+    );
     // The cleanup failure is intentionally best-effort; the stale reverse
     // record is not authoritative because its forward record points at the
     // subject, and normal handle repair can reap it later.
@@ -647,8 +987,12 @@ describe("handle re-homing through migration", () => {
 
   function seedHandle(ownerId: string, handle: string) {
     const claimedAt = "2026-01-01T00:00:00.000Z";
-    bucket.store.set(`handles/${handle}.json`, { data: JSON.stringify({ ownerId, claimedAt }) });
-    bucket.store.set(`userhandles/${ownerId}.json`, { data: JSON.stringify({ handle, claimedAt }) });
+    bucket.store.set(`handles/${handle}.json`, {
+      data: JSON.stringify({ ownerId, claimedAt }),
+    });
+    bucket.store.set(`userhandles/${ownerId}.json`, {
+      data: JSON.stringify({ handle, claimedAt }),
+    });
   }
 
   it("moves the anon handle to a subject with none without storing a publication URL", async () => {
@@ -659,23 +1003,28 @@ describe("handle re-homing through migration", () => {
       {
         published: true,
         slug: "portfolio",
-        publishedAt: "2026-01-02T00:00:00.000Z"
+        publishedAt: "2026-01-02T00:00:00.000Z",
       },
-      "<h1>site</h1>"
+      "<h1>site</h1>",
     );
     const legacyMetadataKey = `projects/${ANON}/portfolio/.metadata.json`;
-    const legacyMetadata = z.object({
-      id: z.string(),
-      name: z.string(),
-      createdAt: z.string(),
-      updatedAt: z.string(),
-      published: z.boolean(),
-      publishedAt: z.string().optional(),
-      slug: z.string().optional(),
-      publishedUrl: z.string().optional(),
-    }).parse(JSON.parse(bucket.store.get(legacyMetadataKey)!.data));
-    legacyMetadata.publishedUrl = "https://old.example/u/jane-rivera/portfolio/";
-    bucket.store.set(legacyMetadataKey, { data: JSON.stringify(legacyMetadata) });
+    const legacyMetadata = z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+        published: z.boolean(),
+        publishedAt: z.string().optional(),
+        slug: z.string().optional(),
+        publishedUrl: z.string().optional(),
+      })
+      .parse(JSON.parse(bucket.store.get(legacyMetadataKey)!.data));
+    legacyMetadata.publishedUrl =
+      "https://old.example/u/jane-rivera/portfolio/";
+    bucket.store.set(legacyMetadataKey, {
+      data: JSON.stringify(legacyMetadata),
+    });
 
     await migrateAnonymousData({
       bucket,
@@ -685,16 +1034,24 @@ describe("handle re-homing through migration", () => {
     });
 
     // Handle re-homed: record points at subject, reverse record moved.
-    expect(JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId).toBe(SUBJECT);
-    expect(JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle).toBe("jane-rivera");
-    expect(JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data)).toMatchObject({
+    expect(
+      JSON.parse(bucket.store.get(`handles/jane-rivera.json`)!.data).ownerId,
+    ).toBe(SUBJECT);
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle,
+    ).toBe("jane-rivera");
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data),
+    ).toMatchObject({
       handle: "jane-rivera",
       claimedAt: "1970-01-01T00:00:00.000Z",
     });
 
     // Publication addresses are derived from the current base and are not
     // copied into project metadata during migration.
-    const meta = JSON.parse(bucket.store.get(`projects/${SUBJECT}/portfolio/.metadata.json`)!.data);
+    const meta = JSON.parse(
+      bucket.store.get(`projects/${SUBJECT}/portfolio/.metadata.json`)!.data,
+    );
     expect(meta.publishedUrl).toBeUndefined();
     expect(JSON.stringify(meta)).not.toContain("old.example");
   });
@@ -702,7 +1059,10 @@ describe("handle re-homing through migration", () => {
   it("keeps the subject's primary handle but re-points the anon handle as an alias", async () => {
     seedHandle(SUBJECT, "primary");
     seedHandle(ANON, "anon-alias");
-    seedAnonProject(bucket, "portfolio", { published: true, slug: "portfolio" });
+    seedAnonProject(bucket, "portfolio", {
+      published: true,
+      slug: "portfolio",
+    });
 
     await migrateAnonymousData({
       bucket,
@@ -712,10 +1072,16 @@ describe("handle re-homing through migration", () => {
     });
 
     // Subject keeps its own primary.
-    expect(JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle).toBe("primary");
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${SUBJECT}.json`)!.data).handle,
+    ).toBe("primary");
     // Anon handle survives as an alias pointing at the subject.
-    expect(JSON.parse(bucket.store.get(`handles/anon-alias.json`)!.data).ownerId).toBe(SUBJECT);
-    expect(JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data)).toMatchObject({
+    expect(
+      JSON.parse(bucket.store.get(`handles/anon-alias.json`)!.data).ownerId,
+    ).toBe(SUBJECT);
+    expect(
+      JSON.parse(bucket.store.get(`userhandles/${ANON}.json`)!.data),
+    ).toMatchObject({
       handle: "anon-alias",
       claimedAt: "1970-01-01T00:00:00.000Z",
     });

--- a/packages/app/src/lib/migration.ts
+++ b/packages/app/src/lib/migration.ts
@@ -34,10 +34,7 @@ import type { ProjectMetadata, ProjectSnapshot } from "../types";
 import { z } from "zod";
 import { migrateHandle } from "./handles";
 import { readR2Json } from "./r2-json";
-import {
-  emitDiagnostic,
-  type SiteStudioLoggingContext,
-} from "./logging";
+import { emitDiagnostic, type SiteStudioLoggingContext } from "./logging";
 
 const projectMetadataSchema = z.object({
   id: z.string(),
@@ -53,6 +50,12 @@ const projectMetadataSchema = z.object({
   importedOriginalId: z.string().optional(),
   creatingOperationId: z.string().optional(),
 });
+
+const projectMetadataWithLegacyUrlSchema = projectMetadataSchema
+  .extend({
+    publishedUrl: z.string().optional(),
+  })
+  .strict();
 
 const projectSnapshotSchema = z.object({
   id: z.string(),
@@ -83,15 +86,12 @@ export interface ChatHistoryPorter {
     fromOwner: string,
     fromProjectId: string,
     toOwner: string,
-    toProjectId: string
+    toProjectId: string,
   ): Promise<void>;
 }
 
 export type MigrationStatus =
-  | "migrated"
-  | "already-complete"
-  | "refused"
-  | "nothing-to-migrate";
+  "migrated" | "already-complete" | "refused" | "nothing-to-migrate";
 
 export interface MigrationResult {
   status: MigrationStatus;
@@ -157,19 +157,28 @@ function bytesEqual(left: ArrayBuffer, right: ArrayBuffer): boolean {
  * Different bytes stop the migration before its delete phase, preserving both
  * namespaces for reconciliation.
  */
-async function copyIfAbsent(bucket: R2Bucket, fromKey: string, toKey: string): Promise<void> {
+async function copyIfAbsent(
+  bucket: R2Bucket,
+  fromKey: string,
+  toKey: string,
+): Promise<void> {
   const object = await bucket.get(fromKey);
   if (!object) return; // source vanished (concurrent run finished it) — fine
   const sourceBytes = await object.arrayBuffer();
   const wrote = await bucket.put(toKey, sourceBytes, {
     httpMetadata: object.httpMetadata,
-    onlyIf: { etagDoesNotMatch: "*" }
+    onlyIf: { etagDoesNotMatch: "*" },
   });
   if (wrote) return;
 
   const destination = await bucket.get(toKey);
-  if (!destination || !bytesEqual(sourceBytes, await destination.arrayBuffer())) {
-    throw new Error("Anonymous-data migration stopped because the destination changed concurrently.");
+  if (
+    !destination ||
+    !bytesEqual(sourceBytes, await destination.arrayBuffer())
+  ) {
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
   }
 }
 
@@ -181,18 +190,94 @@ async function putJsonIfAbsentOrEqual(
   const serialized = JSON.stringify(value);
   const wrote = await bucket.put(key, serialized, {
     httpMetadata: { contentType: "application/json" },
-    onlyIf: { etagDoesNotMatch: "*" }
+    onlyIf: { etagDoesNotMatch: "*" },
   });
   if (wrote) return;
 
   const existing = await bucket.get(key);
   if (!existing || (await existing.text()) !== serialized) {
-    throw new Error("Anonymous-data migration stopped because the destination changed concurrently.");
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
+  }
+}
+
+/**
+ * Resume a metadata copy that an older deployment already stamped as this
+ * exact import. That deployment could have persisted the now-obsolete
+ * publishedUrl field; remove only that field, and only when every remaining
+ * field matches the current import's candidate. Any other destination change
+ * remains a conflict and preserves both namespaces.
+ */
+async function putProjectMetadataIfAbsentOrEqual(
+  bucket: R2Bucket,
+  key: string,
+  value: ProjectMetadata,
+  sourceOwner: string,
+  originalProjectId: string,
+): Promise<void> {
+  const serialized = JSON.stringify(value);
+  const wrote = await bucket.put(key, serialized, {
+    httpMetadata: { contentType: "application/json" },
+    onlyIf: { etagDoesNotMatch: "*" },
+  });
+  if (wrote) return;
+
+  const existing = await bucket.get(key);
+  if (!existing) {
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
+  }
+  const existingText = await existing.text();
+  if (existingText === serialized) return;
+
+  let parsed;
+  try {
+    parsed = projectMetadataWithLegacyUrlSchema.safeParse(
+      JSON.parse(existingText),
+    );
+  } catch {
+    parsed = { success: false } as const;
+  }
+  if (
+    !parsed.success ||
+    parsed.data.importedFrom !== sourceOwner ||
+    parsed.data.importedOriginalId !== originalProjectId ||
+    parsed.data.publishedUrl === undefined
+  ) {
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
+  }
+
+  const normalized = { ...parsed.data };
+  delete normalized.publishedUrl;
+  if (
+    JSON.stringify(normalized, Object.keys(normalized).sort()) !==
+    JSON.stringify(value, Object.keys(value).sort())
+  ) {
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
+  }
+
+  const repaired = await bucket.put(key, serialized, {
+    onlyIf: { etagMatches: existing.etag },
+    httpMetadata: { contentType: "application/json" },
+  });
+  if (!repaired) {
+    throw new Error(
+      "Anonymous-data migration stopped because the destination changed concurrently.",
+    );
   }
 }
 
 /** Distinct project ids under a user namespace. */
-async function listProjectIds(bucket: R2Bucket, userId: string): Promise<string[]> {
+async function listProjectIds(
+  bucket: R2Bucket,
+  userId: string,
+): Promise<string[]> {
   const prefix = projectPrefix(userId);
   const ids = new Set<string>();
   for (const key of await listKeys(bucket, prefix)) {
@@ -207,7 +292,7 @@ async function listProjectIds(bucket: R2Bucket, userId: string): Promise<string[
 async function getMetadata(
   bucket: R2Bucket,
   userId: string,
-  projectId: string
+  projectId: string,
 ): Promise<ProjectMetadata | null> {
   return readR2Json(
     bucket,
@@ -219,11 +304,11 @@ async function getMetadata(
 async function subjectProjectOccupied(
   bucket: R2Bucket,
   subject: string,
-  projectId: string
+  projectId: string,
 ): Promise<boolean> {
   const listed = await bucket.list({
     prefix: `${projectPrefix(subject)}${projectId}/`,
-    limit: 1
+    limit: 1,
   });
   return listed.objects.length > 0;
 }
@@ -239,7 +324,7 @@ async function resolveTargetProjectId(
   subject: string,
   anonUserId: string,
   originalId: string,
-  taken: Set<string>
+  taken: Set<string>,
 ): Promise<string> {
   const candidates = [originalId, `${originalId}-imported`];
   for (let n = 2; candidates.length < 50; n++) {
@@ -252,7 +337,10 @@ async function resolveTargetProjectId(
       return candidate;
     }
     const meta = await getMetadata(bucket, subject, candidate);
-    if (meta?.importedFrom === anonUserId && meta.importedOriginalId === originalId) {
+    if (
+      meta?.importedFrom === anonUserId &&
+      meta.importedOriginalId === originalId
+    ) {
       return candidate; // our own copy from a previous/concurrent run
     }
     // Occupied by something that isn't our copy — collision, try next suffix.
@@ -268,13 +356,17 @@ async function usedSubjectSlugs(
   bucket: R2Bucket,
   subject: string,
   anonUserId: string,
-  originalId: string
+  originalId: string,
 ): Promise<Set<string>> {
   const slugs = new Set<string>();
   for (const projectId of await listProjectIds(bucket, subject)) {
     const meta = await getMetadata(bucket, subject, projectId);
     if (!meta?.published) continue;
-    if (meta.importedFrom === anonUserId && meta.importedOriginalId === originalId) continue;
+    if (
+      meta.importedFrom === anonUserId &&
+      meta.importedOriginalId === originalId
+    )
+      continue;
     slugs.add(meta.slug || projectId);
   }
   return slugs;
@@ -330,7 +422,13 @@ async function copyAnonymousNamespace(options: {
     let newId = projectMap[oldId];
     const portHistory = !newId; // already ported by the sweep that first saw it
     if (!newId) {
-      newId = await resolveTargetProjectId(bucket, subject, anonUserId, oldId, taken);
+      newId = await resolveTargetProjectId(
+        bucket,
+        subject,
+        anonUserId,
+        oldId,
+        taken,
+      );
       taken.add(newId);
       projectMap[oldId] = newId;
     }
@@ -363,7 +461,13 @@ async function copyAnonymousNamespace(options: {
         importedOriginalId: plan.oldId,
       };
       if (plan.newSlug) rewritten.slug = plan.newSlug;
-      await putJsonIfAbsentOrEqual(bucket, `${toPrefix}.metadata.json`, rewritten);
+      await putProjectMetadataIfAbsentOrEqual(
+        bucket,
+        `${toPrefix}.metadata.json`,
+        rewritten,
+        anonUserId,
+        plan.oldId,
+      );
     }
 
     for (const key of await listKeys(bucket, fromPrefix)) {
@@ -381,9 +485,14 @@ async function copyAnonymousNamespace(options: {
       if (key.endsWith(".json")) {
         const record = await readR2Json(bucket, key, projectSnapshotSchema);
         if (!record) {
-          throw new Error("Anonymous-data migration stopped because snapshot metadata is invalid; source retained.");
+          throw new Error(
+            "Anonymous-data migration stopped because snapshot metadata is invalid; source retained.",
+          );
         }
-        await putJsonIfAbsentOrEqual(bucket, toKey, { ...record, projectId: plan.newId });
+        await putJsonIfAbsentOrEqual(bucket, toKey, {
+          ...record,
+          projectId: plan.newId,
+        });
       } else {
         await copyIfAbsent(bucket, key, toKey);
       }
@@ -399,11 +508,18 @@ async function copyAnonymousNamespace(options: {
       try {
         await porter.port(anonUserId, plan.oldId, subject, plan.newId);
       } catch (error) {
-        emitDiagnostic("warning", "migration_chat_history_port_failed", {
-        }, logging);
-        throw new Error("Chat history migration failed; anonymous data retained for retry.", {
-          cause: error,
-        });
+        emitDiagnostic(
+          "warning",
+          "migration_chat_history_port_failed",
+          {},
+          logging,
+        );
+        throw new Error(
+          "Chat history migration failed; anonymous data retained for retry.",
+          {
+            cause: error,
+          },
+        );
       }
     }
   }
@@ -433,7 +549,8 @@ export async function migrateAnonymousData(options: {
   logging?: SiteStudioLoggingContext;
   now?: () => string;
 }): Promise<MigrationResult> {
-  const { bucket, kv, anonUserId, subject, anonSessionId, porter, logging } = options;
+  const { bucket, kv, anonUserId, subject, anonSessionId, porter, logging } =
+    options;
   const now = options.now ?? (() => new Date().toISOString());
 
   if (!isAnonymousUserId(anonUserId) || anonUserId === subject) {
@@ -464,12 +581,15 @@ export async function migrateAnonymousData(options: {
   const claim: MigrationClaim = existingClaim ?? {
     subject,
     status: "pending",
-    startedAt: now()
+    startedAt: now(),
   };
   await kv.put(claimKey, JSON.stringify(claim));
   await kv.put(migrationPendingKey(subject), anonUserId);
 
-  const finish = async (status: MigrationStatus, projects: Record<string, string>) => {
+  const finish = async (
+    status: MigrationStatus,
+    projects: Record<string, string>,
+  ) => {
     if (anonSessionId) {
       // Safe to swallow: deleting the spent anon session is best-effort; if it
       // fails it simply expires on its own TTL. Not on the security path.
@@ -477,7 +597,11 @@ export async function migrateAnonymousData(options: {
     }
     await kv.put(
       claimKey,
-      JSON.stringify({ ...claim, status: "complete", completedAt: now() } satisfies MigrationClaim)
+      JSON.stringify({
+        ...claim,
+        status: "complete",
+        completedAt: now(),
+      } satisfies MigrationClaim),
     );
     // Safe to swallow: best-effort resume-marker cleanup (see above).
     await kv.delete(migrationPendingKey(subject)).catch(() => undefined);

--- a/packages/app/src/lib/migration.ts
+++ b/packages/app/src/lib/migration.ts
@@ -32,7 +32,7 @@
 
 import type { ProjectMetadata, ProjectSnapshot } from "../types";
 import { z } from "zod";
-import { getMigrationHandle, migrateHandle } from "./handles";
+import { migrateHandle } from "./handles";
 import { readR2Json } from "./r2-json";
 import {
   emitDiagnostic,
@@ -45,7 +45,6 @@ const projectMetadataSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   published: z.boolean(),
-  publishedUrl: z.string().optional(),
   publishedAt: z.string().optional(),
   unpublishedAt: z.string().optional(),
   thumbnailUrl: z.string().optional(),
@@ -127,17 +126,6 @@ function uploadsPrefix(userId: string): string {
 
 function isAnonymousUserId(id: string): boolean {
   return id.startsWith("user_");
-}
-
-/**
- * Build the published URL from the current production base. Imported metadata
- * may contain a host and mount from an older deployment, but that value is not
- * authoritative and must never survive into the subject-owned record.
- */
-function canonicalPublishedUrl(publishedBaseUrl: string, handle: string, slug: string): string {
-  const base = new URL(publishedBaseUrl);
-  const mountPath = base.pathname.replace(/\/+$/, "");
-  return `${base.origin}${mountPath}/u/${handle}/${slug}/`;
 }
 
 async function listKeys(bucket: R2Bucket, prefix: string): Promise<string[]> {
@@ -313,8 +301,6 @@ async function copyAnonymousNamespace(options: {
   bucket: R2Bucket;
   anonUserId: string;
   subject: string;
-  subjectHandle: string | null;
-  publishedBaseUrl: string;
   porter?: ChatHistoryPorter;
   /** old anonymous projectId -> subject projectId from an earlier sweep */
   knownProjects?: Record<string, string>;
@@ -325,7 +311,7 @@ async function copyAnonymousNamespace(options: {
   projectMap: Record<string, string>;
   slugMap: Record<string, string>;
 }> {
-  const { bucket, anonUserId, subject, subjectHandle, publishedBaseUrl, porter, logging } = options;
+  const { bucket, anonUserId, subject, porter, logging } = options;
   const projectMap = { ...options.knownProjects };
   const slugMap = { ...options.knownSlugs };
 
@@ -377,15 +363,6 @@ async function copyAnonymousNamespace(options: {
         importedOriginalId: plan.oldId,
       };
       if (plan.newSlug) rewritten.slug = plan.newSlug;
-      if (plan.metadata.publishedUrl && plan.newSlug) {
-        // Never let the subject id or an old host enter a client-visible URL.
-        // When the subject has a handle, build the canonical configured-base
-        // /u/{handle}/ form; otherwise drop the stored URL so it is regenerated
-        // on the next publish once a handle exists.
-        rewritten.publishedUrl = subjectHandle
-          ? canonicalPublishedUrl(publishedBaseUrl, subjectHandle, plan.newSlug)
-          : undefined;
-      }
       await putJsonIfAbsentOrEqual(bucket, `${toPrefix}.metadata.json`, rewritten);
     }
 
@@ -449,8 +426,6 @@ export async function migrateAnonymousData(options: {
   kv: KVNamespace;
   anonUserId: string;
   subject: string;
-  /** Current production public base used to canonicalize imported published URLs. */
-  publishedBaseUrl: string;
   /** The anonymous KV session id (cookie value), deleted on completion. */
   anonSessionId?: string;
   /** Durable Object chat-history porter; failures retain the source for retry. */
@@ -458,7 +433,7 @@ export async function migrateAnonymousData(options: {
   logging?: SiteStudioLoggingContext;
   now?: () => string;
 }): Promise<MigrationResult> {
-  const { bucket, kv, anonUserId, subject, publishedBaseUrl, anonSessionId, porter, logging } = options;
+  const { bucket, kv, anonUserId, subject, anonSessionId, porter, logging } = options;
   const now = options.now ?? (() => new Date().toISOString());
 
   if (!isAnonymousUserId(anonUserId) || anonUserId === subject) {
@@ -509,13 +484,6 @@ export async function migrateAnonymousData(options: {
     return { status, projects };
   };
 
-  // Plan the handle without mutating ownership. The destination metadata can
-  // use the effective handle during the copy sweeps, but the forward/reverse
-  // records must remain anonymous-authoritative until every chat port has
-  // succeeded. Otherwise a failed chat import would make /u/{handle} resolve
-  // to a partial migration while the source is still the retry boundary.
-  const subjectHandle = await getMigrationHandle(bucket, anonUserId, subject);
-
   // ---- Inventory ----
   const anonProjectIds = await listProjectIds(bucket, anonUserId);
   const uploadKeys = await listKeys(bucket, uploadsPrefix(anonUserId));
@@ -532,8 +500,6 @@ export async function migrateAnonymousData(options: {
     bucket,
     anonUserId,
     subject,
-    subjectHandle,
-    publishedBaseUrl,
     porter,
     knownProjects: {},
     knownSlugs: {},
@@ -549,8 +515,6 @@ export async function migrateAnonymousData(options: {
     bucket,
     anonUserId,
     subject,
-    subjectHandle,
-    publishedBaseUrl,
     porter,
     knownProjects: firstSweep.projectMap,
     knownSlugs: firstSweep.slugMap,

--- a/packages/app/src/lib/owner-mutations.ts
+++ b/packages/app/src/lib/owner-mutations.ts
@@ -18,7 +18,7 @@ export type OwnerMutation =
   | { type: "rename-project"; projectId: string; nextProjectId: string; name: string }
   | { type: "rename-project-display"; projectId: string; name: string }
   | { type: "delete-project"; projectId: string }
-  | { type: "publish-project"; projectId: string; desiredSlug: string; publishedBaseUrl: string; handle: string }
+  | { type: "publish-project"; projectId: string; desiredSlug: string }
   | { type: "unpublish-project"; projectId: string; unpublishedAt: string }
   | { type: "write-file"; projectId: string; path: string; content: string; baseEtag: string }
   | { type: "write-file-if-absent"; projectId: string; path: string; content: string }
@@ -35,7 +35,7 @@ export type OwnerMutationResult =
   | { written: boolean }
   | { snapshot: SnapshotResult }
   | { restoredSnapshot: ProjectSnapshot; restorePoint: ProjectSnapshot }
-  | { published: { slug: string; url: string } }
+  | { published: { slug: string } }
   | { ok: true };
 
 type Journal =
@@ -392,15 +392,13 @@ export class OwnerMutationService {
             operation.desiredSlug,
             operation.projectId
           );
-          const url = `${operation.publishedBaseUrl.replace(/\/+$/, "")}/u/${operation.handle}/${claim.slug}/`;
           try {
             await this.storage.updateProjectMetadataForSlugClaim(ownerId, operation.projectId, claim, {
               published: true,
-              publishedUrl: url,
               publishedAt: new Date().toISOString(),
               slug: claim.slug
             });
-            return { published: { slug: claim.slug, url } };
+            return { published: { slug: claim.slug } };
           } catch (error) {
             if (!(error instanceof SlugReservationLostError) || attempt === 4) throw error;
           }
@@ -411,7 +409,6 @@ export class OwnerMutationService {
         await this.requireProject(ownerId, operation.projectId);
         await this.storage.updateProjectMetadata(ownerId, operation.projectId, {
           published: false,
-          publishedUrl: undefined,
           unpublishedAt: operation.unpublishedAt
         });
         return { ok: true };

--- a/packages/app/src/lib/published-url.ts
+++ b/packages/app/src/lib/published-url.ts
@@ -1,0 +1,23 @@
+import { isLoopbackOrigin } from "./csrf";
+
+/**
+ * The public mount is deployment configuration, not project identity. Keep
+ * the current request's loopback origin for local development; production
+ * uses the configured public base when one is present.
+ */
+export function getPublishedBaseUrl(requestUrl: string, configuredBaseUrl?: string): string {
+  const requestOrigin = new URL(requestUrl).origin;
+  if (isLoopbackOrigin(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  return normalizePublishedBaseUrl(configuredBaseUrl?.trim() || requestOrigin);
+}
+
+export function normalizePublishedBaseUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function publishedProjectUrl(baseUrl: string, handle: string, slug: string): string {
+  return `${normalizePublishedBaseUrl(baseUrl)}/u/${handle}/${slug}/`;
+}

--- a/packages/app/src/lib/session.test.ts
+++ b/packages/app/src/lib/session.test.ts
@@ -17,7 +17,6 @@ import type { MutationCoordinator } from "../agents/mutation-coordinator";
 
 let identityIssuer: TestIdentityIssuer;
 let identityJwks: string;
-const PUBLISHED_BASE_URL = "https://tools.ailab.gc.cuny.edu/site-studio";
 
 beforeAll(async () => {
   // Mint the exact production Doorway issuer configured by this suite.
@@ -151,7 +150,6 @@ function createEnv(overrides?: Partial<Env>): Env {
   const env: Env = {
     CAIL_LOG_ENV: "test",
     APP_PUBLIC_DOMAIN: "https://tools.ailab.gc.cuny.edu",
-    PUBLISHED_BASE_URL,
     // SAFETY: Session tests never load a Worker module through this binding.
     LOADER: {} as WorkerLoader,
     CAIL_API_BASE: "https://cail.example/proxy",
@@ -182,7 +180,6 @@ function createEnv(overrides?: Partial<Env>): Env {
           kv: env.SESSION_KV,
           anonUserId,
           subject,
-          publishedBaseUrl: env.PUBLISHED_BASE_URL!,
           anonSessionId
         }),
       // SAFETY: Cloudflare's RPC brand is nominal type metadata; this fixture
@@ -199,7 +196,6 @@ function createEnv(overrides?: Partial<Env>): Env {
           kv: env.SESSION_KV,
           anonUserId,
           subject,
-          publishedBaseUrl: env.PUBLISHED_BASE_URL!,
           anonSessionId,
         }),
       [DURABLE_OBJECT_BRAND]: undefined as never,
@@ -528,7 +524,6 @@ describe("authMiddleware anonymous-data migration", () => {
           kv,
           anonUserId,
           subject,
-          publishedBaseUrl: env.PUBLISHED_BASE_URL!,
           anonSessionId,
         })
     );
@@ -617,7 +612,6 @@ describe("authMiddleware anonymous-data migration", () => {
             kv,
             anonUserId,
             subject,
-            publishedBaseUrl: env.PUBLISHED_BASE_URL!,
             anonSessionId,
           });
         });

--- a/packages/app/src/routes/files.ts
+++ b/packages/app/src/routes/files.ts
@@ -217,7 +217,7 @@ export function createFileRouter() {
 
     // SS-18: protected system files (.metadata.json, .thumbnail.png) were guarded
     // on delete/rename but NOT on write, so a caller could overwrite their own
-    // project's .metadata.json and flip published/slug/publishedUrl. Reject writes
+    // project's .metadata.json and flip published/slug. Reject writes
     // to any protected basename here, matching the delete/rename guards.
     if (PROTECTED_FILE_NAMES.has(filePath.split("/").pop() || "")) {
       jsonError("Cannot overwrite protected files", 403);

--- a/packages/app/src/routes/projects.ts
+++ b/packages/app/src/routes/projects.ts
@@ -14,6 +14,8 @@ import {
   type LoggingVariables,
 } from "../lib/logging";
 import { executeOwnerMutation } from "../lib/owner-mutations";
+import { getUserHandle } from "../lib/handles";
+import { getPublishedBaseUrl, publishedProjectUrl } from "../lib/published-url";
 
 const createProjectSchema = z.object({
   name: z.string().min(1).max(100),
@@ -28,12 +30,20 @@ const createSnapshotSchema = z.object({
   label: z.string().min(1).max(160).optional()
 });
 
-function toProjectSummary(id: string, metadata: ProjectMetadata | null) {
+function toProjectSummary(
+  id: string,
+  metadata: ProjectMetadata | null,
+  publishedBaseUrl: string,
+  handle: string | null,
+) {
+  const publishedUrl = metadata?.published && metadata.slug && handle
+    ? publishedProjectUrl(publishedBaseUrl, handle, metadata.slug)
+    : undefined;
   return {
     id,
     name: metadata?.name || id,
     published: metadata?.published || false,
-    publishedUrl: metadata?.publishedUrl,
+    publishedUrl,
     thumbnailUrl: metadata?.thumbnailUrl
   };
 }
@@ -46,8 +56,15 @@ export function createProjectRouter() {
     const logging = getLoggingContext(c, user.operationalSubject);
     const storage = new R2ProjectStorage(c.env.SITE_STUDIO_BUCKET, logging);
     const projectIds = await storage.listProjects(user.id);
+    const publishedBaseUrl = getPublishedBaseUrl(c.req.url, c.env.PUBLISHED_BASE_URL);
+    const handle = await getUserHandle(c.env.SITE_STUDIO_BUCKET, user.id);
     const projects = await Promise.all(
-      projectIds.map(async (projectId) => toProjectSummary(projectId, await storage.getProjectMetadata(user.id, projectId)))
+      projectIds.map(async (projectId) => toProjectSummary(
+        projectId,
+        await storage.getProjectMetadata(user.id, projectId),
+        publishedBaseUrl,
+        handle,
+      ))
     );
 
     return c.json({ projects });
@@ -147,7 +164,12 @@ export function createProjectRouter() {
       }
       throw error;
     }
-    return c.json(toProjectSummary(nextId, updated));
+    return c.json(toProjectSummary(
+      nextId,
+      updated,
+      getPublishedBaseUrl(c.req.url, c.env.PUBLISHED_BASE_URL),
+      await getUserHandle(c.env.SITE_STUDIO_BUCKET, user.id),
+    ));
   });
 
   app.delete("/api/projects/:id", async (c) => {

--- a/packages/app/src/routes/publish.ts
+++ b/packages/app/src/routes/publish.ts
@@ -42,6 +42,11 @@ import {
 } from "../lib/logging";
 import { executeOwnerMutation } from "../lib/owner-mutations";
 import { readBoundedFormData } from "../lib/multipart";
+import {
+  getPublishedBaseUrl,
+  normalizePublishedBaseUrl,
+  publishedProjectUrl,
+} from "../lib/published-url";
 
 const MAX_PUBLISH_A11Y_FINDINGS = 50;
 
@@ -153,10 +158,6 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, "");
 }
 
-function normalizeBaseUrl(value: string): string {
-  return value.replace(/\/+$/, "");
-}
-
 function getAppPublicRoot(c: AppContext): string {
   const requestOrigin = new URL(c.req.url).origin;
   if (isLoopbackOrigin(requestOrigin)) {
@@ -164,24 +165,7 @@ function getAppPublicRoot(c: AppContext): string {
   }
 
   const configuredOrigin = c.env.APP_PUBLIC_DOMAIN?.trim();
-  return `${normalizeBaseUrl(configuredOrigin || requestOrigin)}/`;
-}
-
-function getPublishedBaseUrl(c: AppContext): string {
-  const requestOrigin = new URL(c.req.url).origin;
-  // Published sites are served by this worker at /u/{handle}/{slug}/. In dev
-  // that means the local worker origin; production keeps its configured public
-  // domain authoritative because its request origin is never loopback.
-  if (isLoopbackOrigin(requestOrigin)) {
-    return normalizeBaseUrl(requestOrigin);
-  }
-
-  const configuredBaseUrl = c.env.PUBLISHED_BASE_URL?.trim();
-  if (configuredBaseUrl) {
-    return normalizeBaseUrl(configuredBaseUrl);
-  }
-
-  return normalizeBaseUrl(requestOrigin);
+  return `${normalizePublishedBaseUrl(configuredOrigin || requestOrigin)}/`;
 }
 
 /**
@@ -190,7 +174,7 @@ function getPublishedBaseUrl(c: AppContext): string {
  * loopback development remains mounted at the origin root.
  */
 function getPublishedPathPrefix(c: AppContext): string {
-  const pathname = new URL(getPublishedBaseUrl(c)).pathname.replace(/\/+$/, "");
+  const pathname = new URL(getPublishedBaseUrl(c.req.url, c.env.PUBLISHED_BASE_URL)).pathname.replace(/\/+$/, "");
   return pathname === "/" ? "" : pathname;
 }
 
@@ -259,8 +243,6 @@ export function createPublishRouter() {
           type: "publish-project",
           projectId,
           desiredSlug,
-          publishedBaseUrl: getPublishedBaseUrl(c),
-          handle
         }, serializeSiteStudioLoggingContext(getLoggingContext(c, user.operationalSubject)));
       } catch (error) {
         if (error instanceof Error && error.message.includes("Project not found")) {
@@ -269,7 +251,11 @@ export function createPublishRouter() {
         throw error;
       }
       if (!("published" in result)) throw new Error("Unexpected mutation result");
-      ({ url } = result.published);
+      url = publishedProjectUrl(
+        getPublishedBaseUrl(c.req.url, c.env.PUBLISHED_BASE_URL),
+        handle,
+        result.published.slug,
+      );
       publishAction.acknowledgeMutation();
 
       const terminalAt = Date.now();

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -471,8 +471,7 @@ describe("route regressions", () => {
     await storage.updateProjectMetadata(userId, "bar", {
       published: true,
       slug: "foo",
-      publishedAt: "2026-04-01T00:00:00.000Z",
-      publishedUrl: "https://tools.cuny.qzz.io/u/janedoe/foo/"
+      publishedAt: "2026-04-01T00:00:00.000Z"
     });
 
     await storage.createProject(userId, "foo", "Foo");
@@ -674,6 +673,74 @@ describe("route regressions", () => {
       success: true,
       url: "http://localhost:8792/u/janedoe/local-publish/"
     });
+  });
+
+  it("derives existing published links from the current base without mutating metadata", async () => {
+    await storage.createProject(userId, "portable", "Portable");
+    await storage.writeFile(userId, "portable", "index.html", "<h1>Portable</h1>");
+    await storage.updateProjectMetadata(userId, "portable", {
+      published: true,
+      slug: "portable",
+      publishedAt: "2026-04-01T00:00:00.000Z"
+    });
+    seedHandle(bucket, userId, handle);
+
+    // An older record may still contain the former derived field. Reading it
+    // must ignore that extra data and must not rewrite the project.
+    const metadataKey = `projects/${userId}/portable/.metadata.json`;
+    const metadataObject = await bucket.get(metadataKey);
+    if (!metadataObject) throw new Error("Expected portable metadata fixture");
+    const rawMetadata = z.object({
+      id: z.string(),
+      name: z.string(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      published: z.boolean(),
+      publishedAt: z.string().optional(),
+      slug: z.string().optional(),
+      publishedUrl: z.string().optional(),
+    }).parse(JSON.parse(await metadataObject.text()));
+    rawMetadata.publishedUrl = "https://old.example/u/janedoe/portable/";
+    await bucket.put(metadataKey, JSON.stringify(rawMetadata));
+    const before = await bucket.get(metadataKey);
+    if (!before) throw new Error("Expected portable metadata after legacy-field seed");
+    const beforeBytes = await before.text();
+
+    const oldBase = "https://tools.example.edu/site-studio";
+    const oldListResponse = await app.request(
+      "https://site-studio.test/api/projects",
+      undefined,
+      { ...createEnv(bucket), PUBLISHED_BASE_URL: oldBase }
+    );
+    expect(oldListResponse.status).toBe(200);
+    const projectListResponseSchema = z.object({
+      projects: z.array(z.object({ id: z.string(), publishedUrl: z.string().optional() })),
+    });
+    const oldList = projectListResponseSchema.parse(await oldListResponse.json());
+    const oldProject = oldList.projects.find((project) => project.id === "portable");
+    expect(oldProject?.publishedUrl).toBe(`${oldBase}/u/${handle}/portable/`);
+
+    const oldPublicResponse = await app.request(
+      new URL(oldProject?.publishedUrl ?? "https://invalid.example").pathname.replace("/site-studio", ""),
+      undefined,
+      { ...createEnv(bucket), PUBLISHED_BASE_URL: oldBase }
+    );
+    expect(oldPublicResponse.status).toBe(200);
+    await expect(oldPublicResponse.text()).resolves.toContain("<h1>Portable</h1>");
+
+    const newBase = "https://projects.ailab.gc.cuny.edu";
+    const newListResponse = await app.request(
+      "https://site-studio.test/api/projects",
+      undefined,
+      { ...createEnv(bucket), PUBLISHED_BASE_URL: newBase }
+    );
+    const newList = projectListResponseSchema.parse(await newListResponse.json());
+    const newProject = newList.projects.find((project) => project.id === "portable");
+    expect(newProject?.publishedUrl).toBe(`${newBase}/u/${handle}/portable/`);
+
+    const after = await bucket.get(metadataKey);
+    if (!after) throw new Error("Portable metadata disappeared while listing");
+    expect(await after.text()).toBe(beforeBytes);
   });
 
   it("skips malformed project metadata instead of failing the projects list", async () => {

--- a/packages/app/src/storage/r2.test.ts
+++ b/packages/app/src/storage/r2.test.ts
@@ -742,10 +742,10 @@ describe("R2ProjectStorage", () => {
       await storage.createProject(userId, projectId, "My Project");
       const updated = await storage.updateProjectMetadata(userId, projectId, {
         published: true,
-        publishedUrl: "https://example.com"
+        slug: "example"
       });
       expect(updated.published).toBe(true);
-      expect(updated.publishedUrl).toBe("https://example.com");
+      expect(updated.slug).toBe("example");
       expect(updated.name).toBe("My Project"); // preserved
     });
 
@@ -805,13 +805,11 @@ describe("R2ProjectStorage", () => {
 
       const updated = await storage.updateProjectMetadata(userId, projectId, {
         published: true,
-        publishedUrl: "https://example.com/u/janedoe/my-project/",
         slug: "my-project"
       });
 
       expect(updated).toMatchObject({
         published: true,
-        publishedUrl: "https://example.com/u/janedoe/my-project/",
         slug: "my-project",
         thumbnailUrl: "/api/projects/my-project/thumbnail"
       });
@@ -1648,9 +1646,7 @@ describe("OwnerMutationService recovery journal", () => {
     await service.execute("user-a", {
       type: "publish-project",
       projectId: "aaa-source",
-      desiredSlug: "site",
-      publishedBaseUrl: "https://published.example",
-      handle: "jane"
+      desiredSlug: "site"
     });
 
     const phases: Array<{
@@ -1719,16 +1715,13 @@ describe("OwnerMutationService recovery journal", () => {
     await service.execute("user-a", {
       type: "publish-project",
       projectId: "source",
-      desiredSlug: "site",
-      publishedBaseUrl: "https://published.example",
-      handle: "jane"
+      desiredSlug: "site"
     });
     await storage.createProject("user-a", "target", "Site");
     await storage.writeFile("user-a", "target", "index.html", "complete");
     await storage.updateProjectMetadata("user-a", "target", {
       published: false,
-      slug: "site",
-      publishedUrl: "https://published.example/u/jane/site/"
+      slug: "site"
     });
     journal.values.set("owner-mutation", {
       type: "rename-project",
@@ -1766,9 +1759,7 @@ describe("OwnerMutationService recovery journal", () => {
     await expect(service.execute("user-a", {
       type: "publish-project",
       projectId: "old-site",
-      desiredSlug: "blog",
-      publishedBaseUrl: "https://published.example",
-      handle: "jane"
+      desiredSlug: "blog"
     })).resolves.toMatchObject({ published: { slug: "blog" } });
     await service.execute("user-a", {
       type: "rename-project",
@@ -1779,9 +1770,7 @@ describe("OwnerMutationService recovery journal", () => {
     await expect(service.execute("user-a", {
       type: "publish-project",
       projectId: "new-site",
-      desiredSlug: "blog",
-      publishedBaseUrl: "https://published.example",
-      handle: "jane"
+      desiredSlug: "blog"
     })).resolves.toMatchObject({ published: { slug: "blog" } });
   });
 

--- a/packages/app/src/storage/r2.ts
+++ b/packages/app/src/storage/r2.ts
@@ -106,7 +106,6 @@ const projectMetadataSchema: z.ZodType<ProjectMetadata> = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   published: z.boolean(),
-  publishedUrl: z.string().optional(),
   publishedAt: z.string().optional(),
   unpublishedAt: z.string().optional(),
   thumbnailUrl: z.string().optional(),

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -111,7 +111,6 @@ export interface ProjectMetadata {
   createdAt: string;
   updatedAt: string;
   published: boolean;
-  publishedUrl?: string;
   publishedAt?: string;
   unpublishedAt?: string;
   thumbnailUrl?: string;

--- a/packages/frontend/src/lib/components/NewProjectDialog.svelte
+++ b/packages/frontend/src/lib/components/NewProjectDialog.svelte
@@ -211,6 +211,11 @@
 		}
 	}
 
+	function beginNameEdit() {
+		hasUserEditedName = true;
+		suggestionGeneration += 1;
+	}
+
 	// Get the Lucide icon component for an icon name
 	function getIcon(iconName: string) {
 		return iconMap[iconName] || FileText;
@@ -303,7 +308,8 @@
 					<Input
 						id="projectName"
 						bind:value={projectName}
-						oninput={() => hasUserEditedName = true}
+						onfocus={beginNameEdit}
+						oninput={beginNameEdit}
 						placeholder="my-awesome-project"
 						disabled={isCreating}
 					/>

--- a/packages/frontend/src/lib/components/NewProjectDialog.test.ts
+++ b/packages/frontend/src/lib/components/NewProjectDialog.test.ts
@@ -96,6 +96,22 @@ describe('NewProjectDialog project-name suggestion race', () => {
 		expect(input.value).toBe('custom-name');
 	});
 
+	it('does not let a pending suggestion change the focused name field', async () => {
+		const projects = deferred<Project[]>();
+		mockFetchProjects.mockReturnValueOnce(projects.promise);
+		openDialog();
+
+		const { user, input } = await chooseTemplate(/Alpha template/);
+		await user.click(input);
+		projects.resolve([{ id: 'alpha-1', name: 'alpha-1' }]);
+		await projects.promise;
+		await flushPendingUpdates();
+
+		expect(input.value).toBe('');
+		await user.type(input, 'custom-name');
+		expect(input.value).toBe('custom-name');
+	});
+
 	it('ignores a stale template request after switching templates', async () => {
 		const alphaProjects = deferred<Project[]>();
 		const betaProjects = deferred<Project[]>();

--- a/scripts/local-browser-e2e.ts
+++ b/scripts/local-browser-e2e.ts
@@ -320,7 +320,7 @@ async function runBrowserPath(baseUrl: string, token: string): Promise<void> {
     await dialog.getByLabel("Project Name (optional)").fill(projectName);
     await dialog.getByRole("button", { name: "Create Project" }).click();
     await page.waitForURL("**/editor/**");
-    await expect(page.getByText(projectName, { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: projectName, exact: true })).toBeVisible();
     await expect(page.getByRole("button", { name: "Show code editor" })).toBeVisible();
 
     // The browser now crosses the real app route into a local


### PR DESCRIPTION
## What changed

- derive public project addresses from the current `PUBLISHED_BASE_URL` instead of storing an absolute URL as project authority
- keep the user handle in its verified owner mapping and the project slug/published state in project metadata
- safely resume the precise old-format partial-import record by removing only its obsolete `publishedUrl` under exact provenance and ETag checks
- leave mismatched or concurrently changed records untouched

## Product effect

Existing published projects can move to a future projects domain without copying files or republishing. The current `/u/{handle}/{slug}` route and public/preview serving behavior remain unchanged.

## Verification

- 768 app tests and 186 frontend tests
- lint, typecheck, Svelte checks, builds, production Wrangler dry build
- real child-process preview and public-mount boundaries
- independent review accepted exact head `92a05abbc8042f8636ecf5678f3d2f73a3a1fa76`

No project was published and no live data was changed.