### PR TITLE
Keep model affinity by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ model and quota paths. The active default is the Workers AI catalog model
 `@cf/zai-org/glm-5.2`; any configured override must also be a `@cf/...` model.
 The app forwards only the separately verified,
 subject-bound gateway identity and stamps `X-CAIL-App: site-studio`. Site Studio
-has no provider keys and does not impose an output-token or model-step cap.
-Billed model POSTs use `maxRetries: 0` because an uncertain automatic retry can
-duplicate a paid execution.
+uses the project id as the Gateway session identifier; Gateway namespaces and
+hashes it before provider egress. Site Studio has no provider keys and does not
+impose an output-token or model-step cap. Billed model POSTs use `maxRetries: 0`
+because an uncertain automatic retry can duplicate a paid execution.
 
 ## One-time first-login import
 

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -2523,7 +2523,9 @@ export class SiteBuilderAgent extends AIChatAgent<Env> {
       // this request's traceparent + X-CAIL-Request-Id so spend and upstream
       // errors are followable end to end (browser → worker → DO → gateway).
       const gatewayFetch = withCorrelationFetch(correlation);
-      const model = createCailModel(this.env, identityJwt, gatewayFetch);
+      const model = createCailModel(this.env, identityJwt, gatewayFetch, {
+        sessionId: scope.projectId,
+      });
       const parsedBody = chatRequestBodySchema.safeParse(options?.body);
       const bodyMessages: RequestMessage[] | undefined = parsedBody.success
         ? parsedBody.data.messages

--- a/packages/app/src/lib/model.test.ts
+++ b/packages/app/src/lib/model.test.ts
@@ -355,13 +355,19 @@ describe("createCailModel wire contract", () => {
       }
       return chatCompletionResponse();
     });
-    const model = createCailModel({ CAIL_API_BASE: "https://cail.example" }, "verified-jwt", stub);
+    const model = createCailModel(
+      { CAIL_API_BASE: "https://cail.example" },
+      "verified-jwt",
+      stub,
+      { sessionId: "project-123" },
+    );
     const hostileHeaders = {
       Authorization: "Bearer attacker",
       Cookie: "session=attacker",
       "X-CAIL-App": "attacker-app",
       "X-CAIL-Identity-JWT": "attacker-jwt",
       "X-CAIL-Request-Id": "attacker-request",
+      "X-CAIL-Session-Id": "attacker-session",
       "cf-aig-provider": "attacker-provider",
       "cf-aig-cache-ttl": "9999",
       "x-openwebui-model": "attacker-model",
@@ -381,6 +387,7 @@ describe("createCailModel wire contract", () => {
       expect(call.url).toBe("https://cail.example/v1/chat/completions");
       expect(call.headers.get("authorization")).toBe("Bearer verified-jwt");
       expect(call.headers.get("x-cail-app")).toBe("site-studio");
+      expect(call.headers.get("x-cail-session-id")).toBe("project-123");
       expect(call.headers.get("x-cail-identity-jwt")).toBeNull();
       expect(call.headers.get("x-cail-request-id")).toBeNull();
       expect(call.headers.get("cookie")).toBeNull();

--- a/packages/app/src/lib/model.ts
+++ b/packages/app/src/lib/model.ts
@@ -26,6 +26,8 @@ export interface CailModelEnv {
 export interface CailModelOptions {
   /** Enable provider JSON-schema output only for a proven model path. */
   supportsStructuredOutputs?: boolean;
+  /** Stable project identifier used for Gateway session affinity. */
+  sessionId?: string;
 }
 
 const WORKERS_AI_MODEL_ID_RE = /^@cf\/[a-z0-9][a-z0-9._/-]*$/i;
@@ -117,6 +119,7 @@ const SAFE_GATEWAY_HEADERS = [
 export function createCailAuthorityFetch(
   identityJwt: string,
   fetchImpl: typeof fetch = fetch,
+  sessionId?: string,
 ): typeof fetch {
   const authorityFetch: typeof fetch = (input, init) => {
     assertCailJwtFresh(identityJwt);
@@ -140,6 +143,7 @@ export function createCailAuthorityFetch(
     safeHeaders.set("content-type", "application/json");
     safeHeaders.set("authorization", `Bearer ${identityJwt}`);
     safeHeaders.set("x-cail-app", CAIL_APP_SLUG);
+    if (sessionId) safeHeaders.set("x-cail-session-id", sessionId);
 
     return fetchImpl(sourceRequest ?? input, {
       ...init,
@@ -191,7 +195,7 @@ export function createCailModel(
   }
 
   const baseUrl = canonicalCailApiBase(env.CAIL_API_BASE);
-  const gatewayFetch = createCailAuthorityFetch(identityJwt, fetchImpl);
+  const gatewayFetch = createCailAuthorityFetch(identityJwt, fetchImpl, options.sessionId);
 
   const provider = createOpenAICompatible({
     name: "cail",


### PR DESCRIPTION
## Summary
- use the stable project ID as the model-session identifier
- preserve the existing two-leg identity and service-binding transport
- document project-scoped affinity

## Boundaries
- no retries, fallback, provider key, or OpenWebUI changes

## Verification
- `bun run check` (755 app tests, 194 frontend tests, chat and preview boundary checks, and production build)