### PR TITLE
Render plaintext responses without stalling chat

### DIFF
--- a/packages/frontend/src/lib/components/MessageContent.svelte
+++ b/packages/frontend/src/lib/components/MessageContent.svelte
@@ -10,6 +10,7 @@
 	import css from 'highlight.js/lib/languages/css';
 	import json from 'highlight.js/lib/languages/json';
 	import bash from 'highlight.js/lib/languages/bash';
+	import plaintext from 'highlight.js/lib/languages/plaintext';
 	import { browserWindow } from '$lib/contracts';
 
 	// One-time configuration of the module-global `marked` singleton. This lives in
@@ -25,6 +26,7 @@
 	hljs.registerLanguage('css', css);
 	hljs.registerLanguage('json', json);
 	hljs.registerLanguage('bash', bash);
+	hljs.registerLanguage('plaintext', plaintext);
 
 	marked.use(
 		markedHighlight({

--- a/packages/frontend/src/lib/components/MessageContent.test.ts
+++ b/packages/frontend/src/lib/components/MessageContent.test.ts
@@ -121,6 +121,21 @@ describe('MessageContent legitimate markdown formatting', () => {
 		expect(pre?.textContent).toContain('const x = 1;');
 	});
 
+	it('renders plain and unknown fenced code without breaking the assistant response', () => {
+		const el = renderContent([
+			'```plaintext',
+			'index.html',
+			'```',
+			'```unregistered-language',
+			'nested-marker.js',
+			'```'
+		].join('\n'));
+		const codeBlocks = el.querySelectorAll('pre code');
+		expect(codeBlocks).toHaveLength(2);
+		expect(codeBlocks[0]).toHaveTextContent('index.html');
+		expect(codeBlocks[1]).toHaveTextContent('nested-marker.js');
+	});
+
 	it('renders a safe https link with its real href intact', () => {
 		const el = renderContent('[link](https://example.com)');
 		const anchor = el.querySelector('a');


### PR DESCRIPTION
## What changed

- register Highlight.js’s maintained plaintext grammar in the existing Markdown renderer
- keep genuinely unknown-language fences on the safe plaintext fallback
- cover valid `plaintext` and unknown fenced blocks at the visible message boundary

## Product evidence

A real signed-in Site Studio turn returned a valid `plaintext` fence. Production repeatedly threw `Unknown language: plaintext`, truncated the response at the fence, and stayed on Responding/Stop indefinitely. The corrected renderer completes that response without the error or spinner trap.

## Verification

- focused MessageContent + AgentChat: 64 tests
- full frontend: 187 tests, zero Svelte errors/warnings
- full repository check: 765 app tests, chat and preview process boundaries, lint, typecheck, builds
- real local Chromium product path across create/chat/stop/recovery/edit/upload/executed nested modules/history/download/reload/delete
- independent review accepted exact head `1d8bf84954819d29211bd819d511a2b0b4bac8b5`

No site was published and no live project data was changed by this source fix.