### PR TITLE
Share project tree and R2 test fixtures

### DIFF
--- a/packages/app/src/agents/project-context.ts
+++ b/packages/app/src/agents/project-context.ts
@@ -7,7 +7,7 @@ type TreeNode = {
   files: string[];
 };
 
-function buildTree(paths: string[]): string {
+export function buildProjectTree(paths: string[]): string {
   const root: TreeNode = {
     dirs: {},
     files: []
@@ -53,7 +53,7 @@ export function buildProjectContext(files: StorageFile[]): string {
 
   const sortedFiles = [...files].sort((left, right) => left.path.localeCompare(right.path));
   const shownFiles = sortedFiles.slice(0, MAX_PROJECT_CONTEXT_FILES);
-  const tree = buildTree(shownFiles.map((file) => file.path));
+  const tree = buildProjectTree(shownFiles.map((file) => file.path));
   const extraFileCount = sortedFiles.length - shownFiles.length;
   const uploadedDocuments = sortedFiles.filter((file) => {
     return !file.isText && (

--- a/packages/app/src/agents/site-builder.test.ts
+++ b/packages/app/src/agents/site-builder.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { CailError } from "@cuny-ai-lab/cail-client";
 import { cailErrorEnvelope, quotaExceededEnvelope } from "@cuny-ai-lab/cail-client/testing";
-import { buildProjectContext } from "./project-context";
+import { buildProjectContext, buildProjectTree } from "./project-context";
+import { createProjectTools, type ProjectStorageLike } from "./site-builder";
 import { describeModelStreamError } from "../lib/model-stream-error";
+import type { StorageFile } from "../types";
 
 describe("describeModelStreamError", () => {
   it("finds quota details nested in an AI_RetryError", () => {
@@ -160,5 +162,85 @@ describe("project context", () => {
     expect(context).toContain("assets/");
     expect(context).toContain("assets/cv.pdf");
     expect(context).toContain("extract_document_text");
+  });
+});
+
+describe("project tree", () => {
+  it("renders nested directories before sorted flat files", () => {
+    expect(buildProjectTree(["b.txt", "a.txt"])).toBe("a.txt\nb.txt");
+    expect(buildProjectTree([
+      "styles.css",
+      "src/z.ts",
+      "index.html",
+      "src/components/Button.tsx",
+      "src/a.ts",
+    ])).toBe([
+      "src/",
+      "  components/",
+      "    Button.tsx",
+      "  a.ts",
+      "  z.ts",
+      "index.html",
+      "styles.css",
+    ].join("\n"));
+  });
+
+  it("list_files returns the storage paths and shared tree, including its empty result", async () => {
+    const projectFiles: StorageFile[] = [
+      {
+        path: "components/Button.tsx",
+        name: "Button.tsx",
+        size: 10,
+        lastModified: "2026-01-01T00:00:00.000Z",
+        isDirectory: false,
+        contentType: "text/typescript",
+        isText: true,
+      },
+      {
+        path: "index.ts",
+        name: "index.ts",
+        size: 10,
+        lastModified: "2026-01-01T00:00:00.000Z",
+        isDirectory: false,
+        contentType: "text/typescript",
+        isText: true,
+      },
+    ];
+    const storage: ProjectStorageLike = {
+      fileExists: async () => false,
+      listFiles: vi.fn(async (_userId: string, _projectId: string, prefix = "") => (
+        prefix === "src" ? projectFiles : []
+      )),
+      readFile: async () => "",
+      readFileWithEtag: async () => null,
+      readFileBuffer: async () => new Uint8Array(),
+    };
+    const tools = createProjectTools(
+      // SAFETY: list_files uses the injected storage override and never reads the bucket.
+      { SITE_STUDIO_BUCKET: {} as R2Bucket },
+      { userId: "user-1", projectId: "project-1" },
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      storage,
+    );
+    if (!tools.list_files.execute) {
+      throw new Error("list_files has no execute handler");
+    }
+    // SAFETY: The list_files execute callback does not inspect the SDK execution context.
+    const toolExecutionOptions = undefined as never;
+
+    const nested = await tools.list_files.execute({ prefix: "src" }, toolExecutionOptions);
+    expect(nested).toEqual({
+      count: 2,
+      tree: "components/\n  Button.tsx\nindex.ts",
+      paths: ["components/Button.tsx", "index.ts"],
+    });
+    const empty = await tools.list_files.execute({}, toolExecutionOptions);
+    expect(empty).toEqual({ count: 0, tree: "(project is empty)", paths: [] });
+    expect(storage.listFiles).toHaveBeenNthCalledWith(1, "user-1", "project-1", "src");
+    expect(storage.listFiles).toHaveBeenNthCalledWith(2, "user-1", "project-1", "");
   });
 });

--- a/packages/app/src/agents/site-builder.ts
+++ b/packages/app/src/agents/site-builder.ts
@@ -40,7 +40,7 @@ import { lintProject } from "../lib/a11y-lint";
 import { createBlankIndexHtml, getTemplateFiles, TEMPLATE_IDS } from "../lib/templates";
 import { FileExistsError, R2ProjectStorage } from "../storage/r2";
 import { SITE_BUILDER_PROMPT } from "../prompts/site-builder";
-import { buildProjectContext } from "./project-context";
+import { buildProjectContext, buildProjectTree } from "./project-context";
 import { describeModelStreamError } from "../lib/model-stream-error";
 import {
   type CailOutcome,
@@ -619,50 +619,6 @@ function createPageHtml(title: string): string {
 </html>`;
 }
 
-type TreeNode = {
-  dirs: Record<string, TreeNode>;
-  files: string[];
-};
-
-function buildTree(paths: string[]): string {
-  const root: TreeNode = {
-    dirs: {},
-    files: []
-  };
-
-  for (const filePath of paths) {
-    const parts = filePath.split("/");
-    let current = root;
-
-    parts.forEach((part, index) => {
-      if (index === parts.length - 1) {
-        current.files.push(part);
-        return;
-      }
-
-      current.dirs[part] ||= { dirs: {}, files: [] };
-      current = current.dirs[part];
-    });
-  }
-
-  function lines(node: TreeNode, prefix = ""): string[] {
-    const result: string[] = [];
-
-    for (const key of Object.keys(node.dirs).sort()) {
-      result.push(`${prefix}${key}/`);
-      result.push(...lines(node.dirs[key], `${prefix}  `));
-    }
-
-    for (const fileName of node.files.sort()) {
-      result.push(`${prefix}${fileName}`);
-    }
-
-    return result;
-  }
-
-  return lines(root).join("\n");
-}
-
 function isTextFile(filePath: string): boolean {
   return isTextContentType(getContentType(filePath));
 }
@@ -781,7 +737,7 @@ export function createProjectTools(
 
         return {
           count: paths.length,
-          tree: paths.length > 0 ? buildTree(paths) : "(project is empty)",
+          tree: paths.length > 0 ? buildProjectTree(paths) : "(project is empty)",
           paths
         };
       }

--- a/packages/app/src/app.test.ts
+++ b/packages/app/src/app.test.ts
@@ -7,44 +7,20 @@ import {
 } from "@cuny-ai-lab/cail-identity/testing";
 import type { Env } from "./types";
 import { CSRF_ERROR_BODY, CSRF_HEADER_NAME } from "./lib/csrf";
-import { createMockKV, createMockMutationCoordinator, createTestNamespace, type MockKV } from "./lib/test-utils";
+import {
+  createMockKV,
+  createMockMutationCoordinator,
+  createStoredR2Body,
+  createStoredR2Object,
+  createTestNamespace,
+  type MockKV,
+} from "./lib/test-utils";
 import type { MutationCoordinator } from "./agents/mutation-coordinator";
 
 import app from "./app";
 
 const BASE = "https://site-studio.example";
 const ALLOWED_ORIGIN = "https://tools.ailab.gc.cuny.edu";
-
-function createStoredR2Object(key: string): R2Object {
-  const object = {
-    key,
-    version: "test-version",
-    size: 0,
-    etag: `${key}:etag`,
-    httpEtag: `"${key}:etag"`,
-    checksums: {},
-    uploaded: new Date(0),
-    storageClass: "Standard",
-  };
-  // SAFETY: The app tests inspect only key/text; the remaining R2 metadata is
-  // an inert fixture value and the runtime binding supplies the full object.
-  return object as R2Object;
-}
-
-function createStoredR2Body(key: string, value: string): R2ObjectBody {
-  const body = {
-    ...createStoredR2Object(key),
-    body: new ReadableStream<Uint8Array>(),
-    bodyUsed: false,
-    arrayBuffer: async () => new TextEncoder().encode(value).buffer,
-    blob: async () => new Blob([value]),
-    json: async () => JSON.parse(value),
-    text: async () => value,
-  };
-  // SAFETY: The app tests consume only text(); the other body methods are
-  // deterministic inert implementations for the R2 object contract.
-  return body as R2ObjectBody;
-}
 
 function createMockBucket(): R2Bucket {
   const store = new Map<string, string>();

--- a/packages/app/src/boundary-logging.test.ts
+++ b/packages/app/src/boundary-logging.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@cuny-ai-lab/cail-log";
 import { TEST_SUBJECTS } from "@cuny-ai-lab/cail-identity/testing";
 import type { Env } from "./types";
-import { createMockKV, type MockKV } from "./lib/test-utils";
+import { createMockKV, createStoredR2Body, createStoredR2Object, type MockKV } from "./lib/test-utils";
 import { z } from "zod";
 
 import app from "./app";
@@ -38,37 +38,6 @@ const capturedLogEventSchema = z.record(
   z.string(),
   z.union([z.string(), z.number(), z.boolean(), z.null()]),
 );
-
-function createStoredR2Object(key: string): R2Object {
-  const object = {
-    key,
-    version: "test-version",
-    size: 0,
-    etag: `${key}:etag`,
-    httpEtag: `"${key}:etag"`,
-    checksums: {},
-    uploaded: new Date(0),
-    storageClass: "Standard",
-  };
-  // SAFETY: Boundary tests inspect only key/text; remaining R2 metadata is
-  // inert fixture data and the runtime binding supplies the complete object.
-  return object as R2Object;
-}
-
-function createStoredR2Body(key: string, value: string): R2ObjectBody {
-  const body = {
-    ...createStoredR2Object(key),
-    body: new ReadableStream<Uint8Array>(),
-    bodyUsed: false,
-    arrayBuffer: async () => new TextEncoder().encode(value).buffer,
-    blob: async () => new Blob([value]),
-    json: async () => JSON.parse(value),
-    text: async () => value,
-  };
-  // SAFETY: Boundary tests consume only text(); other body methods are inert
-  // deterministic implementations for the R2 object contract.
-  return body as R2ObjectBody;
-}
 
 function createMockBucket(): R2Bucket {
   const store = new Map<string, string>();

--- a/packages/app/src/lib/test-utils.ts
+++ b/packages/app/src/lib/test-utils.ts
@@ -41,6 +41,37 @@ export function createTestR2Object(
   return object as R2Object;
 }
 
+export function createStoredR2Object(key: string): R2Object {
+  const object = {
+    key,
+    version: "test-version",
+    size: 0,
+    etag: `${key}:etag`,
+    httpEtag: `"${key}:etag"`,
+    checksums: {},
+    uploaded: new Date(0),
+    storageClass: "Standard",
+  };
+  // SAFETY: Test boundaries inspect only key/text; the remaining R2 metadata
+  // is inert fixture data and the runtime binding supplies the complete object.
+  return object as R2Object;
+}
+
+export function createStoredR2Body(key: string, value: string): R2ObjectBody {
+  const body = {
+    ...createStoredR2Object(key),
+    body: new ReadableStream<Uint8Array>(),
+    bodyUsed: false,
+    arrayBuffer: async () => new TextEncoder().encode(value).buffer,
+    blob: async () => new Blob([value]),
+    json: async () => JSON.parse(value),
+    text: async () => value,
+  };
+  // SAFETY: Test boundaries consume only text(); other body methods are inert
+  // deterministic implementations for the R2 object contract.
+  return body as R2ObjectBody;
+}
+
 /** In-memory KV mock matching the house mock conventions. */
 export function createMockKV(): MockKV {
   const store = new Map<string, string>();

--- a/packages/app/src/routes/agents.test.ts
+++ b/packages/app/src/routes/agents.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { CSRF_ERROR_BODY, csrfProtect } from "../lib/csrf";
-import { createMockKV, mintCsrfSession, type CsrfSession } from "../lib/test-utils";
+import {
+  createMockKV,
+  createStoredR2Body,
+  createStoredR2Object,
+  mintCsrfSession,
+  type CsrfSession,
+} from "../lib/test-utils";
 import { TEST_SUBJECTS } from "@cuny-ai-lab/cail-identity/testing";
 import { SITE_STUDIO_VERIFIED_OPERATIONAL_SUBJECT_HEADER } from "../lib/logging";
 import { SITE_STUDIO_AGENT_PROPS_HEADER } from "../lib/agent-identity";
@@ -19,37 +25,6 @@ const OWN_ORIGIN = "https://site-studio.example";
 const APP_PUBLIC_DOMAIN = "https://tools.ailab.gc.cuny.edu";
 type AgentFetchState = { lastRequest: Request | null };
 const forwardedUrlSchema = z.object({ forwardedUrl: z.string() });
-
-function createStoredR2Object(key: string): R2Object {
-  const object = {
-    key,
-    version: "test-version",
-    size: 0,
-    etag: `${key}:etag`,
-    httpEtag: `"${key}:etag"`,
-    checksums: {},
-    uploaded: new Date(0),
-    storageClass: "Standard",
-  };
-  // SAFETY: The route tests inspect only key/text; the remaining R2 metadata
-  // is inert fixture data and production supplies the complete object.
-  return object as R2Object;
-}
-
-function createStoredR2Body(key: string, value: string): R2ObjectBody {
-  const body = {
-    ...createStoredR2Object(key),
-    body: new ReadableStream<Uint8Array>(),
-    bodyUsed: false,
-    arrayBuffer: async () => new TextEncoder().encode(value).buffer,
-    blob: async () => new Blob([value]),
-    json: async () => JSON.parse(value),
-    text: async () => value,
-  };
-  // SAFETY: The route tests consume only text(); the other body methods are
-  // deterministic inert implementations for the R2 object contract.
-  return body as R2ObjectBody;
-}
 
 function createMockBucket(): R2Bucket {
   const store = new Map<string, string>([[


### PR DESCRIPTION
Uses one byte-equivalent textual project-tree builder for model context and list_files, adds semantic boundary tests, and shares only the three exact duplicate simple R2 fixtures. Rich CAS/fault mocks remain local.

Verification: full checks; 757 app tests, 194 frontend tests, chat/preview boundaries, typecheck and production build.

Independent review: PASS.