### PR TITLE
Serialize editor refresh and correlate chat commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ does the app write the empty subject-keyed completion object
 resolvable legacy source, the same empty record closes the import without
 guessing a mapping.
 
+Resumable legacy metadata migration drops any obsolete stored `publishedUrl`;
+public links are derived from the configured `PUBLISHED_BASE_URL`.
+
 An error returns a private retryable 503 and does not write completion or
 clear the legacy cookie. A later login retries. Verified identity remains the
 sole authentication source; there is no subject session cookie or subject

--- a/docs/cail-log-alignment.md
+++ b/docs/cail-log-alignment.md
@@ -107,10 +107,10 @@ minutes. Build/publish admissions get a 15-minute terminal grace period.
 
 Request p95 latency warns above five seconds for the app. Action p95 warns above ten minutes for build and 30 seconds for
 publish; critical latency is twice the warning threshold. Site Studio has no
-spend SLO or threshold ledger. Its authenticated quota endpoint relays the
-verified user's current Cloudflare Gateway estimate and returned accounting
-window as a display-only value; Site Studio does not create a local spend ledger
-or infer a budget from model prices.
+spend SLO or threshold ledger. Its authenticated quota endpoint returns the
+verified user's current Cloudflare Gateway estimate and accounting window to the
+authenticated caller as a display-only value; Site Studio does not create a
+local spend ledger or infer a budget from model prices.
 
 Contract version 4 retains the fleet projection without changing that privacy
 posture. At each trusted Worker boundary, the logger uses
@@ -232,7 +232,7 @@ remain external.
 Site Studio surfaces terminal `quota_exceeded` failures. Its authenticated
 `GET /api/quota` route uses `@cuny-ai-lab/cail-client` with the canonical
 `CAIL_API_BASE`, which requests the Gateway's `GET /v1/quota` estimate and
-passes the typed Cloudflare-managed result to the UI. The gateway ignores
-caller-supplied `X-CAIL-Metadata`, so local
+returns the typed Cloudflare-managed result to authenticated callers. The
+gateway ignores caller-supplied `X-CAIL-Metadata`, so local
 purpose/project/course labels must not be described as authoritative cost
 attribution.

--- a/docs/security-and-recovery.md
+++ b/docs/security-and-recovery.md
@@ -46,6 +46,9 @@ stable source owner and original project id so interrupted sweeps reuse the same
 destination instead of creating another suffix. Source deletion happens only
 after copying and chat transfer have succeeded.
 
+Resumable legacy metadata migration drops any obsolete stored `publishedUrl`;
+public links are derived from the configured `PUBLISHED_BASE_URL`.
+
 The app records the empty marker `imports/:subject` only after a successful
 import, or after the first verified login establishes that no resolvable source
 exists. A failure returns a

--- a/packages/app/scripts/local-browser-worker.ts
+++ b/packages/app/scripts/local-browser-worker.ts
@@ -297,6 +297,7 @@ type LocalAgentTurn = {
   socket: LocalAgentSocket;
   cancelled: boolean;
   held: boolean;
+  toolCallIds: string[];
 };
 
 type LocalWebSocketServer = {
@@ -448,43 +449,49 @@ class LocalSiteBuilderAgent {
       socket,
       cancelled: false,
       held: prompt.includes("hold") || prompt.includes("stop"),
+      toolCallIds: prompt.includes("multiple mutating tools")
+        ? [`local-tool-${requestId}-one`, `local-tool-${requestId}-two`]
+        : [`local-tool-${requestId}`],
     };
     this.activeTurn = turn;
     this.messages.push(structuredClone(latest));
-    const toolCallId = `local-tool-${requestId}`;
     localChatChunk(turn, { type: "text-start", id: `local-text-${requestId}` });
     localChatChunk(turn, {
       type: "text-delta",
       id: `local-text-${requestId}`,
       delta: "Local agent is working. ",
     });
-    localChatChunk(turn, {
-      type: "tool-input-start",
-      toolCallId,
-      toolName: "codemode",
-    });
-    localChatChunk(turn, {
-      type: "tool-input-available",
-      toolCallId,
-      toolName: "codemode",
-      input: { operation: "inspect project", source: "local SiteBuilderAgent" },
-    });
+    for (const toolCallId of turn.toolCallIds) {
+      localChatChunk(turn, {
+        type: "tool-input-start",
+        toolCallId,
+        toolName: "codemode",
+      });
+      localChatChunk(turn, {
+        type: "tool-input-available",
+        toolCallId,
+        toolName: "codemode",
+        input: { operation: "inspect project", source: "local SiteBuilderAgent" },
+      });
+    }
 
     if (turn.held) return;
-    this.finishTurn(turn, toolCallId);
+    this.finishTurn(turn);
   }
 
-  private finishTurn(turn: LocalAgentTurn, toolCallId: string): void {
+  private finishTurn(turn: LocalAgentTurn): void {
     if (turn.cancelled) return;
-    localChatChunk(turn, {
-      type: "tool-output-available",
-      toolCallId,
-      output: {
-        ok: true,
-        boundary: "SITE_BUILDER_AGENT",
-        files: ["index.html", "styles.css"],
-      },
-    });
+    for (const toolCallId of turn.toolCallIds) {
+      localChatChunk(turn, {
+        type: "tool-output-available",
+        toolCallId,
+        output: {
+          ok: true,
+          boundary: "SITE_BUILDER_AGENT",
+          files: ["index.html", "styles.css"],
+        },
+      });
+    }
     localChatChunk(turn, {
       type: "text-delta",
       id: `local-text-${turn.requestId}`,
@@ -505,7 +512,7 @@ class LocalSiteBuilderAgent {
           text: "Local agent is working. The local tool completed successfully.",
           state: "done",
         },
-        {
+        ...turn.toolCallIds.map((toolCallId) => ({
           type: "tool-codemode",
           toolCallId,
           toolName: "codemode",
@@ -519,7 +526,7 @@ class LocalSiteBuilderAgent {
             boundary: "SITE_BUILDER_AGENT",
             files: ["index.html", "styles.css"],
           },
-        },
+        })),
       ],
     };
     this.messages.push(assistant);

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -76,8 +76,9 @@ export function createApp(agentResolver?: AgentResolver) {
   // including the error and not-found paths.
   app.use("*", requestLogging());
 
-  // Rule 5 (docs/INTEGRATION.md §3¾): credentialed CORS must use a strict
-  // allowlist — never a wildcard or reflected origin. Pinned by test.
+  // Credentialed CORS follows docs/security-and-recovery.md (browser and
+  // serving defenses): strict allowlist, never wildcard or reflected origin.
+  // Pinned by test.
 const allowedOrigins = new Set([
 	"http://localhost:5173",
 	"http://127.0.0.1:5173",
@@ -119,12 +120,13 @@ app.use("/preview/*", cors({
   app.use("/api/projects/:id", requireProject());
   app.use("/api/projects/:id/*", requireProject());
 
-  // Token issuance for the shared contract (INTEGRATION.md §3¾ rule 3): GET
-  // /api/csrf mints/looks-up the stable per-session R2 token and DELIVERS it via
-  // a path-scoped Set-Cookie (setCsrfCookie) — never in the response body. A body
-  // token would be readable by any same-origin sibling or published-site script that
-  // fetches this endpoint with the ambient session cookie, defeating rule 3. The
-  // body is 204 with no token anywhere.
+  // Token issuance for the local CSRF contract (docs/security-and-recovery.md,
+  // browser and serving defenses): GET /api/csrf mints/looks-up the stable
+  // per-session R2 token and DELIVERS it via a path-scoped Set-Cookie
+  // (setCsrfCookie) — never in the response body. A body token would be readable
+  // by any same-origin sibling or published-site script that fetches this
+  // endpoint with the ambient session cookie, defeating the contract. The body
+  // is 204 with no token anywhere.
   app.get("/api/csrf", async (c) => {
     const user = c.get("user");
     const token = await getOrMintCsrfToken(c.env.SITE_STUDIO_BUCKET, user.id);

--- a/packages/app/src/lib/cail-identity.ts
+++ b/packages/app/src/lib/cail-identity.ts
@@ -117,9 +117,10 @@ export async function getRequestIdentity(
 }
 
 /**
- * The CAIL `authentication_required` envelope (docs/INTEGRATION.md §2), returned
- * verbatim so the frontend treats worker-issued and gate-issued 401s alike and
- * redirects to the protected Doorway Site Studio path.
+ * The CAIL `authentication_required` envelope (docs/security-and-recovery.md,
+ * identity and ownership), returned verbatim so the frontend treats worker-issued
+ * and gate-issued 401s alike and redirects to the protected Doorway Site Studio
+ * path.
  */
 export function cailAuthRequiredResponse(): Response {
   const body = createCailAuthError(

--- a/packages/app/src/lib/constants.ts
+++ b/packages/app/src/lib/constants.ts
@@ -1,6 +1,7 @@
 export const SESSION_COOKIE_NAME = "site-studio-session";
 /**
- * Delivery cookie for the anti-CSRF token (INTEGRATION.md §3¾ rule 3). The
+ * Delivery cookie for the anti-CSRF token (docs/security-and-recovery.md,
+ * browser and serving defenses). The
  * KV-stored per-subject token is handed to page JS via this cookie instead of
  * a response body, so a same-origin sibling/attacker script cannot read it out
  * of a fetch response. NOT HttpOnly (page JS must read it), Secure, SameSite=Lax,

--- a/packages/app/src/lib/csrf.ts
+++ b/packages/app/src/lib/csrf.ts
@@ -6,7 +6,8 @@ import type { SessionVariables } from "./session";
 import { CSRF_COOKIE_NAME, SESSION_TTL_SECONDS } from "./constants";
 
 /**
- * CSRF protection per docs/INTEGRATION.md §3¾ ("CSRF for gated tools").
+ * CSRF protection per docs/security-and-recovery.md (browser and serving
+ * defenses).
  *
  * Threat model recap: the SSO gate authenticates browsers with an ambient
  * SameSite=Lax cookie, so a forged cross-site request can arrive already
@@ -113,8 +114,8 @@ export async function getOrMintCsrfToken(bucket: R2Bucket, userId: string): Prom
 }
 
 /**
- * Deliver the R2 token to page JS via a cookie (INTEGRATION.md §3¾ rule 3
- * "Delivery"). The token must NEVER appear in a response body — a same-origin
+ * Deliver the R2 token to page JS via a cookie (docs/security-and-recovery.md,
+ * browser and serving defenses). The token must NEVER appear in a response body — a same-origin
  * sibling or user-authored published script could fetch GET /api/csrf with
  * ambient browser credentials and read a JSON token straight out of the body,
  * defeating rule 3. A path-scoped cookie is the one same-origin-proof channel:

--- a/packages/app/src/lib/image-generation.ts
+++ b/packages/app/src/lib/image-generation.ts
@@ -19,7 +19,8 @@ import { sniffImageType, type ImageType } from "./image-validation";
 import { IMAGE_MAX_UPLOAD_BYTES } from "./constants";
 
 /**
- * Default image-generation model. CAIL policy (docs/INTEGRATION.md §1):
+ * Default image-generation model. CAIL model admission policy
+ * (cail-gateway docs/model-admission-contract.md):
  * Cloudflare models only — must be a Workers AI catalog id (`@cf/...`).
  * Overridable via `CAIL_IMAGE_MODEL`, but the value must also be `@cf/`.
  *

--- a/packages/app/src/lib/session.ts
+++ b/packages/app/src/lib/session.ts
@@ -361,7 +361,7 @@ async function migrateAnonymousSessionIfPresent(
 /**
  * Auth middleware for protected routes.
  *
- * Identity contract (docs/INTEGRATION.md §3):
+ * Identity contract (docs/security-and-recovery.md, identity and ownership):
  *   1. `X-CAIL-Identity-JWT` must verify as RS256 against
  *      `CAIL_IDENTITY_JWKS`; `CAIL_IDENTITY_ISSUER` must match CAIL's
  *      canonical issuer exactly for audience `cail:site-studio`. The durable

--- a/packages/app/src/routes/agents.ts
+++ b/packages/app/src/routes/agents.ts
@@ -133,10 +133,11 @@ export function createAgentRouter(resolveAgent: AgentResolver = resolveAgentByNa
 
   async function handleAgentRequest(c: Context<{ Bindings: Env; Variables: AgentRouterVariables }>) {
     const user = getUser(c);
-    // Rule 4 (docs/INTEGRATION.md §3¾): origin-check + token-gate WebSocket
-    // upgrades BEFORE accepting. The browser enforces no same-origin policy on
-    // WS handshakes. The identity JWT is captured on connect, then replaced by
-    // the authenticated refresh route immediately before each model frame.
+    // WebSocket origin-check and token-gating follow docs/security-and-recovery.md
+    // (browser and serving defenses) BEFORE accepting. The browser enforces no
+    // same-origin policy on WS handshakes. The identity JWT is captured on
+    // connect, then replaced by the authenticated refresh route immediately
+    // before each model frame.
     //
     // Judgment call on "gate the first state-changing WS message on your CSRF
     // token": the WS message protocol is owned by @cloudflare/ai-chat, so we

--- a/packages/app/src/routes/input-validation.test.ts
+++ b/packages/app/src/routes/input-validation.test.ts
@@ -210,7 +210,7 @@ describe("SS-6 input validation (bad body → 400, not 500)", () => {
     const patch = (raw: string): RequestInit => ({ ...jsonBody(raw), method: "PATCH" });
 
     beforeEach(async () => {
-      await storage.createProject(userId, "proj-x", "Proj X");
+      await storage.createProjectIfAbsent(userId, "proj-x", "Proj X");
     });
 
     it("non-JSON body → 400", async () => {
@@ -244,7 +244,7 @@ describe("SS-6 input validation (bad body → 400, not 500)", () => {
     const url = "http://site-studio.test/api/projects/proj-x/file";
 
     beforeEach(async () => {
-      await storage.createProject(userId, "proj-x", "Proj X");
+      await storage.createProjectIfAbsent(userId, "proj-x", "Proj X");
     });
 
     it("non-JSON body → 400", async () => {
@@ -282,7 +282,7 @@ describe("SS-6 input validation (bad body → 400, not 500)", () => {
     const put = (raw: string): RequestInit => ({ ...jsonBody(raw), method: "PUT" });
 
     beforeEach(async () => {
-      await storage.createProject(userId, "proj-x", "Proj X");
+      await storage.createProjectIfAbsent(userId, "proj-x", "Proj X");
       await storage.writeFile(userId, "proj-x", "a.html", "<h1>A</h1>");
     });
 

--- a/packages/app/src/routes/preview.test.ts
+++ b/packages/app/src/routes/preview.test.ts
@@ -122,7 +122,7 @@ describe("preview file resolution", () => {
     storage = new R2ProjectStorage(bucket);
     app = createTestApp();
     kv = createMockKV();
-    await storage.createProject(userId, "proj", "Proj");
+    await storage.createProjectIfAbsent(userId, "proj", "Proj");
     await storage.writeFile(userId, "proj", "index.html", "<h1>Home</h1>");
   });
 
@@ -645,9 +645,9 @@ describe("preview token authentication", () => {
     storage = new R2ProjectStorage(bucket);
     kv = createMockKV();
     app = createAuthenticatedPreviewApp();
-    await storage.createProject(userId, "proj", "Proj");
+    await storage.createProjectIfAbsent(userId, "proj", "Proj");
     await storage.writeFile(userId, "proj", "styles.css", "body { color: red; }");
-    await storage.createProject(userId, "other", "Other");
+    await storage.createProjectIfAbsent(userId, "other", "Other");
     await storage.writeFile(userId, "other", "styles.css", "body { color: blue; }");
   });
 
@@ -883,7 +883,7 @@ describe("preview ↔ publish extensionless parity", () => {
     storage = new R2ProjectStorage(bucket);
     app = createTestApp();
     seedHandle(bucket, userId, handle);
-    await storage.createProject(userId, slug, "Site");
+    await storage.createProjectIfAbsent(userId, slug, "Site");
     await storage.writeFile(userId, slug, "index.html", "<h1>Home</h1>");
     // Flat sibling only.
     await storage.writeFile(userId, slug, "about.html", "<h1>Flat About</h1>");

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -262,7 +262,7 @@ describe("route regressions", () => {
   });
 
   it("returns a terse 404 for missing preview assets", async () => {
-    await storage.createProject(userId, "preview-project", "Preview Project");
+    await storage.createProjectIfAbsent(userId, "preview-project", "Preview Project");
     await storage.writeFile(userId, "preview-project", "index.html", "<h1>Hello</h1>");
 
     const response = await app.request(
@@ -277,7 +277,7 @@ describe("route regressions", () => {
   });
 
   it("serves the styled 404 page for missing preview navigations", async () => {
-    await storage.createProject(userId, "preview-project", "Preview Project");
+    await storage.createProjectIfAbsent(userId, "preview-project", "Preview Project");
     await storage.writeFile(userId, "preview-project", "index.html", "<h1>Hello</h1>");
 
     const response = await app.request(
@@ -294,7 +294,7 @@ describe("route regressions", () => {
   });
 
   it("serves the styled 404 page for missing published navigations", async () => {
-    await storage.createProject(userId, "pub", "Pub");
+    await storage.createProjectIfAbsent(userId, "pub", "Pub");
     await storage.writeFile(userId, "pub", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "pub", {
       published: true,
@@ -332,7 +332,7 @@ describe("route regressions", () => {
   });
 
   it("honors a project 404.html for missing published navigations", async () => {
-    await storage.createProject(userId, "pub2", "Pub2");
+    await storage.createProjectIfAbsent(userId, "pub2", "Pub2");
     await storage.writeFile(userId, "pub2", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "pub2", "404.html", "<h1>Custom missing</h1>");
     await storage.updateProjectMetadata(userId, "pub2", {
@@ -351,7 +351,7 @@ describe("route regressions", () => {
   });
 
   it("keeps a terse 404 for missing published assets", async () => {
-    await storage.createProject(userId, "pub3", "Pub3");
+    await storage.createProjectIfAbsent(userId, "pub3", "Pub3");
     await storage.writeFile(userId, "pub3", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "pub3", {
       published: true,
@@ -370,7 +370,7 @@ describe("route regressions", () => {
   });
 
   it("returns 404 for protected published bookkeeping files", async () => {
-    await storage.createProject(userId, "protected-publish", "Protected Publish");
+    await storage.createProjectIfAbsent(userId, "protected-publish", "Protected Publish");
     await storage.writeFile(userId, "protected-publish", "index.html", "<h1>Home</h1>");
     await storage.writeThumbnail(userId, "protected-publish", pngBytes());
     await storage.updateProjectMetadata(userId, "protected-publish", {
@@ -396,7 +396,7 @@ describe("route regressions", () => {
   });
 
   it("returns 404 for missing project file reads and downloads", async () => {
-    await storage.createProject(userId, "files-project", "Files Project");
+    await storage.createProjectIfAbsent(userId, "files-project", "Files Project");
 
     const fileResponse = await app.request(
       "http://site-studio.test/api/projects/files-project/file?path=missing.txt",
@@ -418,7 +418,7 @@ describe("route regressions", () => {
   // SS-18: PROTECTED_FILE_NAMES were guarded on delete/rename but not on write,
   // so a caller could overwrite their own .metadata.json (flip published/slug).
   it("SS-18: rejects a write to .metadata.json via POST /file", async () => {
-    await storage.createProject(userId, "protproj", "Prot Proj");
+    await storage.createProjectIfAbsent(userId, "protproj", "Prot Proj");
     const before = await storage.getProjectMetadata(userId, "protproj");
 
     const response = await app.request(
@@ -447,7 +447,7 @@ describe("route regressions", () => {
   // header token; the ASCII fallback is quote-stripped and the real name rides in
   // the RFC 5987 filename* form.
   it("SS-20: download emits a well-formed Content-Disposition for a quoted filename", async () => {
-    await storage.createProject(userId, "dlproj", "Dl Proj");
+    await storage.createProjectIfAbsent(userId, "dlproj", "Dl Proj");
     await storage.writeFile(userId, "dlproj", 'a"b.txt', "hello");
 
     const response = await app.request(
@@ -466,7 +466,7 @@ describe("route regressions", () => {
   });
 
   it("assigns a unique slug when another published project already owns it", async () => {
-    await storage.createProject(userId, "bar", "Bar");
+    await storage.createProjectIfAbsent(userId, "bar", "Bar");
     await storage.writeFile(userId, "bar", "index.html", "<h1>Alpha</h1>");
     await storage.updateProjectMetadata(userId, "bar", {
       published: true,
@@ -474,7 +474,7 @@ describe("route regressions", () => {
       publishedAt: "2026-04-01T00:00:00.000Z"
     });
 
-    await storage.createProject(userId, "foo", "Foo");
+    await storage.createProjectIfAbsent(userId, "foo", "Foo");
     await storage.writeFile(userId, "foo", "index.html", "<h1>Beta</h1>");
 
     const publishResponse = await app.request(
@@ -515,7 +515,7 @@ describe("route regressions", () => {
   });
 
   it("returns the committed publish when terminal-record RPC outcomes remain ambiguous", async () => {
-    await storage.createProject(userId, "terminal-rpc", "Terminal RPC");
+    await storage.createProjectIfAbsent(userId, "terminal-rpc", "Terminal RPC");
     await storage.writeFile(userId, "terminal-rpc", "index.html", "<h1>Committed</h1>");
     actionAttemptRpc.terminal.mockRejectedValue(new Error("ambiguous Durable Object RPC"));
 
@@ -538,9 +538,9 @@ describe("route regressions", () => {
   });
 
   it("fences a stale publisher after another project reclaims its slug", async () => {
-    await storage.createProject(userId, "former-owner", "Shared");
+    await storage.createProjectIfAbsent(userId, "former-owner", "Shared");
     await storage.writeFile(userId, "former-owner", "index.html", "<h1>Former</h1>");
-    await storage.createProject(userId, "new-owner", "Shared");
+    await storage.createProjectIfAbsent(userId, "new-owner", "Shared");
     await storage.writeFile(userId, "new-owner", "index.html", "<h1>New</h1>");
 
     const reservationKey = `slugreservations/${userId}/shared.json`;
@@ -636,7 +636,7 @@ describe("route regressions", () => {
   });
 
   it("uses the configured published base URL when provided", async () => {
-    await storage.createProject(userId, "configured-url", "Configured Url");
+    await storage.createProjectIfAbsent(userId, "configured-url", "Configured Url");
     await storage.writeFile(userId, "configured-url", "index.html", "<h1>Configured</h1>");
 
     const response = await app.request(
@@ -656,7 +656,7 @@ describe("route regressions", () => {
   });
 
   it("uses the local worker origin for published URLs during loopback development", async () => {
-    await storage.createProject(userId, "local-publish", "Local Publish");
+    await storage.createProjectIfAbsent(userId, "local-publish", "Local Publish");
     await storage.writeFile(userId, "local-publish", "index.html", "<h1>Local</h1>");
 
     const response = await app.request(
@@ -676,7 +676,7 @@ describe("route regressions", () => {
   });
 
   it("derives existing published links from the current base without mutating metadata", async () => {
-    await storage.createProject(userId, "portable", "Portable");
+    await storage.createProjectIfAbsent(userId, "portable", "Portable");
     await storage.writeFile(userId, "portable", "index.html", "<h1>Portable</h1>");
     await storage.updateProjectMetadata(userId, "portable", {
       published: true,
@@ -745,7 +745,7 @@ describe("route regressions", () => {
 
   it("skips malformed project metadata instead of failing the projects list", async () => {
     await bucket.put(`projects/${userId}/broken-project/.metadata.json`, "{not valid json");
-    await storage.createProject(userId, "healthy-project", "Healthy Project");
+    await storage.createProjectIfAbsent(userId, "healthy-project", "Healthy Project");
 
     const response = await app.request(
       "http://site-studio.test/api/projects",
@@ -775,7 +775,7 @@ describe("route regressions", () => {
   });
 
   it("serves the most recently published project when legacy duplicate slugs exist", async () => {
-    await storage.createProject(userId, "bar", "Bar");
+    await storage.createProjectIfAbsent(userId, "bar", "Bar");
     await storage.writeFile(userId, "bar", "index.html", "<h1>Alpha</h1>");
     await storage.updateProjectMetadata(userId, "bar", {
       published: true,
@@ -783,7 +783,7 @@ describe("route regressions", () => {
       publishedAt: "2026-04-01T00:00:00.000Z"
     });
 
-    await storage.createProject(userId, "foo", "Foo");
+    await storage.createProjectIfAbsent(userId, "foo", "Foo");
     await storage.writeFile(userId, "foo", "index.html", "<h1>Beta</h1>");
     await storage.updateProjectMetadata(userId, "foo", {
       published: true,
@@ -805,7 +805,7 @@ describe("route regressions", () => {
     bucket.store.delete(`userhandles/${userId}.json`);
     bucket.store.delete(`handles/${handle}.json`);
 
-    await storage.createProject(userId, "nohandle", "No Handle");
+    await storage.createProjectIfAbsent(userId, "nohandle", "No Handle");
     await storage.writeFile(userId, "nohandle", "index.html", "<h1>Hi</h1>");
 
     const response = await app.request(
@@ -827,7 +827,7 @@ describe("route regressions", () => {
     });
     bucket.store.delete(`handles/${handle}.json`);
 
-    await storage.createProject(userId, "stalepair", "Stale Pair");
+    await storage.createProjectIfAbsent(userId, "stalepair", "Stale Pair");
     await storage.writeFile(userId, "stalepair", "index.html", "<h1>Hi</h1>");
 
     const response = await app.request(
@@ -841,7 +841,7 @@ describe("route regressions", () => {
   });
 
   it("301s a slashless canonical root to the trailing-slash URL with its query", async () => {
-    await storage.createProject(userId, "slashroot", "Slash Root");
+    await storage.createProjectIfAbsent(userId, "slashroot", "Slash Root");
     await storage.writeFile(userId, "slashroot", "index.html", '<link href="styles.css">');
     await storage.updateProjectMetadata(userId, "slashroot", {
       published: true,
@@ -859,7 +859,7 @@ describe("route regressions", () => {
   });
 
   it("retains the configured ingress prefix in slashless redirects", async () => {
-    await storage.createProject(userId, "prefixed-root", "Prefixed Root");
+    await storage.createProjectIfAbsent(userId, "prefixed-root", "Prefixed Root");
     await storage.writeFile(userId, "prefixed-root", "index.html", "<h1>Prefixed</h1>");
     await storage.updateProjectMetadata(userId, "prefixed-root", {
       published: true,
@@ -880,7 +880,7 @@ describe("route regressions", () => {
   });
 
   it("retains the configured ingress prefix in styled 404 home links", async () => {
-    await storage.createProject(userId, "prefixed-404", "Prefixed 404");
+    await storage.createProjectIfAbsent(userId, "prefixed-404", "Prefixed 404");
     await storage.writeFile(userId, "prefixed-404", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "prefixed-404", {
       published: true,
@@ -901,7 +901,7 @@ describe("route regressions", () => {
   });
 
   it("SS-14: resolves an extensionless path to {path}.html", async () => {
-    await storage.createProject(userId, "flat", "Flat");
+    await storage.createProjectIfAbsent(userId, "flat", "Flat");
     await storage.writeFile(userId, "flat", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "flat", "about.html", "<h1>Flat About</h1>");
     await storage.updateProjectMetadata(userId, "flat", { published: true, slug: "flat" });
@@ -916,7 +916,7 @@ describe("route regressions", () => {
   });
 
   it("SS-14: prefers {path}.html over {path}/index.html", async () => {
-    await storage.createProject(userId, "both", "Both");
+    await storage.createProjectIfAbsent(userId, "both", "Both");
     await storage.writeFile(userId, "both", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "both", "about.html", "<h1>Flat</h1>");
     await storage.writeFile(userId, "both", "about/index.html", "<h1>Nested</h1>");
@@ -932,7 +932,7 @@ describe("route regressions", () => {
   });
 
   it("published HTML revalidates mutable URLs and carries ETag with the CSP", async () => {
-    await storage.createProject(userId, "cache", "Cache");
+    await storage.createProjectIfAbsent(userId, "cache", "Cache");
     await storage.writeFile(userId, "cache", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "cache", { published: true, slug: "cache" });
 
@@ -949,7 +949,7 @@ describe("route regressions", () => {
   });
 
   it("returns 304 when a published file validator still matches", async () => {
-    await storage.createProject(userId, "cache-304", "Cache 304");
+    await storage.createProjectIfAbsent(userId, "cache-304", "Cache 304");
     await storage.writeFile(userId, "cache-304", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "cache-304", { published: true, slug: "cache-304" });
 
@@ -974,7 +974,7 @@ describe("route regressions", () => {
   });
 
   it("SS-27: a missing published ASSET does not download the project 404.html", async () => {
-    await storage.createProject(userId, "gate", "Gate");
+    await storage.createProjectIfAbsent(userId, "gate", "Gate");
     await storage.writeFile(userId, "gate", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "gate", "404.html", "<h1>Custom missing</h1>");
     await storage.updateProjectMetadata(userId, "gate", { published: true, slug: "gate" });
@@ -1022,7 +1022,7 @@ describe("served-bytes security headers (§3¾)", () => {
   }
 
   it("sandboxes a served published page (/u/)", async () => {
-    await storage.createProject(userId, "sec", "Sec");
+    await storage.createProjectIfAbsent(userId, "sec", "Sec");
     await storage.writeFile(userId, "sec", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "sec", { published: true, slug: "sec" });
 
@@ -1036,7 +1036,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("sandboxes a served published asset (e.g. .svg)", async () => {
-    await storage.createProject(userId, "sec2", "Sec2");
+    await storage.createProjectIfAbsent(userId, "sec2", "Sec2");
     await storage.writeFile(userId, "sec2", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "sec2", "art.svg", "<svg xmlns='http://www.w3.org/2000/svg'></svg>");
     await storage.updateProjectMetadata(userId, "sec2", { published: true, slug: "sec2" });
@@ -1052,7 +1052,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("sandboxes a project-supplied 404.html", async () => {
-    await storage.createProject(userId, "sec3", "Sec3");
+    await storage.createProjectIfAbsent(userId, "sec3", "Sec3");
     await storage.writeFile(userId, "sec3", "index.html", "<h1>Home</h1>");
     await storage.writeFile(userId, "sec3", "404.html", "<h1>Custom missing</h1>");
     await storage.updateProjectMetadata(userId, "sec3", { published: true, slug: "sec3" });
@@ -1068,7 +1068,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("sandboxes a served preview page", async () => {
-    await storage.createProject(userId, "prev", "Prev");
+    await storage.createProjectIfAbsent(userId, "prev", "Prev");
     await storage.writeFile(userId, "prev", "index.html", "<h1>Preview</h1>");
 
     const response = await app.request(
@@ -1081,7 +1081,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("does NOT sandbox the JSON publish API response", async () => {
-    await storage.createProject(userId, "apisec", "ApiSec");
+    await storage.createProjectIfAbsent(userId, "apisec", "ApiSec");
     await storage.writeFile(userId, "apisec", "index.html", "<h1>Home</h1>");
 
     const response = await app.request(
@@ -1094,7 +1094,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("hardens the styled fallback 404 without sandboxing our own trusted markup", async () => {
-    await storage.createProject(userId, "fb", "Fb");
+    await storage.createProjectIfAbsent(userId, "fb", "Fb");
     await storage.writeFile(userId, "fb", "index.html", "<h1>Home</h1>");
     await storage.updateProjectMetadata(userId, "fb", { published: true, slug: "fb" });
 
@@ -1110,7 +1110,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("adds nosniff but does NOT sandbox the owner thumbnail PNG", async () => {
-    await storage.createProject(userId, "thumb", "Thumb");
+    await storage.createProjectIfAbsent(userId, "thumb", "Thumb");
     await storage.writeThumbnail(userId, "thumb", pngBytes());
 
     const response = await app.request(
@@ -1127,7 +1127,7 @@ describe("served-bytes security headers (§3¾)", () => {
   // SS-21: the thumbnail POST previously trusted image.type === "image/png".
   // Sniff the magic bytes and reject a non-PNG body posted as image/png.
   it("SS-21: rejects a non-PNG body posted to the thumbnail route as image/png", async () => {
-    await storage.createProject(userId, "thumbsniff", "Thumb Sniff");
+    await storage.createProjectIfAbsent(userId, "thumbsniff", "Thumb Sniff");
     const html = new TextEncoder().encode("<!DOCTYPE html><html></html>");
     const form = new FormData();
     // SAFETY: The encoder's backing buffer is an ArrayBuffer in this fixture.
@@ -1149,7 +1149,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("rejects a PNG signature without a valid IHDR chunk", async () => {
-    await storage.createProject(userId, "thumbihdr", "Thumb IHDR");
+    await storage.createProjectIfAbsent(userId, "thumbihdr", "Thumb IHDR");
     const signatureOnly = new Uint8Array(32);
     signatureOnly.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     const form = new FormData();
@@ -1166,7 +1166,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-21: accepts a real PNG body on the thumbnail route", async () => {
-    await storage.createProject(userId, "thumbok", "Thumb OK");
+    await storage.createProjectIfAbsent(userId, "thumbok", "Thumb OK");
     const form = new FormData();
     // SAFETY: The PNG fixture's backing buffer is an ArrayBuffer.
     form.append(
@@ -1185,7 +1185,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("rejects a thumbnail whose IHDR dimensions exceed the render ceiling", async () => {
-    await storage.createProject(userId, "thumbdimensions", "Thumb Dimensions");
+    await storage.createProjectIfAbsent(userId, "thumbdimensions", "Thumb Dimensions");
     const png = pngBytes();
     new DataView(png.buffer).setUint32(16, 5000);
     const form = new FormData();
@@ -1203,7 +1203,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("rejects a thumbnail body above the thumbnail byte ceiling before buffering it again", async () => {
-    await storage.createProject(userId, "thumbbytes", "Thumb Bytes");
+    await storage.createProjectIfAbsent(userId, "thumbbytes", "Thumb Bytes");
     const form = new FormData();
     // SAFETY: pngBytes returns an ArrayBuffer-backed Uint8Array fixture.
     form.append("image", new File([pngBytes(2 * 1024 * 1024 + 1).buffer as ArrayBuffer], "thumb.png", { type: "image/png" }));
@@ -1261,7 +1261,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-33: unpublish keeps 400 for an existing unpublished project", async () => {
-    await storage.createProject(userId, "draft", "Draft");
+    await storage.createProjectIfAbsent(userId, "draft", "Draft");
 
     const response = await app.request(
       "http://site-studio.test/api/projects/draft/unpublish",
@@ -1274,7 +1274,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-40: GET file returns the content ETag", async () => {
-    await storage.createProject(userId, "editor-etag", "Editor ETag");
+    await storage.createProjectIfAbsent(userId, "editor-etag", "Editor ETag");
     const etag = await storage.writeFile(userId, "editor-etag", "index.html", "first");
 
     const response = await app.request(
@@ -1292,7 +1292,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-40: POST file rejects a stale base ETag without overwriting", async () => {
-    await storage.createProject(userId, "editor-conflict", "Editor Conflict");
+    await storage.createProjectIfAbsent(userId, "editor-conflict", "Editor Conflict");
     const staleEtag = await storage.writeFile(userId, "editor-conflict", "index.html", "first");
     const currentEtag = await storage.writeFile(userId, "editor-conflict", "index.html", "newer");
 
@@ -1316,7 +1316,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-40: POST file rejects a missing base ETag without overwriting", async () => {
-    await storage.createProject(userId, "editor-missing-etag", "Editor Missing ETag");
+    await storage.createProjectIfAbsent(userId, "editor-missing-etag", "Editor Missing ETag");
     await storage.writeFile(userId, "editor-missing-etag", "index.html", "current");
 
     const response = await app.request(
@@ -1335,7 +1335,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-40: POST file cannot create a file through a fabricated base ETag", async () => {
-    await storage.createProject(userId, "editor-no-create", "Editor No Create");
+    await storage.createProjectIfAbsent(userId, "editor-no-create", "Editor No Create");
 
     const response = await app.request(
       "http://site-studio.test/api/projects/editor-no-create/file",
@@ -1357,7 +1357,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-40: POST file accepts a matching base ETag and returns the new ETag", async () => {
-    await storage.createProject(userId, "editor-save", "Editor Save");
+    await storage.createProjectIfAbsent(userId, "editor-save", "Editor Save");
     const baseEtag = await storage.writeFile(userId, "editor-save", "index.html", "first");
 
     const response = await app.request(
@@ -1379,7 +1379,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-31: PATCH rename returns 409 if the target project appears after preflight", async () => {
-    await storage.createProject(userId, "old-name", "Old Name");
+    await storage.createProjectIfAbsent(userId, "old-name", "Old Name");
     await storage.writeFile(userId, "old-name", "index.html", "<h1>Old</h1>");
     const targetMetadataKey = `projects/${userId}/new-name/.metadata.json`;
     const originalPut = bucket.put;
@@ -1421,7 +1421,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-50: PUT files/rename returns 409 when the destination appears after the preflight", async () => {
-    await storage.createProject(userId, "rename-race", "Rename Race");
+    await storage.createProjectIfAbsent(userId, "rename-race", "Rename Race");
     await storage.writeFile(userId, "rename-race", "a.html", "mine");
     const destKey = `projects/${userId}/rename-race/b.html`;
     const originalPut = bucket.put;
@@ -1457,7 +1457,7 @@ describe("served-bytes security headers (§3¾)", () => {
   });
 
   it("SS-51: publish racing a delete returns 404 instead of resurrecting a published ghost", async () => {
-    await storage.createProject(userId, "pub-race", "Pub Race");
+    await storage.createProjectIfAbsent(userId, "pub-race", "Pub Race");
     await storage.writeFile(userId, "pub-race", "index.html", "<h1>Hi</h1>");
     const metadataKey = `projects/${userId}/pub-race/.metadata.json`;
     const originalPut = bucket.put;
@@ -1525,7 +1525,7 @@ describe("image upload hardening", () => {
     app = createTestApp();
     kv = createMockKV();
     csrf = await mintCsrfSession(bucket, userId);
-    await storage.createProject(userId, "imgproj", "Image Project");
+    await storage.createProjectIfAbsent(userId, "imgproj", "Image Project");
   });
 
   it("accepts an image whose magic bytes match its extension", async () => {
@@ -1760,7 +1760,7 @@ describe("images inventory endpoint", () => {
   });
 
   it("lists project images and placeholder findings with an extractable src", async () => {
-    await storage.createProject(userId, "inv", "Inventory");
+    await storage.createProjectIfAbsent(userId, "inv", "Inventory");
     await storage.uploadToProject(userId, "inv", "images/hero.png", pngBytes());
     await storage.writeFile(
       userId,
@@ -1908,7 +1908,7 @@ describe("SS-28 manual snapshot cap (over-cap → 413, normal → 201)", () => {
     app = createTestApp();
     kv = createMockKV();
     csrf = await mintCsrfSession(bucket, userId);
-    await storage.createProject(userId, "snapproj", "Snap Project");
+    await storage.createProjectIfAbsent(userId, "snapproj", "Snap Project");
   });
 
   it("normal-sized project → 201 with a snapshot", async () => {

--- a/packages/app/src/routes/regressions.test.ts
+++ b/packages/app/src/routes/regressions.test.ts
@@ -991,7 +991,8 @@ describe("route regressions", () => {
 });
 
 /**
- * INTEGRATION.md §3¾ active-content invariant. Every served user/agent byte
+ * docs/security-and-recovery.md (browser and serving defenses) active-content
+ * invariant. Every served user/agent byte
  * (published sites, previews, a project-supplied 404.html) must carry the
  * opaque-origin CSP (`sandbox allow-scripts`, NEVER allow-same-origin) + nosniff
  * so it can never read our cookie/session. JSON API responses and the styled
@@ -1799,7 +1800,8 @@ describe("images inventory endpoint", () => {
 });
 
 /**
- * INTEGRATION.md §3¾ rules 2+3 over every state-changing route. Each mutation
+ * docs/security-and-recovery.md (browser and serving defenses) rules over every
+ * state-changing route. Each mutation
  * must: reject without the token (403 + exact envelope), reject a valid token
  * arriving with `Sec-Fetch-Site: cross-site` (403), and proceed past CSRF with
  * the token + compliant same-origin posture (whatever domain-level status the

--- a/packages/app/src/storage/r2.test.ts
+++ b/packages/app/src/storage/r2.test.ts
@@ -176,9 +176,9 @@ describe("R2ProjectStorage", () => {
     );
   });
 
-  describe("createProject", () => {
+  describe("createProjectIfAbsent", () => {
     it("creates metadata in R2", async () => {
-      const result = await storage.createProject(userId, projectId, "My Project");
+      const result = await storage.createProjectIfAbsent(userId, projectId, "My Project");
       expect(result.id).toBe(projectId);
       expect(result.name).toBe("My Project");
       expect(result.published).toBe(false);
@@ -227,7 +227,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("returns true when metadata exists", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       expect(await storage.projectExists(userId, projectId)).toBe(true);
     });
 
@@ -240,7 +240,7 @@ describe("R2ProjectStorage", () => {
   describe("listProjects", () => {
     it("returns projects across paginated delimiter listings", async () => {
       for (let index = 0; index < 7; index += 1) {
-        await storage.createProject(userId, `project-${index}`, `Project ${index}`);
+        await storage.createProjectIfAbsent(userId, `project-${index}`, `Project ${index}`);
       }
 
       await expect(storage.listProjects(userId)).resolves.toEqual([
@@ -257,7 +257,7 @@ describe("R2ProjectStorage", () => {
 
   describe("readFile / writeFile", () => {
     it("writes and reads a text file", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
       const content = await storage.readFile(userId, projectId, "index.html");
       expect(content).toBe("<h1>Hello</h1>");
@@ -359,7 +359,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("suffixes when the desired slug is already published by another project", async () => {
-      await storage.createProject(userId, "p1", "P1");
+      await storage.createProjectIfAbsent(userId, "p1", "P1");
       await storage.updateProjectMetadata(userId, "p1", { published: true, slug: "blog" });
       const claim = await storage.resolvePublishedSlug(userId, "blog", "p2");
       expect(claim.slug).toBe("blog-2");
@@ -409,13 +409,13 @@ describe("R2ProjectStorage", () => {
 
   describe("listFiles", () => {
     it("returns empty list for empty project", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       const files = await storage.listFiles(userId, projectId);
       expect(files).toEqual([]);
     });
 
     it("lists files excluding metadata", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hi</h1>");
       await storage.writeFile(userId, projectId, "styles.css", "body {}");
 
@@ -429,7 +429,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("returns all files across paginated listings", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       for (let index = 0; index < 7; index += 1) {
         await storage.writeFile(userId, projectId, `page-${index}.html`, `<h1>${index}</h1>`);
       }
@@ -447,7 +447,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("excludes protected files", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "hi");
       // .metadata.json is already excluded by the listing logic
       const files = await storage.listFiles(userId, projectId);
@@ -460,7 +460,7 @@ describe("R2ProjectStorage", () => {
     // "images" also caught "images2.txt" and "images-old/…". The prefix must be a
     // directory boundary.
     it("SS-7: a prefix listing does not include sibling keys sharing the prefix", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "images/a.png", "A");
       await storage.writeFile(userId, projectId, "images/b.png", "B");
       await storage.writeFile(userId, projectId, "images2.txt", "sibling file");
@@ -474,7 +474,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-7: a prefix already ending in / is not double-slashed", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "images/a.png", "A");
 
       const files = await storage.listFiles(userId, projectId, "images/");
@@ -482,7 +482,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("marks binary files as non-text", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "paper.pdf", new Uint8Array([1, 2, 3]));
 
       const files = await storage.listFiles(userId, projectId);
@@ -555,7 +555,7 @@ describe("R2ProjectStorage", () => {
 
   describe("renameProject", () => {
     it("SS-43: moves files, snapshots, and thumbnail only after every copy succeeds", async () => {
-      await storage.createProject(userId, "old-complete", "Old Complete");
+      await storage.createProjectIfAbsent(userId, "old-complete", "Old Complete");
       await storage.writeFile(userId, "old-complete", "index.html", "<h1>Hi</h1>");
       await storage.writeThumbnail(userId, "old-complete", new Uint8Array([137, 80, 78, 71]));
       // SAFETY: This project contains files, so createSnapshot returns a full snapshot.
@@ -579,7 +579,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("keeps a published rename target hidden until every object is copied", async () => {
-      await storage.createProject(userId, "aaa-source", "Published");
+      await storage.createProjectIfAbsent(userId, "aaa-source", "Published");
       await storage.writeFile(userId, "aaa-source", "index.html", "complete");
       await storage.updateProjectMetadata(userId, "aaa-source", {
         published: true,
@@ -616,7 +616,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-43: rolls back a partial target and preserves the source when a snapshot copy fails", async () => {
-      await storage.createProject(userId, "old-atomic", "Old Atomic");
+      await storage.createProjectIfAbsent(userId, "old-atomic", "Old Atomic");
       await storage.writeFile(userId, "old-atomic", "index.html", "source file");
       // SAFETY: This project contains files, so createSnapshot returns a full snapshot.
       const snapshot = (await storage.createSnapshot(userId, "old-atomic", {
@@ -651,7 +651,7 @@ describe("R2ProjectStorage", () => {
     // SS-25: thumbnailUrl embeds the project id, so after a rename it must point
     // at the new id (or be cleared), never at the old/now-deleted project.
     it("SS-25: re-points thumbnailUrl to the new project id", async () => {
-      await storage.createProject(userId, "old-id", "Old");
+      await storage.createProjectIfAbsent(userId, "old-id", "Old");
       await storage.writeFile(userId, "old-id", "index.html", "<h1>Hi</h1>");
       await storage.updateProjectMetadata(userId, "old-id", {
         thumbnailUrl: "/api/projects/old-id/thumbnail"
@@ -667,7 +667,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-25: leaves thumbnailUrl unset when the old metadata had none", async () => {
-      await storage.createProject(userId, "old-id2", "Old2");
+      await storage.createProjectIfAbsent(userId, "old-id2", "Old2");
       await storage.writeFile(userId, "old-id2", "index.html", "<h1>Hi</h1>");
 
       await storage.renameProject(userId, "old-id2", "new-id2");
@@ -677,9 +677,9 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-31: throws when the target metadata appears and leaves the target untouched", async () => {
-      await storage.createProject(userId, "old-id3", "Old3");
+      await storage.createProjectIfAbsent(userId, "old-id3", "Old3");
       await storage.writeFile(userId, "old-id3", "index.html", "<h1>Old</h1>");
-      await storage.createProject(userId, "new-id3", "Existing");
+      await storage.createProjectIfAbsent(userId, "new-id3", "Existing");
       await storage.writeFile(userId, "new-id3", "index.html", "<h1>Existing</h1>");
 
       await expect(storage.renameProject(userId, "old-id3", "new-id3")).rejects.toBeInstanceOf(ProjectExistsError);
@@ -693,7 +693,7 @@ describe("R2ProjectStorage", () => {
 
   describe("deleteProject", () => {
     it("removes all project files and metadata", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "hi");
       await storage.writeFile(userId, projectId, "styles.css", "body {}");
 
@@ -703,7 +703,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("removes project and snapshot keys across paginated listings", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       for (let index = 0; index < 7; index += 1) {
         await storage.writeFile(userId, projectId, `file-${index}.html`, `<h1>${index}</h1>`);
       }
@@ -726,7 +726,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("returns metadata for existing project", async () => {
-      await storage.createProject(userId, projectId, "My Project");
+      await storage.createProjectIfAbsent(userId, projectId, "My Project");
       const metadata = await storage.getProjectMetadata(userId, projectId);
       expect(metadata?.name).toBe("My Project");
       expect(metadata?.published).toBe(false);
@@ -739,7 +739,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("updates metadata fields", async () => {
-      await storage.createProject(userId, projectId, "My Project");
+      await storage.createProjectIfAbsent(userId, projectId, "My Project");
       const updated = await storage.updateProjectMetadata(userId, projectId, {
         published: true,
         slug: "example"
@@ -758,7 +758,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-51: a publish update racing a delete fails instead of resurrecting the project", async () => {
-      await storage.createProject(userId, projectId, "My Project");
+      await storage.createProjectIfAbsent(userId, projectId, "My Project");
       const key = `projects/${userId}/${projectId}/.metadata.json`;
       const originalPut = bucket.put;
       let injected = false;
@@ -784,7 +784,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-30: retries a stale metadata write and preserves both concurrent updates", async () => {
-      await storage.createProject(userId, projectId, "My Project");
+      await storage.createProjectIfAbsent(userId, projectId, "My Project");
       const key = `projects/${userId}/${projectId}/.metadata.json`;
       const originalPut = bucket.put;
       let injected = false;
@@ -820,7 +820,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-30: throws after repeated metadata CAS conflicts", async () => {
-      await storage.createProject(userId, projectId, "My Project");
+      await storage.createProjectIfAbsent(userId, projectId, "My Project");
       const key = `projects/${userId}/${projectId}/.metadata.json`;
       const original = await storage.getProjectMetadata(userId, projectId);
       // SAFETY: This replacement preserves the R2 put signature while forcing
@@ -856,7 +856,7 @@ describe("R2ProjectStorage", () => {
 
   describe("exportProjectZip", () => {
     it("creates a zip archive of project files", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
       await storage.writeFile(userId, projectId, "styles.css", "body {}");
 
@@ -866,7 +866,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("adds README for projects without index.html", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "about.html", "<p>About</p>");
 
       const zip = await storage.exportProjectZip(userId, projectId);
@@ -876,7 +876,7 @@ describe("R2ProjectStorage", () => {
 
   describe("snapshots", () => {
     it("creates and lists snapshots", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
       const result = await storage.createSnapshot(userId, projectId, {
@@ -898,7 +898,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("returns snapshots across paginated listings", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
       for (let index = 0; index < 7; index += 1) {
@@ -923,7 +923,7 @@ describe("R2ProjectStorage", () => {
     it("SS-38: keeps exactly 50 snapshots without pruning at the boundary", async () => {
       vi.useFakeTimers();
       try {
-        await storage.createProject(userId, projectId, "Test");
+        await storage.createProjectIfAbsent(userId, projectId, "Test");
         await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
         for (let index = 0; index < SNAPSHOT_KEEP_COUNT; index += 1) {
@@ -947,7 +947,7 @@ describe("R2ProjectStorage", () => {
     it("SS-38: prunes exactly the oldest archive and metadata on the 51st snapshot", async () => {
       vi.useFakeTimers();
       try {
-        await storage.createProject(userId, projectId, "Test");
+        await storage.createProjectIfAbsent(userId, projectId, "Test");
         await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
         const created: ProjectSnapshot[] = [];
@@ -977,7 +977,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-39: lists modern snapshots without GETs for snapshot metadata objects", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
       for (let index = 0; index < 4; index += 1) {
@@ -1000,7 +1000,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-39: falls back to one GET for a legacy snapshot without custom metadata", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
       await storage.createSnapshot(userId, projectId, {
@@ -1041,7 +1041,7 @@ describe("R2ProjectStorage", () => {
       // The prune failure is surfaced through the structured Worker sink.
       const logSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
-        await storage.createProject(userId, projectId, "Test");
+        await storage.createProjectIfAbsent(userId, projectId, "Test");
         await storage.writeFile(userId, projectId, "index.html", "<h1>Hello</h1>");
 
         for (let index = 0; index < SNAPSHOT_KEEP_COUNT; index += 1) {
@@ -1102,7 +1102,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("restores a snapshot", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Original</h1>");
 
       // SAFETY: This project contains files, so createSnapshot returns a full snapshot.
@@ -1126,7 +1126,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("rolls back every partial write when restoring a snapshot fails", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "a.txt", "snapshot-a");
       await storage.writeFile(userId, projectId, "b.txt", "snapshot-b");
       // SAFETY: This project contains files, so createSnapshot returns a full snapshot.
@@ -1167,7 +1167,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("rolls back overwritten and deleted files when a restore delete fails", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.writeFile(userId, projectId, "index.html", "snapshot");
       // SAFETY: This project contains a file, so createSnapshot returns a full snapshot.
       const snapshot = (await storage.createSnapshot(userId, projectId, {
@@ -1211,7 +1211,7 @@ describe("R2ProjectStorage", () => {
     // over it SKIPS (no read+zip of every file) and returns a visible skip
     // signal instead of a ProjectSnapshot.
     it("SS-28: snapshots a project under MAX_SNAPSHOT_BYTES normally", async () => {
-      await storage.createProject(userId, projectId, "Small");
+      await storage.createProjectIfAbsent(userId, projectId, "Small");
       await storage.writeFile(userId, projectId, "index.html", "<h1>Small site</h1>");
 
       const result = await storage.createSnapshot(userId, projectId, { trigger: "agent" });
@@ -1222,7 +1222,7 @@ describe("R2ProjectStorage", () => {
     });
 
     it("SS-28: skips (visibly) when the project exceeds MAX_SNAPSHOT_BYTES and writes no archive", async () => {
-      await storage.createProject(userId, projectId, "Huge");
+      await storage.createProjectIfAbsent(userId, projectId, "Huge");
       // One oversized file pushes the summed project size past the cap.
       const oversized = "x".repeat(MAX_SNAPSHOT_BYTES + 1);
       await storage.writeFile(userId, projectId, "big.txt", oversized);
@@ -1258,13 +1258,13 @@ describe("R2ProjectStorage", () => {
 
   describe("findPublishedProjectBySlug", () => {
     it("returns null when no published project matches", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       const result = await storage.findPublishedProjectBySlug(userId, "my-slug");
       expect(result).toBeNull();
     });
 
     it("finds published project by slug", async () => {
-      await storage.createProject(userId, projectId, "Test");
+      await storage.createProjectIfAbsent(userId, projectId, "Test");
       await storage.updateProjectMetadata(userId, projectId, {
         published: true,
         slug: "my-slug"
@@ -1319,7 +1319,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "existing", "Existing");
+    await storage.createProjectIfAbsent("user-a", "existing", "Existing");
     await storage.writeFile("user-a", "existing", "index.html", "keep me");
     journal.values.set("owner-mutation", {
       type: "create",
@@ -1339,7 +1339,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     await storage.writeFile("user-a", "site", "old.txt", "content");
     await storage.writeFile("user-a", "site", "new.txt", "content");
     journal.values.set("owner-mutation", {
@@ -1363,7 +1363,7 @@ describe("OwnerMutationService recovery journal", () => {
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
     const service = new OwnerMutationService(bucket, journal);
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     const admission = {
       type: "upload-if-absent" as const,
       projectId: "site",
@@ -1387,7 +1387,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     const originalPut = journal.put.bind(journal);
     journal.put = vi.fn(async (key, value) => {
       if (key === "upload-admissions") throw new Error("injected DO storage failure");
@@ -1413,7 +1413,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     const prior = [
       { id: "prior-upload", timestamp: 100_000 },
       { id: "corrupt-upload", timestamp: "100_000" },
@@ -1440,7 +1440,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const service = new OwnerMutationService(bucket, journalStore());
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     await storage.writeFile("user-a", "site", "images/photo.png", "existing");
     const operation = {
       type: "upload-if-absent" as const,
@@ -1475,7 +1475,7 @@ describe("OwnerMutationService recovery journal", () => {
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
     const service = new OwnerMutationService(bucket, journal);
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     const existingBytes = (await bucket.list({ prefix: "projects/user-a/site/" })).objects
       .reduce((sum, object) => sum + object.size, 0);
     const policy = {
@@ -1507,7 +1507,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const service = new OwnerMutationService(bucket, journalStore());
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     await service.execute("user-a", { type: "delete-project", projectId: "site" });
 
     await expect(service.execute("user-a", {
@@ -1532,7 +1532,7 @@ describe("OwnerMutationService recovery journal", () => {
       move: vi.fn(async () => undefined)
     };
     const service = new OwnerMutationService(bucket, journal, undefined, history);
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
 
     await expect(service.execute("user-a", {
       type: "delete-project",
@@ -1566,7 +1566,7 @@ describe("OwnerMutationService recovery journal", () => {
       })
     };
     const service = new OwnerMutationService(bucket, journal, undefined, history);
-    await storage.createProject("user-a", "source", "Site");
+    await storage.createProjectIfAbsent("user-a", "source", "Site");
     await storage.writeFile("user-a", "source", "index.html", "complete");
 
     await expect(service.execute("user-a", {
@@ -1593,7 +1593,7 @@ describe("OwnerMutationService recovery journal", () => {
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
     const service = new OwnerMutationService(bucket, journal);
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     await storage.writeFile("user-a", "site", "index.html", "public");
     await storage.updateProjectMetadata("user-a", "site", {
       published: true,
@@ -1641,7 +1641,7 @@ describe("OwnerMutationService recovery journal", () => {
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
     const service = new OwnerMutationService(bucket, journal);
-    await storage.createProject("user-a", "aaa-source", "Site");
+    await storage.createProjectIfAbsent("user-a", "aaa-source", "Site");
     await storage.writeFile("user-a", "aaa-source", "index.html", "complete");
     await service.execute("user-a", {
       type: "publish-project",
@@ -1710,14 +1710,14 @@ describe("OwnerMutationService recovery journal", () => {
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
     const service = new OwnerMutationService(bucket, journal);
-    await storage.createProject("user-a", "source", "Site");
+    await storage.createProjectIfAbsent("user-a", "source", "Site");
     await storage.writeFile("user-a", "source", "index.html", "complete");
     await service.execute("user-a", {
       type: "publish-project",
       projectId: "source",
       desiredSlug: "site"
     });
-    await storage.createProject("user-a", "target", "Site");
+    await storage.createProjectIfAbsent("user-a", "target", "Site");
     await storage.writeFile("user-a", "target", "index.html", "complete");
     await storage.updateProjectMetadata("user-a", "target", {
       published: false,
@@ -1754,7 +1754,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const service = new OwnerMutationService(bucket, journalStore());
-    await storage.createProject("user-a", "old-site", "Blog");
+    await storage.createProjectIfAbsent("user-a", "old-site", "Blog");
 
     await expect(service.execute("user-a", {
       type: "publish-project",
@@ -1778,7 +1778,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "existing", "Existing");
+    await storage.createProjectIfAbsent("user-a", "existing", "Existing");
     await storage.writeFile("user-a", "existing", "index.html", "keep me");
     const service = new OwnerMutationService(bucket, journal);
     const journalPut = vi.spyOn(journal, "put");
@@ -1806,7 +1806,7 @@ describe("OwnerMutationService recovery journal", () => {
     const bucket = createMockBucket();
     const storage = new R2ProjectStorage(bucket);
     const journal = journalStore();
-    await storage.createProject("user-a", "site", "Site");
+    await storage.createProjectIfAbsent("user-a", "site", "Site");
     await storage.writeFile("user-a", "site", "old.txt", "source");
     await storage.writeFile("user-a", "site", "new.txt", "existing destination");
     const service = new OwnerMutationService(bucket, journal);

--- a/packages/app/src/storage/r2.ts
+++ b/packages/app/src/storage/r2.ts
@@ -223,20 +223,6 @@ export class R2ProjectStorage {
     return visible.filter((projectId): projectId is string => projectId !== null).sort();
   }
 
-  async createProject(userId: string, projectId: string, name: string): Promise<ProjectMetadata> {
-    const now = new Date().toISOString();
-    const metadata: ProjectMetadata = {
-      id: projectId,
-      name,
-      createdAt: now,
-      updatedAt: now,
-      published: false
-    };
-
-    await this.putJson(metadataKey(userId, projectId), metadata);
-    return metadata;
-  }
-
   async createProjectIfAbsent(
     userId: string,
     projectId: string,
@@ -422,8 +408,8 @@ export class R2ProjectStorage {
       // fabricate the record. The old absent-object branch wrote a default
       // record via `etagDoesNotMatch: "*"`, so a publish racing a delete could
       // resurrect the just-deleted project as a `{published: true, slug}`
-      // ghost. Creation stays with the explicit create paths (createProject,
-      // createProjectIfAbsent, renameProject's target claim); an update of an
+      // ghost. Creation stays with the explicit create paths
+      // (createProjectIfAbsent, renameProject's target claim); an update of an
       // absent record is always a caller bug or a concurrent delete, and both
       // must surface.
       if (!object) {

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -17,10 +17,10 @@ export interface Env {
   APP_PUBLIC_DOMAIN?: string;
   PUBLISHED_BASE_URL?: string;
   LOADER: WorkerLoader;
-  // ---- CAIL backbone (docs/INTEGRATION.md) ----
+  // ---- CAIL model gateway (cail-gateway docs/gateway-contract.md) ----
   // The public base URL of the CAIL model proxy. The checked-in value is source
   // configuration, not proof of the live deployment; verify operations state
-  // against the gateway integration contract.
+  // against the Gateway runtime contract.
   CAIL_API_BASE?: string;
   // Workers AI model id for the gateway's OpenAI-compatible path (`@cf/...`
   // only under current CAIL policy).

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -56,14 +56,15 @@
     "CAIL_LOG_ENV": "production",
     "APP_PUBLIC_DOMAIN": "https://tools.ailab.gc.cuny.edu",
     "PUBLISHED_BASE_URL": "https://tools.ailab.gc.cuny.edu/site-studio",
-    // ---- CAIL backbone (see cail-gateway docs/INTEGRATION.md) ----
+    // ---- CAIL model gateway (see cail-gateway docs/gateway-contract.md) ----
     // CAIL_API_BASE: the canonical CAIL Gateway origin. The shared client owns
     // its /v1 model and quota paths. Chat calls hit
     // {CAIL_API_BASE}/v1/chat/completions; image generation hits the native
     // {CAIL_API_BASE}/v1/run.
     "CAIL_API_BASE": "https://tools.ailab.gc.cuny.edu",
-    // CAIL_MODEL: Workers AI catalog id. CAIL policy (2026-07-04): Cloudflare
-    // models only — any override must also be a `@cf/...` id. Default is the
+    // CAIL_MODEL: Workers AI catalog id. CAIL model admission policy
+    // (cail-gateway docs/model-admission-contract.md): Cloudflare models only —
+    // any override must also be a `@cf/...` id. Default is the
     // agentic-coding flagship; `@cf/openai/gpt-oss-120b` is the cheaper fallback.
     "CAIL_MODEL": "@cf/zai-org/glm-5.2",
     // CAIL_IMAGE_MODEL: text-to-image Workers AI catalog id (native /v1/run

--- a/packages/frontend/src/lib/api/csrf.ts
+++ b/packages/frontend/src/lib/api/csrf.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 import { handleApiErrorResponse } from './error-handler';
 
 /**
- * Anti-CSRF token client (CAIL INTEGRATION.md §3¾).
+ * Anti-CSRF token client (docs/security-and-recovery.md, browser and serving
+ * defenses).
  *
  * Every state-changing request to /api/* must carry an `X-CSRF-Token` header, and
  * agent WebSocket connects must append `?csrf=<token>`. The token is DELIVERED by

--- a/packages/frontend/src/lib/components/AgentChat.svelte
+++ b/packages/frontend/src/lib/components/AgentChat.svelte
@@ -125,7 +125,6 @@ import {
 	// transport owns active response streams; these markers cover server resume
 	// announcements that can arrive after the local stream has been stopped.
 	let cancelledRequestIds = $state<Set<string>>(new Set());
-	let settledRequestIds = $state<Set<string>>(new Set());
 	let cancelTurnDeliveryPending = false;
 	let ignoreNextSocketClose = $state(false);
 	let requestStartedAt = $state<number | null>(null);
@@ -135,7 +134,6 @@ import {
 	// hook runs. Keep its correlation and message anchors long enough for the one
 	// authenticated history read or the late custom commit to repair the transcript.
 	let pendingHistoryReconciliations = $state<PendingHistoryReconciliation[]>([]);
-	let pendingCommit: { requestId: string; messages: UIChatMessage[] } | null = $state(null);
 	const completedMutatingToolCalls = new Set<string>();
 	let historyRefreshPending = $state(false);
 	// SS-11: guard so we refresh the CSRF cookie at most once per reconnect cycle
@@ -404,7 +402,7 @@ import {
 		};
 	}
 
-	function resetRequestState() {
+	function resetRequestState(scheduleRefresh = true) {
 		isLoading = false;
 		currentStatus = '';
 		currentRequestId = null;
@@ -413,12 +411,11 @@ import {
 		requestStartedAt = null;
 		toolStartTimes = {};
 		isReconnecting = false;
-		schedulePendingHistoryRefresh();
+		if (scheduleRefresh) schedulePendingHistoryRefresh();
 	}
 
 	function cancelResumedRequest(requestId: string) {
 		cancelledRequestIds.add(requestId);
-		settledRequestIds = new Set([...settledRequestIds, requestId].slice(-8));
 		try {
 			sendSocketMessage({ type: AgentMessageType.CF_AGENT_CHAT_REQUEST_CANCEL, id: requestId });
 		} catch (error) {
@@ -1137,17 +1134,7 @@ import {
 			generation: requestGeneration
 		};
 		rememberHistoryReconciliation(reconciliation);
-		const committed = pendingCommit;
-		pendingCommit = null;
 		resetRequestState();
-		if (committed) {
-			setChatMessages(committed.messages);
-			takeHistoryReconciliation(reconciliation.requestId);
-			historyLoadFailed = false;
-			onUpdate();
-			scrollToBottom();
-			return;
-		}
 		const targetProjectId = projectId;
 		const targetEpoch = projectContextEpoch;
 		if (targetProjectId) {
@@ -1194,7 +1181,6 @@ import {
 		expectingContinuation = false;
 		cancelledContinuationPending = false;
 		cancelledRequestIds = new Set();
-		settledRequestIds = new Set();
 		void chat.sendMessage().catch((error) => {
 			if (isCurrentProjectContext(targetProjectId, targetEpoch)) {
 				console.error('Error sending chat request:', error);
@@ -1278,19 +1264,20 @@ import {
 				clearReconciledHistoryEntries(incomingHistory);
 				historyLoadFailed = false;
 				scrollToBottom();
+				schedulePendingHistoryRefresh();
 				break;
 			}
 			case AgentMessageType.CF_AGENT_MESSAGE_UPDATED:
 				if (data.message) {
 					setChatMessages(mergeUpdatedMessage(uiMessages, data.message));
 					clearReconciledHistoryEntries(uiMessages);
+					schedulePendingHistoryRefresh();
 				}
 				scrollToBottom();
 				break;
 			case AgentMessageType.SITE_STUDIO_CHAT_CANCELLED:
 				if (currentRequestId) {
 					cancelledRequestIds.add(currentRequestId);
-					settledRequestIds = new Set([...settledRequestIds, currentRequestId].slice(-8));
 				}
 				cancelledContinuationPending = cancelledContinuationPending || expectingContinuation;
 				resetRequestState();
@@ -1301,14 +1288,8 @@ import {
 				const isCurrentRequest = committed.requestId === currentRequestId;
 				const isActiveTransportRequest = activeRequestIds.has(committed.requestId);
 				const matchingReconciliation = pendingHistoryReconciliations.find(
-					(entry) =>
-						entry.requestId === committed.requestId ||
-						committed.messages.some((message) => message.id === entry.assistantMessageId)
+					(entry) => entry.requestId === committed.requestId
 				);
-				const currentAssistantId = findLastAssistantMessage(uiMessages)?.id;
-				const commitContainsCurrentAssistant = currentAssistantId
-					? committed.messages.some((message) => message.id === currentAssistantId)
-					: false;
 				// The persisted commit is the authoritative terminal for this connection.
 				// The maintained transport removes its request id synchronously when it
 				// sees done:true, while the SDK may still be consuming the final tool
@@ -1319,23 +1300,21 @@ import {
 				if (isLoading && (isCurrentRequest || isActiveTransportRequest)) {
 					if (isActiveTransportRequest) void chat.stop();
 					chatTransport.handleServerTurnCompleted(committed.requestId);
-					resetRequestState();
+					resetRequestState(false);
 					setChatMessages(committed.messages);
 					historyLoadFailed = false;
 					onUpdate();
 					scrollToBottom();
+					schedulePendingHistoryRefresh();
 					break;
 				}
 				if (isLoading) {
-					pendingCommit = { requestId: committed.requestId, messages: committed.messages };
 					historyRefreshPending = true;
 					break;
 				}
-				if (!matchingReconciliation && committed.messages.length < uiMessages.length) {
+				if (!matchingReconciliation) {
 					historyRefreshPending = true;
-					break;
-				}
-				if (!matchingReconciliation && uiMessages.length > 0 && !commitContainsCurrentAssistant && committed.messages.length <= uiMessages.length) {
+					schedulePendingHistoryRefresh();
 					break;
 				}
 				if (matchingReconciliation) takeHistoryReconciliation(matchingReconciliation.requestId);
@@ -1343,6 +1322,7 @@ import {
 				historyLoadFailed = false;
 				onUpdate();
 				scrollToBottom();
+				schedulePendingHistoryRefresh();
 				break;
 			}
 		}
@@ -1414,6 +1394,8 @@ import {
 		attachedFile = null;
 		cancelledContinuationPending = false;
 		cancelTurnDeliveryPending = false;
+		pendingHistoryReconciliations = [];
+		historyRefreshPending = false;
 		resetRequestState();
 		setChatMessages([]);
 		closeSocket();
@@ -1446,7 +1428,6 @@ import {
 		const wasAwaitingContinuation = expectingContinuation;
 		if (stoppedRequestId) {
 			cancelledRequestIds.add(stoppedRequestId);
-			settledRequestIds = new Set([...settledRequestIds, stoppedRequestId].slice(-8));
 		}
 		cancelledContinuationPending = wasAwaitingContinuation;
 		cancelTurnDeliveryPending = true;

--- a/packages/frontend/src/lib/components/AgentChat.test.ts
+++ b/packages/frontend/src/lib/components/AgentChat.test.ts
@@ -616,6 +616,75 @@ describe('AgentChat', () => {
 		await waitFor(() => expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument());
 	});
 
+	it('repairs an unrelated commit through authenticated history without replacing the active turn', async () => {
+		let historyGets = 0;
+		let authoritativeHistory: UIChatMessage[] = [];
+		fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+			const url = requestUrl(input);
+			if (url.endsWith('/api/csrf')) {
+				document.cookie = 'cail_csrf_sitestudio=test-csrf-token';
+				return new Response(null, { status: 204 });
+			}
+			if (url.endsWith('/get-messages')) {
+				historyGets += 1;
+				return new Response(JSON.stringify(authoritativeHistory), { status: 200 });
+			}
+			return new Response('[]', { status: 200 });
+		});
+
+		const { component } = renderExposed();
+		await waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+		const ws = FakeWebSocket.last();
+		ws.open();
+		await settle();
+
+		await component.sendPrompt('keep this turn visible');
+		await settle();
+		const request = ws.sent
+			.map((raw) => JSON.parse(raw))
+			.find((message) => message.type === AgentMessageType.CF_AGENT_USE_CHAT_REQUEST);
+		expect(request).toBeTruthy();
+		const userMessageId = JSON.parse(request.init.body).messages.at(-1).id;
+		authoritativeHistory = [
+			{ id: userMessageId, role: 'user', parts: [{ type: 'text', text: 'keep this turn visible' }] },
+			{ id: 'current-persisted-assistant', role: 'assistant', parts: [{ type: 'text', text: 'current persisted answer' }] }
+		];
+
+		ws.serverMessage({
+			type: AgentMessageType.SITE_STUDIO_CHAT_COMMITTED,
+			requestId: 'other-tab-request',
+			messages: [
+				{ id: 'other-tab-user', role: 'user', parts: [{ type: 'text', text: 'other tab turn' }] },
+				{ id: 'other-tab-assistant', role: 'assistant', parts: [{ type: 'text', text: 'other tab answer' }] }
+			]
+		});
+		await settle();
+		expect(screen.queryByText('other tab answer')).not.toBeInTheDocument();
+		expect(screen.getByTitle('Stop request')).toBeInTheDocument();
+
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({ type: 'text-start', id: 'current-text' })
+		});
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({ type: 'text-delta', id: 'current-text', delta: 'current answer' })
+		});
+		ws.serverMessage({
+			type: AgentMessageType.CF_AGENT_USE_CHAT_RESPONSE,
+			id: request.id,
+			body: JSON.stringify({ type: 'text-end', id: 'current-text' }),
+			done: true
+		});
+
+		await waitFor(() => expect(screen.getByText('current persisted answer')).toBeInTheDocument());
+		await waitFor(() => expect(screen.queryByTitle('Stop request')).not.toBeInTheDocument());
+		await waitFor(() => expect(historyGets).toBeGreaterThanOrEqual(3));
+		expect(screen.queryByText('other tab answer')).not.toBeInTheDocument();
+	});
+
 	it('does not let a delayed completed-turn history read erase a newer request', async () => {
 		let historyGets = 0;
 		let oldHistoryRequested = false;

--- a/packages/frontend/src/lib/components/CodeView.svelte
+++ b/packages/frontend/src/lib/components/CodeView.svelte
@@ -34,7 +34,7 @@
 		onFileSelect: (path: string) => void;
 		onEditorChange: (content: string) => void;
 		onDownloadFile: (path: string) => void | Promise<void>;
-		onRefreshFiles: () => void;
+		onRefreshFiles: () => void | Promise<void>;
 		isSaving: boolean;
 	} = $props();
 

--- a/packages/frontend/src/lib/components/FileTree.svelte
+++ b/packages/frontend/src/lib/components/FileTree.svelte
@@ -26,7 +26,7 @@
 		files: FileNode[],
 		projectId: string,
 		onSelect: (path: string) => void,
-		onRefresh: () => void
+		onRefresh: () => void | Promise<void>
 	} = $props();
 
 	let fileInput: HTMLInputElement;
@@ -52,7 +52,7 @@
 			if (!response.ok) await handleApiError(response);
 
 			// Refresh file list
-			onRefresh();
+			await onRefresh();
 
 			// Clear input
 			input.value = '';
@@ -94,7 +94,7 @@
 			}
 
 			// Refresh file list
-			onRefresh();
+			await onRefresh();
 		} catch (error) {
 			console.error('Error deleting file:', error);
 			toast.error(`Couldn't delete that file. ${getErrorMessage(error instanceof Error ? error : undefined)}`);
@@ -124,7 +124,7 @@
 			}
 
 			// Refresh file list
-			onRefresh();
+			await onRefresh();
 		} catch (error) {
 			console.error('Error renaming file:', error);
 			toast.error(`Couldn't rename that file. ${getErrorMessage(error instanceof Error ? error : undefined)}`);

--- a/packages/frontend/src/lib/file-tree-refresh.test.ts
+++ b/packages/frontend/src/lib/file-tree-refresh.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createFileTreeRefreshCoordinator,
+	type FileTreeRefreshRequest
+} from './file-tree-refresh';
+
+function request(overrides: Partial<FileTreeRefreshRequest> = {}): FileTreeRefreshRequest {
+	return {
+		projectId: 'project-a',
+		contextVersion: 1,
+		source: 'manual',
+		reloadCurrentFile: false,
+		refreshPreview: false,
+		...overrides
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}
+
+describe('file-tree refresh coordinator', () => {
+	it('keeps one load in flight and performs one latest invalidation after it', async () => {
+		const first = deferred<string[]>();
+		const second = deferred<string[]>();
+		const loads: Array<ReturnType<typeof deferred<string[]>>> = [first, second];
+		const load = vi.fn(() => loads.shift()?.promise ?? Promise.resolve([]));
+		let current: FileTreeRefreshRequest = request();
+		const loaded: string[][] = [];
+		const coordinator = createFileTreeRefreshCoordinator<string[]>({
+			load,
+			isCurrent: (next) => next.projectId === current.projectId && next.contextVersion === current.contextVersion,
+			onLoaded: (_next, value) => {
+				loaded.push(value);
+			},
+			onError: vi.fn()
+		});
+
+		const initial = coordinator.request(current);
+		const coalesced = coordinator.request({ ...current, source: 'agent', refreshPreview: true });
+		expect(load).toHaveBeenCalledTimes(1);
+
+		first.resolve(['index.html']);
+		await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+		second.resolve(['index.html', 'about.html']);
+		await Promise.all([initial, coalesced]);
+
+		expect(load).toHaveBeenCalledTimes(2);
+		expect(loaded).toEqual([
+			['index.html'],
+			['index.html', 'about.html']
+		]);
+	});
+
+	it('drops an old project result and reads the switched project through the same queue', async () => {
+		const projectA = deferred<string[]>();
+		const projectB = deferred<string[]>();
+		const load = vi.fn((projectId: string) => (projectId === 'project-a' ? projectA.promise : projectB.promise));
+		let current = request();
+		const loaded: string[][] = [];
+		const coordinator = createFileTreeRefreshCoordinator<string[]>({
+			load,
+			isCurrent: (next) => next.projectId === current.projectId && next.contextVersion === current.contextVersion,
+			onLoaded: (_next, value) => {
+				loaded.push(value);
+			},
+			onError: vi.fn()
+		});
+
+		const oldRequest = coordinator.request(current);
+		current = request({ projectId: 'project-b', contextVersion: 2, source: 'project-load' });
+		const newRequest = coordinator.request(current);
+		projectA.resolve(['stale-a.html']);
+		await Promise.resolve();
+		expect(load).toHaveBeenCalledTimes(2);
+		projectB.resolve(['current-b.html']);
+		await Promise.all([oldRequest, newRequest]);
+
+		expect(loaded).toEqual([['current-b.html']]);
+	});
+
+	it('reports a current failure and can recover on the next explicit invalidation', async () => {
+		const load = vi
+			.fn<() => Promise<string[]>>()
+			.mockRejectedValueOnce(new Error('temporary read failure'))
+			.mockResolvedValueOnce(['recovered.html']);
+		const onError = vi.fn();
+		const loaded: string[][] = [];
+		const coordinator = createFileTreeRefreshCoordinator<string[]>({
+			load,
+			isCurrent: () => true,
+			onLoaded: (_request, value) => {
+				loaded.push(value);
+			},
+			onError
+		});
+
+		await coordinator.request(request());
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(loaded).toEqual([]);
+
+		await coordinator.request(request({ source: 'manual' }));
+		expect(loaded).toEqual([['recovered.html']]);
+	});
+});

--- a/packages/frontend/src/lib/file-tree-refresh.ts
+++ b/packages/frontend/src/lib/file-tree-refresh.ts
@@ -1,0 +1,99 @@
+export type FileTreeRefreshSource = 'project-load' | 'manual' | 'agent';
+
+export interface FileTreeRefreshRequest {
+	projectId: string;
+	contextVersion: number;
+	source: FileTreeRefreshSource;
+	reloadCurrentFile: boolean;
+	refreshPreview: boolean;
+}
+
+export interface FileTreeRefreshCallbacks<T> {
+	load: (projectId: string) => Promise<T>;
+	isCurrent: (request: FileTreeRefreshRequest) => boolean;
+	onLoaded: (request: FileTreeRefreshRequest, value: T) => void | Promise<void>;
+	onError: (request: FileTreeRefreshRequest, error: Error) => void | Promise<void>;
+}
+
+export interface FileTreeRefreshCoordinator {
+	request: (request: FileTreeRefreshRequest) => Promise<void>;
+	dispose: () => void;
+}
+
+function mergeRequests(
+	current: FileTreeRefreshRequest,
+	next: FileTreeRefreshRequest
+): FileTreeRefreshRequest {
+	if (current.projectId !== next.projectId || current.contextVersion !== next.contextVersion) {
+		return next;
+	}
+
+	return {
+		...next,
+		reloadCurrentFile: current.reloadCurrentFile || next.reloadCurrentFile,
+		refreshPreview: current.refreshPreview || next.refreshPreview
+	};
+}
+
+/**
+ * Keep file-tree reads single-flight while coalescing invalidations that happen
+ * during the current read. The parent owns the callbacks so a stale project
+ * response cannot update a newer project or clear its error state.
+ */
+export function createFileTreeRefreshCoordinator<T>(
+	callbacks: FileTreeRefreshCallbacks<T>
+): FileTreeRefreshCoordinator {
+	let pending: FileTreeRefreshRequest | null = null;
+	let inFlight: Promise<void> | null = null;
+	let disposed = false;
+
+	async function run(): Promise<void> {
+		while (!disposed && pending) {
+			const request = pending;
+			pending = null;
+
+			let value: T;
+			try {
+				value = await callbacks.load(request.projectId);
+			} catch (error) {
+				if (!disposed && callbacks.isCurrent(request)) {
+					await callbacks.onError(
+						request,
+						error instanceof Error ? error : new Error('File tree refresh failed')
+					);
+				}
+				continue;
+			}
+
+			if (!disposed && callbacks.isCurrent(request)) {
+				try {
+					await callbacks.onLoaded(request, value);
+				} catch (error) {
+					await callbacks.onError(
+						request,
+						error instanceof Error ? error : new Error('File tree refresh failed')
+					);
+				}
+			}
+		}
+	}
+
+	function request(next: FileTreeRefreshRequest): Promise<void> {
+		if (disposed) return Promise.resolve();
+
+		pending = pending ? mergeRequests(pending, next) : next;
+		if (!inFlight) {
+			inFlight = run().finally(() => {
+				inFlight = null;
+			});
+		}
+		return inFlight;
+	}
+
+	function dispose(): void {
+		disposed = true;
+		pending = null;
+	}
+
+	return { request, dispose };
+}

--- a/packages/frontend/src/routes/editor/[projectId]/+page.svelte
+++ b/packages/frontend/src/routes/editor/[projectId]/+page.svelte
@@ -25,6 +25,11 @@
 	import ImageManagerDialog from '$lib/components/ImageManagerDialog.svelte';
 	import HandleClaimDialog from '$lib/components/HandleClaimDialog.svelte';
 	import { toast } from '$lib/toast.svelte';
+	import {
+		createFileTreeRefreshCoordinator,
+		type FileTreeRefreshRequest,
+		type FileTreeRefreshSource
+	} from '$lib/file-tree-refresh';
 	import { Pane } from 'paneforge';
 	import { z } from 'zod';
 	import type { Driver } from 'driver.js';
@@ -252,6 +257,66 @@
 		return data.files;
 	}
 
+	function isCurrentFileContext(targetProjectId: string, targetContextVersion: number): boolean {
+		return targetProjectId === projectId && targetContextVersion === projectLoadVersion;
+	}
+
+	function isCurrentFileRefresh(request: FileTreeRefreshRequest): boolean {
+		return isCurrentFileContext(request.projectId, request.contextVersion);
+	}
+
+	const fileTreeRefreshCoordinator = createFileTreeRefreshCoordinator<ProjectFile[]>({
+		load: loadFiles,
+		isCurrent: isCurrentFileRefresh,
+		onLoaded: async (request, loadedFiles) => {
+			if (!isCurrentFileRefresh(request)) return;
+
+			filesLoadError = null;
+			files = loadedFiles;
+
+			if (request.reloadCurrentFile && currentFile) {
+				const filePath = currentFile;
+				await onFileSelect(filePath, request.projectId, request.contextVersion);
+			}
+
+			if (request.refreshPreview && isCurrentFileRefresh(request)) {
+				previewComponent?.refresh();
+			}
+		},
+		onError: (request, error) => {
+			if (!isCurrentFileRefresh(request)) return;
+
+			console.error('Error refreshing files:', error);
+			filesLoadError = error instanceof Error ? error.message : 'Failed to load project files';
+			toast.error(
+				request.source === 'project-load'
+					? 'Could not load the project. Check your connection and retry.'
+					: 'Could not refresh the file list. Check your connection and retry.'
+			);
+		}
+	});
+
+	$effect(() => {
+		return () => fileTreeRefreshCoordinator.dispose();
+	});
+
+	function requestFileRefresh(
+		source: FileTreeRefreshSource,
+		options: Partial<Pick<FileTreeRefreshRequest, 'reloadCurrentFile' | 'refreshPreview'>> = {},
+		targetProjectId = projectId,
+		targetContextVersion = projectLoadVersion
+	): Promise<void> {
+		if (!targetProjectId) return Promise.resolve();
+
+		return fileTreeRefreshCoordinator.request({
+			projectId: targetProjectId,
+			contextVersion: targetContextVersion,
+			source,
+			reloadCurrentFile: options.reloadCurrentFile ?? false,
+			refreshPreview: options.refreshPreview ?? false
+		});
+	}
+
 	function findFileByPath(nodes: ProjectFile[], filePath: string): ProjectFile | null {
 		for (const node of nodes) {
 			if (node.type === 'file' && node.path === filePath) {
@@ -274,10 +339,17 @@
 
 	let fileSelectCounter = 0;
 
-	async function onFileSelect(filePath: string) {
-		if (!projectId) return;
+	async function onFileSelect(
+		filePath: string,
+		expectedProjectId = projectId,
+		expectedContextVersion = projectLoadVersion
+	) {
+		if (!isCurrentFileContext(expectedProjectId, expectedContextVersion)) return;
+
+		const targetProjectId = expectedProjectId;
 		const didFlushPendingSave = await flushPendingSave();
 		if (!didFlushPendingSave) return;
+		if (!isCurrentFileContext(targetProjectId, expectedContextVersion)) return;
 
 		const requestId = ++fileSelectCounter;
 		const selectedFile = findFileByPath(files, filePath);
@@ -299,13 +371,13 @@
 
 		try {
 			const response = await apiResponseFetch(
-				resolvePath(`/api/projects/${projectId}/file?path=${encodeURIComponent(filePath)}`),
+				resolvePath(`/api/projects/${targetProjectId}/file?path=${encodeURIComponent(filePath)}`),
 				{
 					credentials: 'include'
 				}
 			);
 			if (response.status === 415) {
-				if (requestId !== fileSelectCounter) return;
+				if (requestId !== fileSelectCounter || !isCurrentFileContext(targetProjectId, expectedContextVersion)) return;
 				currentFileIsText = false;
 				fileContent = '';
 				currentFileEtag = null;
@@ -315,7 +387,7 @@
 			if (!response.ok) throw new Error('Failed to load file');
 
 			// Ignore stale response if user selected a different file
-			if (requestId !== fileSelectCounter) return;
+			if (requestId !== fileSelectCounter || !isCurrentFileContext(targetProjectId, expectedContextVersion)) return;
 
 			const data = parseLoadedFileResponse(await response.text());
 			currentFileContentType = data.contentType || selectedFile?.contentType || '';
@@ -327,7 +399,7 @@
 			} catch (error) {
 				console.error('Could not read encrypted local draft:', error);
 			}
-			if (requestId !== fileSelectCounter) return;
+			if (requestId !== fileSelectCounter || !isCurrentFileContext(targetProjectId, expectedContextVersion)) return;
 			if (draft && draft.content !== data.content) {
 				fileContent = draft.content;
 				currentFileEtag = draft.baseEtag;
@@ -339,7 +411,7 @@
 			currentFileOpenStatus = 'loaded';
 		} catch (error) {
 			console.error('Error loading file:', error);
-			if (requestId === fileSelectCounter) {
+			if (requestId === fileSelectCounter && isCurrentFileContext(targetProjectId, expectedContextVersion)) {
 				// SS-47: the load FAILED — do not present the previous file's text as
 				// this file, and do not drop into an unguarded-write state (the etag
 				// is gone, so autosave would silently overwrite the file with stale
@@ -467,15 +539,15 @@
 		};
 	});
 
-	async function refreshProjectState(targetProjectId: string) {
-		const loadVersion = ++projectLoadVersion;
+	async function refreshProjectState(targetProjectId: string, loadVersion = ++projectLoadVersion) {
 		projectMissing = false;
-		let loadedFiles: ProjectFile[];
-		let loadedProjects: Project[];
+		let loadedProjects: Project[] | undefined;
 		try {
-			[loadedFiles, loadedProjects] = await Promise.all([
-				loadFiles(targetProjectId),
-				loadAllProjects()
+			await Promise.all([
+				requestFileRefresh('project-load', {}, targetProjectId, loadVersion),
+				loadAllProjects().then((projects) => {
+					loadedProjects = projects;
+				})
 			]);
 		} catch (error) {
 			console.error('Error loading project state:', error);
@@ -490,12 +562,11 @@
 			return;
 		}
 
-		if (loadVersion !== projectLoadVersion || targetProjectId !== projectId) {
+		if (!isCurrentFileContext(targetProjectId, loadVersion) || filesLoadError || !loadedProjects) {
 			return;
 		}
 
 		filesLoadError = null;
-		files = loadedFiles;
 		allProjects = loadedProjects;
 		currentProject = loadedProjects.find((project) => project.id === targetProjectId) || null;
 		projectMissing = currentProject === null;
@@ -503,16 +574,8 @@
 	}
 
 	/** Retry/refresh the file tree from CodeView; failures surface, never blank. */
-	async function handleRefreshFiles() {
-		try {
-			const loadedFiles = await loadFiles();
-			filesLoadError = null;
-			files = loadedFiles;
-		} catch (error) {
-			console.error('Error refreshing files:', error);
-			filesLoadError = error instanceof Error ? error.message : 'Failed to load project files';
-			toast.error('Could not refresh the file list. Check your connection and retry.');
-		}
+	async function handleRefreshFiles(): Promise<void> {
+		await requestFileRefresh('manual');
 	}
 
 	async function navigateToProject(targetProjectId: string) {
@@ -525,6 +588,7 @@
 	}
 
 	async function handleProjectChange(targetProjectId: string, fallbackProjectId: string | null) {
+		const loadVersion = ++projectLoadVersion;
 		const didFlushPendingSave = await flushPendingSave();
 		if (!didFlushPendingSave) {
 			if (fallbackProjectId && fallbackProjectId !== targetProjectId) {
@@ -544,7 +608,7 @@
 		projectMissing = false;
 		currentProject = null;
 
-		await refreshProjectState(targetProjectId);
+		await refreshProjectState(targetProjectId, loadVersion);
 	}
 
 	$effect(() => {
@@ -556,26 +620,7 @@
 	});
 
 	async function onAgentUpdate() {
-		// Reload files when agent makes changes. SS-48: on failure keep the tree
-		// we already have (it is stale, not gone) and say so, rather than
-		// rendering the project as empty.
-		try {
-			files = await loadFiles(projectId);
-			filesLoadError = null;
-		} catch (error) {
-			console.error('Error reloading files after agent update:', error);
-			toast.error('Could not refresh the file list after the last change.');
-		}
-
-		// Reload current file if it's open
-		if (currentFile) {
-			await onFileSelect(currentFile);
-		}
-
-		// Refresh preview to show agent's changes
-		if (previewComponent) {
-			previewComponent.refresh();
-		}
+		await requestFileRefresh('agent', { reloadCurrentFile: true, refreshPreview: true });
 	}
 
 	async function handleCurrentFileDownload(filePath: string) {

--- a/scripts/local-browser-e2e.ts
+++ b/scripts/local-browser-e2e.ts
@@ -385,6 +385,20 @@ async function runBrowserPath(baseUrl: string, token: string): Promise<void> {
     await page.getByRole("button", { name: "Send message" }).click();
     await expect.poll(() => completionMessages().count()).toBe(completedMessagesBeforeStop + 1);
 
+    const completedMessagesBeforeMultiple = await completionMessages().count();
+    await chatInput.fill("Run multiple mutating tools.");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect.poll(() => completionMessages().count()).toBe(completedMessagesBeforeMultiple + 1);
+    await expect
+      .poll(() => receivedSocketFrames.some((frame) =>
+        frame.type === "site_studio_chat_committed"
+        && frame.messages?.some((message) =>
+          message.role === "assistant"
+          && message.parts.filter((part) => part.type === "tool-codemode").length >= 2,
+        ) === true,
+      ))
+      .toBe(true);
+
     // A blank project is visibly useful only once authored assets execute.
     await page.getByRole("button", { name: "Show code editor" }).click();
     await expect(page.getByRole("button", { name: "Upload file" })).toBeVisible();
@@ -398,6 +412,22 @@ async function runBrowserPath(baseUrl: string, token: string): Promise<void> {
         exact: true,
       }),
     ).toBeVisible();
+
+    // Exercise the parent-owned refresh queue across real file mutations. The
+    // mutation requests overlap with their follow-up tree reads; the visible
+    // tree must settle on the final state without losing the current project.
+    page.once("dialog", async (dialog) => {
+      await dialog.accept("browser-child-renamed.js");
+    });
+    await page.getByRole("button", { name: "Rename browser-child.js" }).click();
+    await expect(page.getByRole("button", { name: "browser-child-renamed.js", exact: true })).toBeVisible();
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await page.getByRole("button", { name: "Delete browser-child-renamed.js" }).click();
+    await expect(page.getByRole("button", { name: "browser-child-renamed.js", exact: true })).not.toBeVisible();
+    await upload.setInputFiles(CHILD_FIXTURE);
+    await expect(page.getByRole("button", { name: "browser-child.js", exact: true })).toBeVisible();
 
     await page.getByRole("button", { name: "index.html", exact: true }).click();
     await waitForEditorText(page, "<!DOCTYPE html>");
@@ -554,7 +584,7 @@ async function main(): Promise<void> {
     await waitForWorker(baseUrl, worker.child);
     await runBrowserPath(baseUrl, identity.token);
     console.log(
-      "local browser acceptance passed: dashboard/create/chat-tool/stop-recovery/persisted-commit/edit/upload/preview/CSS+nested-module/version-restore/download/ZIP/reload/delete",
+      "local browser acceptance passed: dashboard/create/chat-tool/stop-recovery/multiple-tools/persisted-commit/edit/upload/rename/delete/preview/CSS+nested-module/version-restore/download/ZIP/reload",
     );
     passed = true;
   } finally {


### PR DESCRIPTION
## What changed

- serialize file-tree refreshes and coalesce later invalidations without letting stale project reads overwrite current state
- refresh the current file and preview only for the active project context
- correlate persisted chat commits by exact request ID; unmatched commits repair from authenticated history instead of overwriting another turn
- remove dead settlement state and the obsolete non-atomic project-creation method
- align maintained Gateway, quota, and portable publication documentation with source

## Verification

- `bun run check` (768 app tests, 192 frontend tests, lint, types, boundary contracts, production build)
- `bun run e2e:local` across dashboard/create/chat/tool/stop recovery/multiple tools/persisted commit/edit/upload/rename/delete/preview/CSS+nested modules/version restore/download/ZIP/reload
- independent review of exact combined SHA accepted

No Gateway/provider, OpenWebUI, Bedrock, NML, dev, account, or production changes.